### PR TITLE
feat: [IAC-7382]: add list/get for hosts, inventory, playbook, module…

### DIFF
--- a/pkg/spec/iacm.spec.yaml
+++ b/pkg/spec/iacm.spec.yaml
@@ -37,6 +37,133 @@ nouns:
       - id: updated
         expr: epochMs(it.updated)
 
+  - noun: hosts
+    short_desc: An IACM Ansible host tracked across inventories.
+    noun_aliases: [host]
+    fields:
+      - id: id
+        expr: it.id
+      - id: host_address
+        expr: it.host_address
+      - id: status
+        expr: it.last_activity?.status
+      - id: inventories
+        expr: it.inventories
+      - id: created
+        expr: epochMs(it.created)
+      - id: updated
+        expr: epochMs(it.updated)
+
+  - noun: inventory
+    short_desc: An IACM Ansible inventory of hosts and groups.
+    noun_aliases: [inventories]
+    fields:
+      - id: identifier
+        expr: it.identifier
+      - id: name
+        expr: it.name
+      - id: type
+        expr: it.type
+      - id: description
+        expr: it.description
+      - id: account
+        expr: it.account
+      - id: org
+        expr: it.org
+      - id: project
+        expr: it.project
+      - id: tags
+        expr: it.tags
+      - id: created
+        expr: epochMs(it.created)
+      - id: updated
+        expr: epochMs(it.updated)
+
+  - noun: playbook
+    short_desc: An IACM Ansible playbook definition.
+    noun_aliases: [playbooks]
+    fields:
+      - id: identifier
+        expr: it.identifier
+      - id: name
+        expr: it.name
+      - id: description
+        expr: it.description
+      - id: repository
+        expr: it.repository
+      - id: repository_branch
+        expr: it.repository_branch
+      - id: repository_connector
+        expr: it.repository_connector
+      - id: repository_path
+        expr: it.repository_path
+      - id: tags
+        expr: it.tags
+      - id: created
+        expr: epochMs(it.created)
+      - id: updated
+        expr: epochMs(it.updated)
+
+  # `module` is already a CLI noun in core.spec.yaml (lists/installs loaded CLI
+  # modules). To avoid the collision, IaCM registry modules use the noun variant
+  # `module:iacm` → `harness list module:iacm` / `harness get module:iacm <id>`.
+  # NounDefs are keyed by base noun only (no per-variant fields), and the base
+  # `module` noun is owned by core, so the IaCM field set lives under a distinct
+  # `iacm_module` noun that the variant commands reference via `fields_noun`.
+  - noun: iacm_module
+    short_desc: An IACM Terraform/OpenTofu module from the module registry.
+    noun_aliases: [iacm_modules]
+    fields:
+      - id: id
+        expr: it.id
+      - id: name
+        expr: it.name
+      - id: system
+        expr: it.system
+      - id: namespace
+        expr: it.namespace
+      - id: description
+        expr: it.description
+      - id: org
+        expr: it.org
+      - id: project
+        expr: it.project
+      - id: repository
+        expr: it.repository
+      - id: repository_branch
+        expr: it.repository_branch
+      - id: repository_connector
+        expr: it.repository_connector
+      - id: versions
+        expr: it.versions
+      - id: created
+        expr: epochMs(it.created)
+      - id: updated
+        expr: epochMs(it.updated)
+
+  - noun: provider
+    short_desc: An IACM Terraform provider from the provider registry.
+    noun_aliases: [providers]
+    fields:
+      - id: id
+        expr: it.id
+      - id: type
+        expr: it.type
+      - id: namespace
+        expr: it.namespace
+      - id: description
+        expr: it.description
+      - id: domain_prefix
+        expr: it.domain_prefix
+      - id: account
+        expr: it.account
+      - id: versions
+        expr: it.versions
+      - id: created
+        expr: epochMs(it.created)
+      - id: updated
+        expr: epochMs(it.updated)
+
 commands:
   - command: list workspace
     verb: list
@@ -112,3 +239,238 @@ commands:
       - name: force
         description: "Skip confirmation prompt"
         is_bool: true
