### PR TITLE
fix: code module create commands broken — path routing and missing mutable fields

### DIFF
--- a/modules/code/code.go
+++ b/modules/code/code.go
@@ -8,9 +8,11 @@ import "github.com/harness/harness-cli/pkg/registry"
 const (
 	mergePRBodyFnID         = "merge_pr_body"
 	createPRCommentBodyFnID = "create_pr_comment_body"
+	createPRBodyFnID        = "create_pr_body"
 )
 
 func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterBodyFn(mergePRBodyFnID, mergePRBodyFn)
 	reg.RegisterBodyFn(createPRCommentBodyFnID, createPRCommentBodyFn)
+	reg.RegisterBodyFn(createPRBodyFnID, createPRBodyFn)
 }

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -1,0 +1,47 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package code
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/harness/harness-cli/pkg/cmdctx"
+)
+
+// createPRBodyFn builds the pull request create body.
+// Required: --set title=<title> source_branch=<branch> target_branch=<branch>
+// Optional: --set description=<text>  OR  -f <file> for multi-line description.
+func createPRBodyFn(ctx *cmdctx.Ctx) (any, error) {
+	title := ctx.SetArgs["title"]
+	if title == "" {
+		return nil, fmt.Errorf("--set title=<title> is required")
+	}
+	sourceBranch := ctx.SetArgs["source_branch"]
+	if sourceBranch == "" {
+		return nil, fmt.Errorf("--set source_branch=<branch> is required")
+	}
+	targetBranch := ctx.SetArgs["target_branch"]
+	if targetBranch == "" {
+		targetBranch = "main"
+	}
+
+	description := ctx.SetArgs["description"]
+
+	// -f / --file overrides --set description when provided
+	if fileText, err := cmdctx.SlurpInputFile(ctx.FlagValues); err == nil && strings.TrimSpace(fileText) != "" {
+		description = strings.TrimRight(fileText, "\n")
+	}
+
+	isDraft := ctx.SetArgs["is_draft"] == "true"
+
+	body := map[string]any{
+		"title":         title,
+		"source_branch": sourceBranch,
+		"target_branch": targetBranch,
+		"description":   description,
+		"is_draft":      isDraft,
+	}
+	return body, nil
+}

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -79,20 +79,25 @@ nouns:
         align: right
       - id: title
         expr: it.title
+        mutable_path: title
       - id: description
         expr: it.description
         field_type: multiline_text
+        mutable_path: description
       - id: state
         expr: it.state
       - id: is_draft
         label: Draft
         expr: it.is_draft
+        mutable_path: is_draft
       - id: source_branch
         label: Source Branch
         expr: it.source_branch
+        mutable_path: source_branch
       - id: target_branch
         label: Target Branch
         expr: it.target_branch
+        mutable_path: target_branch
       - id: author
         expr: it.author.display_name
       - id: author_email
@@ -165,6 +170,10 @@ nouns:
     fields:
       - id: name
         expr: it.name
+        mutable_path: name
+      - id: target
+        expr: it.sha
+        mutable_path: target
       - id: sha
         expr: it.sha
       - id: sha8
@@ -211,10 +220,15 @@ nouns:
     fields:
       - id: name
         expr: it.name
+        mutable_path: name
+      - id: target
+        expr: it.sha
+        mutable_path: target
       - id: sha
         expr: it.sha
       - id: message
         expr: it.message
+        mutable_path: message
 
   - noun: pr_comment
     short_desc: A comment on a pull request.
@@ -456,12 +470,12 @@ commands:
     flags:
       - name: state
         description: "Filter by state: open, closed, merged, all"
-        default: all
+        default: open
         completion_values: [open, closed, merged, all]
       - name: search
         description: Filter by keyword
       - name: author
-        description: "Filter by author (principal ID number from user list)"
+        description: "Filter by author principal ID (integer). Get it via: harness list pr <repo> --state all --format json | jq '.[0].author.id'"
       - name: created-after
         description: "Show PRs created after this date (YYYY-MM-DD, relative like 30d/2w/1m (m=month), or epoch ms)"
       - name: created-before