+
+  # ── host (Ansible) ────────────────────────────────────────────────────────────
+  - command: list hosts
+    verb: list
+    noun: hosts
+    short: List IACM Ansible hosts at the project level
+    handler_type: endpoint
+    flags:
+      - name: search
+        description: Filter hosts by partial host address match
+      - name: inventory
+        description: Filter hosts by inventory membership
+      - name: status
+        description: Filter hosts by last activity status
+    endpoint:
+      path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/hosts
+      request_headers:
+        Harness-Account: auth.account
+      items_expr: it
+      get_id_expr: it.id
+      completion:
+        id_expr: it.id
+        name_expr: it.host_address
+      query_params:
+        searchTerm: flags.search
+        inventory: flags.inventory
+        status: flags.status
+      paging:
+        paging_strategy: page_header
+        countable: true
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+        total_header: "X-Total-Items"
+      columns: [id, host_address, status, updated]
+
+  - command: get hosts
+    verb: get
+    noun: hosts
+    short: Get an IACM Ansible host by identifier
+    completion_noun: hosts
+    handler_type: endpoint
+    endpoint:
+      path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/hosts/{{ctx.id}}
+      request_headers:
+        Harness-Account: auth.account
+      item_expr: it
+      yaml_pick_expr: it
+
+  # ── inventory (Ansible) ─────────────────────────────────────────────────────--
+  - command: list inventory
+    verb: list
+    noun: inventory
+    short: List IACM Ansible inventories at the project level
+    handler_type: endpoint
+    flags:
+      - name: search
+        description: Filter inventories by partial name match
+    endpoint:
+      path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/inventory
+      request_headers:
+        Harness-Account: auth.account
+      items_expr: it
+      get_id_expr: it.identifier
+      completion:
+        id_expr: it.identifier
+        name_expr: it.name
+      query_params:
+        searchTerm: flags.search
+      paging:
+        paging_strategy: page_header
+        countable: true
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+        total_header: "X-Total-Items"
+      columns: [identifier, name, type, updated]
+
+  - command: get inventory
+    verb: get
+    noun: inventory
+    short: Get an IACM Ansible inventory by identifier
+    completion_noun: inventory
+    handler_type: endpoint
+    endpoint:
+      path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/inventory/{{ctx.id}}
+      request_headers:
+        Harness-Account: auth.account
+      item_expr: it
+      yaml_pick_expr: it
+
+  # ── playbook (Ansible) ──────────────────────────────────────────────────────--
+  - command: list playbook
+    verb: list
+    noun: playbook
+    short: List IACM Ansible playbooks at the project level
+    handler_type: endpoint
+    flags:
+      - name: search
+        description: Filter playbooks by partial name match
+    endpoint:
+      path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/playbook
+      request_headers:
+        Harness-Account: auth.account
+      items_expr: it
+      get_id_expr: it.identifier
+      completion:
+        id_expr: it.identifier
+        name_expr: it.name
+      query_params:
+        searchTerm: flags.search
+      paging:
+        paging_strategy: page_header
+        countable: true
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+        total_header: "X-Total-Items"
+      columns: [identifier, name, repository, updated]
+
+  - command: get playbook
+    verb: get
+    noun: playbook
+    short: Get an IACM Ansible playbook by identifier
+    completion_noun: playbook
+    handler_type: endpoint
+    endpoint:
+      path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/playbook/{{ctx.id}}
+      request_headers:
+        Harness-Account: auth.account
+      item_expr: it
+      yaml_pick_expr: it
+
+  # ── module:iacm (registry) ──────────────────────────────────────────────────--
+  - command: list module:iacm
+    verb: list
+    noun: module
+    noun_variant: iacm
+    fields_noun: iacm_module
+    short: List IACM modules at the level queried
+    handler_type: endpoint
+    flags:
+      - name: search
+        description: Filter modules by partial name or provider match
+    endpoint:
+      path: /gateway/iacm/api/modules
+      request_headers:
+        Harness-Account: auth.account
+      items_expr: it
+      get_id_expr: it.id
+      completion:
+        id_expr: it.id
+        name_expr: it.name
+      query_params:
+        searchTerm: flags.search
+        scope_org: auth.org
+        scope_project: auth.project
+      paging:
+        paging_strategy: page_header
+        countable: true
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+        total_header: "X-Total-Items"
+      columns: [id, name, system, updated]
+
+  - command: get module:iacm
+    verb: get
+    noun: module
+    noun_variant: iacm
+    fields_noun: iacm_module
+    short: Get an IACM module by identifier
+    completion_noun: module:iacm
+    handler_type: endpoint
+    endpoint:
+      path: /gateway/iacm/api/modules/{{ctx.id}}
+      request_headers:
+        Harness-Account: auth.account
+      query_params:
+        scope_org: auth.org
+        scope_project: auth.project
+      item_expr: it
+      yaml_pick_expr: it
+
+  # ── provider (registry) ─────────────────────────────────────────────────────--
+  - command: list provider
+    verb: list
+    noun: provider
+    short: List IACM providers at the level queried
+    handler_type: endpoint
+    flags:
+      - name: search
+        description: Filter providers by partial name match
+    endpoint:
+      path: /gateway/iacm/api/providers
+      request_headers:
+        Harness-Account: auth.account
+      items_expr: it
+      get_id_expr: it.id
+      completion:
+        id_expr: it.id
+        name_expr: it.type
+      query_params:
+        searchTerm: flags.search
+      paging:
+        paging_strategy: page_header
+        countable: true
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+        total_header: "X-Total-Items"
+      columns: [id, type, namespace, updated]
+
+  - command: get provider
+    verb: get
+    noun: provider
+    short: Get an IACM provider by identifier
+    completion_noun: provider
+    handler_type: endpoint
+    endpoint:
+      path: /gateway/iacm/api/providers/{{ctx.id}}
+      request_headers:
+        Harness-Account: auth.account
+      item_expr: it
+      yaml_pick_expr: it

--- a/pkg/spec/iacm.spec.yaml
+++ b/pkg/spec/iacm.spec.yaml
@@ -105,14 +105,13 @@ nouns:
         expr: epochMs(it.updated)
 
   # `module` is already a CLI noun in core.spec.yaml (lists/installs loaded CLI
-  # modules). To avoid the collision, IaCM registry modules use the noun variant
-  # `module:iacm` → `harness list module:iacm` / `harness get module:iacm <id>`.
-  # NounDefs are keyed by base noun only (no per-variant fields), and the base
-  # `module` noun is owned by core, so the IaCM field set lives under a distinct
-  # `iacm_module` noun that the variant commands reference via `fields_noun`.
-  - noun: iacm_module
+  # modules). An IaCM registry module is a distinct resource, not a variant of
+  # that noun, so per the naming convention (`_` separates words in a distinct
+  # base noun; `:` is reserved for noun-variants) it gets its own base noun
+  # `registry_module` → `harness list registry_module` / `get registry_module <id>`.
+  - noun: registry_module
     short_desc: An IACM Terraform/OpenTofu module from the module registry.
-    noun_aliases: [iacm_modules]
+    noun_aliases: [registry_modules]
     fields:
       - id: id
         expr: it.id
@@ -378,12 +377,10 @@ commands:
       item_expr: it
       yaml_pick_expr: it
 
-  # ── module:iacm (registry) ──────────────────────────────────────────────────--
-  - command: list module:iacm
+  # ── registry_module (registry) ──────────────────────────────────────────────--
+  - command: list registry_module
     verb: list
-    noun: module
-    noun_variant: iacm
-    fields_noun: iacm_module
+    noun: registry_module
     short: List IACM modules at the level queried
     handler_type: endpoint
     flags:
@@ -413,13 +410,10 @@ commands:
         total_header: "X-Total-Items"
       columns: [id, name, system, updated]
 
-  - command: get module:iacm
+  - command: get registry_module
     verb: get
-    noun: module
-    noun_variant: iacm
-    fields_noun: iacm_module
+    noun: registry_module
     short: Get an IACM module by identifier
-    completion_noun: module:iacm
     handler_type: endpoint
     endpoint:
       path: /gateway/iacm/api/modules/{{ctx.id}}

--- a/pkg/spec/iacm.spec.yaml
+++ b/pkg/spec/iacm.spec.yaml
@@ -37,16 +37,16 @@ nouns:
       - id: updated
         expr: epochMs(it.updated)
 
-  - noun: hosts
+  - noun: host
     short_desc: An IACM Ansible host tracked across inventories.