@@ -521,19 +535,19 @@ commands:
   - command: create pr
     verb: create
     noun: pr
-    short: "Create a pull request: harness create pr <repo_id> --set title=... source_branch=... target_branch=..."
+    short: "Create a pull request: harness create pr <repo_id> --set title=... source_branch=... [target_branch=main] [description=...] [-f desc.md]"
     handler_type: endpoint
-    requires_parentid: true
-    parentid_label: "<repo_id>"
     flags_builtin:
       set: true
+    flags:
+      - name: file
+        short: f
+        description: "File containing the PR description (use - for stdin)"
     endpoint:
       method: POST
-      path: /code/api/v1/repos/{{ctx.parentId}}/pullreq
-      create_strategy: set-fields
-      create_body_init:
-        target_branch: '"main"'
-      create_body_wrap: ""
+      path: /code/api/v1/repos/{{ctx.id}}/pullreq
+      body_fn: create_pr_body
+      no_fields: true
       text_header: "\nCreated PR #{{it.number}}: {{it.title}}\n"
       text_footer: "{{url(it)}}\n"
 
@@ -651,13 +665,11 @@ commands:
     noun: branch
     short: "Create a branch: harness create branch <repo_id> --set name=<branch> target=<sha_or_branch>"
     handler_type: endpoint
-    requires_parentid: true
-    parentid_label: "<repo_id>"
     flags_builtin:
       set: true
     endpoint:
       method: POST
-      path: /code/api/v1/repos/{{ctx.parentId}}/branches
+      path: /code/api/v1/repos/{{ctx.id}}/branches
       create_strategy: set-fields
       create_body_wrap: ""
       text_header: "\nCreated branch {{it.name}}\n"
@@ -757,13 +769,11 @@ commands:
     noun: tag
     short: "Create a tag: harness create tag <repo_id> --set name=<tag> target=<sha>"
     handler_type: endpoint
-    requires_parentid: true
-    parentid_label: "<repo_id>"
     flags_builtin:
       set: true
     endpoint:
       method: POST
-      path: /code/api/v1/repos/{{ctx.parentId}}/tags
+      path: /code/api/v1/repos/{{ctx.id}}/tags
       create_strategy: set-fields
       create_body_wrap: ""
       text_header: "\nCreated tag {{it.name}}\n"


### PR DESCRIPTION
## Summary

- **`create pr` / `create branch` / `create tag` path was always empty** — all three used `ctx.parentId` in path templates, but the `create` verb routes the positional repo arg to `ctx.id`. This caused paths like `/code/api/v1/repos//pullreq`, making every create command silently broken with a 405 error.
- **`create pr` rejected every `--set` field** — the `pr` noun had no `mutable_path` on any field, so `--set title=...`, `--set source_branch=...`, etc. were all rejected as "unknown or read-only field".
- **`create branch` / `create tag` had the same mutable_path gap** — added `mutable_path` to `name`/`target` on branch, and `name`/`target`/`message` on tag.
- **`create pr` now supports `-f/--file`** for multi-line descriptions, consistent with `create pr_comment`. Implemented via new `createPRBodyFn` in `modules/code/pr.go`.
- **`list pr --state` defaults to `open`** instead of `all` — matches typical day-to-day usage.
- **`--author` flag description** now explains how to get the required numeric principal ID.

## Test plan

- [x] `harness create pr <repo> --set title=... source_branch=... target_branch=...` — creates PR (verified against schema-service, PR #87 created and closed)
- [x] `harness create pr <repo> --set title=... source_branch=... -f description.md` — description from file works
- [x] `harness list pr <repo>` — shows only open PRs by default
- [x] `harness list pr <repo> --state all` — shows all states
- [x] `harness list pr <repo> --author <numeric-id>` — filters by author correctly
- [x] `harness create branch <repo> --set name=... target=main` — creates branch
- [x] `harness get noun pull_request` — resolves alias correctly
- [x] `harness list pr_check <repo>/<pr>` — table and JSON both return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)