-    noun_aliases: [host]
+    noun_aliases: [hosts]
     fields:
       - id: id
         expr: it.id
       - id: host_address
         expr: it.host_address
       - id: status
-        expr: it.last_activity?.status
+        expr: 'it.last_activity != nil ? it.last_activity.status : nil'
       - id: inventories
         expr: it.inventories
       - id: created
@@ -240,9 +240,9 @@ commands:
         is_bool: true
 
   # ── host (Ansible) ────────────────────────────────────────────────────────────
-  - command: list hosts
+  - command: list host
     verb: list
-    noun: hosts
+    noun: host
     short: List IACM Ansible hosts at the project level
     handler_type: endpoint
     flags:
@@ -276,11 +276,11 @@ commands:
         total_header: "X-Total-Items"
       columns: [id, host_address, status, updated]
 
-  - command: get hosts
+  - command: get host
     verb: get
-    noun: hosts
+    noun: host
     short: Get an IACM Ansible host by identifier
-    completion_noun: hosts
+    completion_noun: host
     handler_type: endpoint
     endpoint:
       path: /gateway/iacm/api/orgs/{{auth.org}}/projects/{{auth.project}}/ansible/hosts/{{ctx.id}}
@@ -414,6 +414,7 @@ commands:
     verb: get
     noun: registry_module
     short: Get an IACM module by identifier
+    completion_noun: registry_module
     handler_type: endpoint
     endpoint:
       path: /gateway/iacm/api/modules/{{ctx.id}}


### PR DESCRIPTION
### Summary
Adds read commands (`list` / `get`) for five IaCM resource types to the unified CLI. Commands are declared entirely in [pkg/spec/iacm.spec.yaml](cci:7://file:///Users/rahulbalani/Desktop/harness-unified-cli/pkg/spec/iacm.spec.yaml:0:0-0:0); no Go changes. Endpoints were sourced from the iac-server Goa-generated OpenAPI spec.

### What's added

| Command | Endpoint | Scope |
|---|---|---|
| `harness list hosts` / `get hosts <id>` | `/ansible/hosts` | project |
| `harness list inventory` / `get inventory <id>` | `/ansible/inventory` | project |
| `harness list playbook` / `get playbook <id>` | `/ansible/playbook` | project |
| `harness list registry_module` / `get registry_module <id>` | `/modules` | account (narrows by org/project scope) |
| `harness list provider` / `get provider <id>` | `/providers` | account |

All paths are prefixed with `/gateway/iacm` and send the `Harness-Account` header.

### Supported features

**Listing**
- Pagination via `--limit`, `--offset`, `--all`, `--count` (page_header strategy: `page`/`limit` query params, total read from `X-Total-Items`).
- Search filters: `--search` on all five; `hosts` additionally supports `--inventory` and `--status`.
- `registry_module` narrows to the active scope via `scope_org`/`scope_project` (empty values omitted → account-level listing).
- Column customization: `--columns`, `--list-columns`, `--no-headers`.

**Get / detail**
- Field rendering via `--fields` / `--list-fields`.
- Output formats: default fields view, `--json` (`--format json`), and `--format yaml` (via `yaml_pick_expr`).
- Shell completion of `<id>` from the corresponding `list` command.

**Default columns**
- hosts: `id, host_address, status, updated`
- inventory: `identifier, name, type, updated`
- playbook: `identifier, name, repository, updated`
- registry_module: `id, name, system, updated`
- provider: `id, type, namespace, updated`

### Notable decisions
- **`registry_module` naming:** `module` is already a core CLI noun (lists/installs loaded CLI modules). An IaCM registry module is a distinct resource, not a variant of that noun, so per the naming convention (`_` separates words in a distinct base noun; `:` is reserved for noun-variants) it gets its own base noun `registry_module`. Still pending the team's "blessed" noun list — easy to rename if a different word is chosen.
- **Timestamps:** all resources return millisecond epochs, rendered with `epochMs(...)` directly (no scaling).

### Testing
Validated against `qa.harness.io` (org `default`, project `stephenAnsible`):
- All `list` commands return data with correct dates and pagination footers.
- `get <noun> <id>` renders fields, `--json`, and `--format yaml`.
- Search/filter flags and `--columns` verified.

### Not included
- No create/update/delete (read-only).
- No changes to Go framework code.