### PR TITLE
feat: [FME-17239]: add offset_limit paging strategy and get-then-patch update strategy

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -150,6 +150,16 @@ func (c *Client) PutRaw(path string, queryParams map[string]string, body, conten
 	return c.DoRequest(Request{Method: "PUT", Path: path, QueryParams: queryParams, Body: body, BodyContentType: contentType})
 }
 
+// Patch performs a PATCH request with an optional JSON body.
+func (c *Client) Patch(path string, queryParams map[string]string, body any) (any, http.Header, error) {
+	return c.do("PATCH", path, queryParams, body)
+}
+
+// PatchRaw performs a PATCH request with a raw string body and explicit Content-Type.
+func (c *Client) PatchRaw(path string, queryParams map[string]string, body, contentType string) (any, http.Header, error) {
+	return c.DoRequest(Request{Method: "PATCH", Path: path, QueryParams: queryParams, Body: body, BodyContentType: contentType})
+}
+
 // DoRequest executes a Request and returns the decoded JSON response body, response headers, and any error.
 // If Body is a string, it is sent as-is using BodyContentType. Otherwise Body is JSON-marshaled and
 // BodyContentType defaults to "application/json". Extra per-request headers may be set via Headers.

--- a/pkg/cmdctx/flagutil.go
+++ b/pkg/cmdctx/flagutil.go
@@ -95,16 +95,18 @@ func Exists(fv map[string]any, key string) bool {
 }
 
 // NormalizeFileBody validates and normalizes a file body string based on the effective content type.
+// ct should already be resolved (e.g. via resolveContentType) before calling; empty ct defaults to application/json.
 //
 // For application/yaml endpoints: the body must NOT be JSON (first non-whitespace char is '{').
-// For application/json endpoints (ct == "" or "application/json"): JSON is passed through after
-// validation; YAML is parsed and re-encoded as JSON.
+// For JSON/merge-patch endpoints: JSON is passed through after validation; YAML is parsed and re-encoded as JSON.
 //
 // Returns the normalized body string and the resolved content type, or an error.
-func NormalizeFileBody(body string, ct string, filePath string) (string, string, error) {
+func NormalizeFileBody(body, ct, filePath string) (string, string, error) {
 	switch ct {
-	case "", "application/json":
+	case "":
 		ct = "application/json"
+	case "application/json", "application/merge-patch+json":
+		// ok, pass through as declared
 	case "application/yaml":
 		// ok
 	default:

--- a/pkg/endpoint/pagingstrategy.go
+++ b/pkg/endpoint/pagingstrategy.go
@@ -198,7 +198,7 @@ func (pageHeaderStrategy) ExtractPaging(_ *cmdctx.Ctx, ep *spec.EndpointSpec, ra
 // offset_limit
 // ---------------------------------------------------------------------------
 
-// offsetLimitStrategy sends offset=pageIndex*pageSize and limit=pageSize.
+// offsetLimitStrategy sends offset=wantStart and limit=pageSize directly.
 // Used for APIs that use item-count offsets rather than page numbers (e.g. FME).
 type offsetLimitStrategy struct{}
 

--- a/pkg/endpoint/pagingstrategy.go
+++ b/pkg/endpoint/pagingstrategy.go
@@ -33,6 +33,8 @@ func MakePagingStrategy(strategyName string) (PagingStrategy, error) {
 		return pageIndexStrategy{}, nil
 	case spec.PagingStrategyPageHeader:
 		return pageHeaderStrategy{}, nil
+	case spec.PagingStrategyOffsetLimit:
+		return offsetLimitStrategy{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported paging strategy %q", strategyName)
 	}
@@ -188,6 +190,70 @@ func (pageHeaderStrategy) ExtractPaging(_ *cmdctx.Ctx, ep *spec.EndpointSpec, ra
 	pr.Last = len(items) == 0 ||
 		(d.pageSize > 0 && len(items) < d.pageSize) ||
 		(pr.HasTotal && int64(d.startOffset+len(items)) >= pr.Total)
+
+	return pr, nil
+}
+
+// ---------------------------------------------------------------------------
+// offset_limit
+// ---------------------------------------------------------------------------
+
+// offsetLimitStrategy sends offset=pageIndex*pageSize and limit=pageSize.
+// Used for APIs that use item-count offsets rather than page numbers (e.g. FME).
+type offsetLimitStrategy struct{}
+
+type offsetLimitData struct {
+	offset   int
+	pageSize int
+}
+
+func (offsetLimitStrategy) InjectPaging(req *client.Request, pg *spec.PagingSpec, wantStart, wantCount int) any {
+	pageSize := pg.PageSizeMax
+	if wantCount < pageSize {
+		pageSize = wantCount
+	}
+	offset := wantStart
+
+	offsetParam := pg.PageIndexParam
+	if offsetParam == "" {
+		offsetParam = "offset"
+	}
+	if req.QueryParams == nil {
+		req.QueryParams = map[string]string{}
+	}
+	req.QueryParams[offsetParam] = strconv.Itoa(offset)
+	if pg.PageSizeParam != "" && pageSize > 0 {
+		req.QueryParams[pg.PageSizeParam] = strconv.Itoa(pageSize)
+	}
+
+	return offsetLimitData{offset: offset, pageSize: pageSize}
+}
+
+func (offsetLimitStrategy) ExtractPaging(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, raw any, items []any, _ http.Header, pagingData any) (*cmdctx.PageResult, error) {
+	d := pagingData.(offsetLimitData)
+
+	pr := &cmdctx.PageResult{
+		Raw:         raw,
+		Items:       items,
+		StartOffset: d.offset,
+	}
+
+	if ep.Paging.TotalExpr != "" {
+		exprEnv := exprenv.WithIt(exprenv.Make(ctx), raw)
+		v, ok := exprenv.EvalExprAny(exprEnv, ep.Paging.TotalExpr)
+		if !ok {
+			return nil, fmt.Errorf("offset_limit: total_expr %q did not resolve", ep.Paging.TotalExpr)
+		}
+		n, err := toInt64(v)
+		if err != nil {
+			return nil, fmt.Errorf("offset_limit: total_expr %q resolved to unexpected type %T", ep.Paging.TotalExpr, v)
+		}
+		pr.HasTotal, pr.Total = true, n
+	}
+
+	pr.Last = len(items) == 0 ||
+		(d.pageSize > 0 && len(items) < d.pageSize) ||
+		(pr.HasTotal && int64(d.offset+len(items)) >= pr.Total)
 
 	return pr, nil
 }

--- a/pkg/registry/checks.go
+++ b/pkg/registry/checks.go
@@ -201,10 +201,10 @@ func validateEndpointConstraints(cs *spec.CommandSpec) error {
 		return fmt.Errorf("command %q: invalid file_body %q (must be \"optional\" or \"required\")", cs.Command, ep.FileBody)
 	}
 	switch ep.ContentType {
-	case "", "application/json", "application/yaml":
+	case "", "application/json", "application/merge-patch+json", "application/yaml":
 		// valid
 	default:
-		return fmt.Errorf("command %q: invalid content_type %q (must be \"application/json\" or \"application/yaml\")", cs.Command, ep.ContentType)
+		return fmt.Errorf("command %q: invalid content_type %q (must be \"application/json\", \"application/merge-patch+json\", or \"application/yaml\")", cs.Command, ep.ContentType)
 	}
 	if ep.ContentType != "" && ep.FileBody == spec.FileBodyNone {
 		return fmt.Errorf("command %q: content_type requires file_body to be set", cs.Command)
@@ -214,27 +214,29 @@ func validateEndpointConstraints(cs *spec.CommandSpec) error {
 
 func validatePaging(command string, pg *spec.PagingSpec) error {
 	switch pg.PagingStrategy {
-	case spec.PagingStrategyPageIndex, spec.PagingStrategyPageHeader:
+	case spec.PagingStrategyPageIndex, spec.PagingStrategyPageHeader, spec.PagingStrategyOffsetLimit:
 		// valid, fall through to server-paging checks below
 	case spec.PagingStrategyFlatList:
 		return nil
 	default:
 		return fmt.Errorf("command %q: unknown paging model %q", command, pg.PagingStrategy)
 	}
-	if pg.PageSizeDefault <= 0 {
-		return fmt.Errorf("command %q: paging requires page_size_default > 0", command)
-	}
 	if pg.PageSizeMax <= 0 {
 		return fmt.Errorf("command %q: paging requires page_size_max > 0", command)
 	}
-	if pg.PageSizeMax < pg.PageSizeDefault {
-		return fmt.Errorf("command %q: paging page_size_max (%d) must be >= page_size_default (%d)", command, pg.PageSizeMax, pg.PageSizeDefault)
-	}
-	if pg.PageIndexParam == "" {
-		return fmt.Errorf("command %q: paging requires page_index_param", command)
-	}
-	if pg.PageSizeParam == "" {
-		return fmt.Errorf("command %q: paging requires page_size_param", command)
+	if pg.PagingStrategy == spec.PagingStrategyPageIndex || pg.PagingStrategy == spec.PagingStrategyPageHeader {
+		if pg.PageSizeDefault <= 0 {
+			return fmt.Errorf("command %q: paging requires page_size_default > 0", command)
+		}
+		if pg.PageSizeMax < pg.PageSizeDefault {
+			return fmt.Errorf("command %q: paging page_size_max (%d) must be >= page_size_default (%d)", command, pg.PageSizeMax, pg.PageSizeDefault)
+		}
+		if pg.PageIndexParam == "" {
+			return fmt.Errorf("command %q: paging requires page_index_param", command)
+		}
+		if pg.PageSizeParam == "" {
+			return fmt.Errorf("command %q: paging requires page_size_param", command)
+		}
 	}
 	if pg.PagingStrategy == spec.PagingStrategyPageIndex && pg.TotalExpr == "" {
 		return fmt.Errorf("command %q: page_index paging requires total_expr", command)

--- a/pkg/registry/endpoint.go
+++ b/pkg/registry/endpoint.go
@@ -80,7 +80,7 @@ func callEndpointFull(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, extraQueryParams m
 		if err != nil {
 			return nil, nil, err
 		}
-		body, ct, err := cmdctx.NormalizeFileBody(body, ep.ContentType, cmdctx.GetString(ctx.FlagValues, "file"))
+		body, ct, err := cmdctx.NormalizeFileBody(body, resolveContentType(ep, method), cmdctx.GetString(ctx.FlagValues, "file"))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -94,25 +94,27 @@ func callEndpointFull(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, extraQueryParams m
 		}); err != nil {
 			return nil, nil, err
 		}
-		if method == "PUT" {
+		if method == "PUT" || method == "PATCH" {
 			if ep.UpdateBodyWrap != "" {
 				var parsed any
 				if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 					return nil, nil, fmt.Errorf("parsing -f body: %w", err)
 				}
-				return c.Put(path, qp, map[string]any{ep.UpdateBodyWrap: parsed})
+				return c.DoRequest(client.Request{
+					Method:          method,
+					Path:            path,
+					QueryParams:     qp,
+					Body:            map[string]any{ep.UpdateBodyWrap: parsed},
+					BodyContentType: ct,
+				})
 			}
-			return c.PutRaw(path, qp, body, ct)
-		}
-		if method == "PATCH" {
-			if ep.UpdateBodyWrap != "" {
-				var parsed any
-				if err := json.Unmarshal([]byte(body), &parsed); err != nil {
-					return nil, nil, fmt.Errorf("parsing -f body: %w", err)
-				}
-				return c.Patch(path, qp, map[string]any{ep.UpdateBodyWrap: parsed})
-			}
-			return c.PatchRaw(path, qp, body, ct)
+			return c.DoRequest(client.Request{
+				Method:          method,
+				Path:            path,
+				QueryParams:     qp,
+				Body:            body,
+				BodyContentType: ct,
+			})
 		}
 		if ep.CreateBodyWrap != "" || len(ep.CreateBodyInit) > 0 {
 			var parsed map[string]any
@@ -143,7 +145,7 @@ func callEndpointFull(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, extraQueryParams m
 
 	// Priority 2: update/create strategies — each owns its own query params.
 	if ep.UpdateStrategy == spec.UpdateStrategyGetThenPut && method == "PUT" {
-		result, err := runGetThenPut(ctx, ep, c, path)
+		result, err := runGetThenUpdate(ctx, ep, c, path, method)
 		return result, nil, err
 	}
 	if ep.UpdateStrategy == spec.UpdateStrategyGetThenPutKV && method == "PUT" {
@@ -151,7 +153,7 @@ func callEndpointFull(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, extraQueryParams m
 		return result, nil, err
 	}
 	if ep.UpdateStrategy == spec.UpdateStrategyGetThenPatch && method == "PATCH" {
-		result, err := runGetThenPatch(ctx, ep, c, path)
+		result, err := runGetThenUpdate(ctx, ep, c, path, method)
 		return result, nil, err
 	}
 	if ep.CreateStrategy == spec.CreateStrategySetFields && method == "POST" {
@@ -547,13 +549,29 @@ func setDotPath(m map[string]any, path string, val any) {
 	setDotPath(child, parts[1], val)
 }
 
-// runGetThenPut implements the "get-then-put" update strategy:
+// resolveContentType returns the Content-Type for a request: ep.ContentType if set,
+// otherwise a method-based default (PATCH → merge-patch+json, POST/PUT → application/json).
+func resolveContentType(ep *spec.EndpointSpec, method string) string {
+	if ep.ContentType != "" {
+		return ep.ContentType
+	}
+	switch method {
+	case "PATCH":
+		return "application/merge-patch+json"
+	case "POST", "PUT":
+		return "application/json"
+	default:
+		return ""
+	}
+}
+
+// runGetThenUpdate implements the "get-then-put" and "get-then-patch" update strategies:
 //  1. GET the resource using get_query_params (falls back to query_params)
 //  2. Extract ep.UpdateBodyPick subtree from the response
 //  3. Apply --set/--del mutations using noun field paths
-//  4. Re-wrap under ep.UpdateBodyWrap key
-//  5. PUT the result
-func runGetThenPut(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, path string) (any, error) {
+//  4. Re-wrap under ep.UpdateBodyWrap key (if set)
+//  5. PUT or PATCH the result (method determines verb and Content-Type)
+func runGetThenUpdate(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, path, method string) (any, error) {
 	exprEnv := exprenv.Make(ctx)
 
 	getPath := path
@@ -561,14 +579,14 @@ func runGetThenPut(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, pat
 		var err error
 		getPath, err = exprenv.ResolvePath(exprEnv, ep.GetPath)
 		if err != nil {
-			return nil, fmt.Errorf("get-then-put: resolving get_path %q: %w", ep.GetPath, err)
+			return nil, fmt.Errorf("get-then-%s: resolving get_path %q: %w", strings.ToLower(method), ep.GetPath, err)
 		}
 	}
 
 	getQP := evalQueryParams(ctx, firstNonEmptyMap(ep.GetQueryParams, ep.QueryParams), true)
 	getResult, _, err := c.Get(getPath, getQP)
 	if err != nil {
-		return nil, fmt.Errorf("get-then-put: GET failed: %w", err)
+		return nil, fmt.Errorf("get-then-%s: GET failed: %w", strings.ToLower(method), err)
 	}
 
 	// Extract the mutable subtree from the root GET response.
@@ -578,7 +596,7 @@ func runGetThenPut(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, pat
 	if ep.UpdateBodyPick != "" {
 		picked, ok := exprenv.EvalExprAny(exprenv.WithIt(exprEnv, getResult), ep.UpdateBodyPick)
 		if !ok {
-			return nil, fmt.Errorf("get-then-put: update_body_pick %q did not resolve", ep.UpdateBodyPick)
+			return nil, fmt.Errorf("get-then-%s: update_body_pick %q did not resolve", strings.ToLower(method), ep.UpdateBodyPick)
 		}
 		item = picked
 	} else if ep.ItemExpr != "" && ep.ItemExpr != "it" {
@@ -590,11 +608,11 @@ func runGetThenPut(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, pat
 	// Round-trip through JSON to get a map[string]any we can mutate.
 	b, err := json.Marshal(item)
 	if err != nil {
-		return nil, fmt.Errorf("get-then-put: marshaling picked item: %w", err)
+		return nil, fmt.Errorf("get-then-%s: marshaling picked item: %w", strings.ToLower(method), err)
 	}
 	var mutable map[string]any
 	if err := json.Unmarshal(b, &mutable); err != nil {
-		return nil, fmt.Errorf("get-then-put: unmarshaling picked item: %w", err)
+		return nil, fmt.Errorf("get-then-%s: unmarshaling picked item: %w", strings.ToLower(method), err)
 	}
 
 	// Build a fieldID→FieldDef map from the noun's mutable fields for --set/--del resolution.
@@ -607,82 +625,17 @@ func runGetThenPut(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, pat
 		return nil, err
 	}
 
-	// Re-wrap and PUT.
-	var putBody any = mutable
+	var updateBody any = mutable
 	if ep.UpdateBodyWrap != "" {
-		putBody = map[string]any{ep.UpdateBodyWrap: mutable}
+		updateBody = map[string]any{ep.UpdateBodyWrap: mutable}
 	}
-	putQP := evalQueryParams(ctx, ep.QueryParams, true)
-	result, _, err := c.Put(path, putQP, putBody)
-	return result, err
-}
-
-// runGetThenPatch implements the "get-then-patch" update strategy:
-//  1. GET the resource using get_path (falls back to path)
-//  2. Extract ep.UpdateBodyPick subtree from the response
-//  3. Apply --set/--del mutations using noun field paths
-//  4. Re-wrap under ep.UpdateBodyWrap key (if set)
-//  5. PATCH the result with Content-Type: application/merge-patch+json
-func runGetThenPatch(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, path string) (any, error) {
-	exprEnv := exprenv.Make(ctx)
-
-	getPath := path
-	if ep.GetPath != "" {
-		var err error
-		getPath, err = exprenv.ResolvePath(exprEnv, ep.GetPath)
-		if err != nil {
-			return nil, fmt.Errorf("get-then-patch: resolving get_path %q: %w", ep.GetPath, err)
-		}
-	}
-
-	getQP := evalQueryParams(ctx, firstNonEmptyMap(ep.GetQueryParams, ep.QueryParams), true)
-	getResult, _, err := c.Get(getPath, getQP)
-	if err != nil {
-		return nil, fmt.Errorf("get-then-patch: GET failed: %w", err)
-	}
-
-	item := getResult
-	if ep.UpdateBodyPick != "" {
-		picked, ok := exprenv.EvalExprAny(exprenv.WithIt(exprEnv, getResult), ep.UpdateBodyPick)
-		if !ok {
-			return nil, fmt.Errorf("get-then-patch: update_body_pick %q did not resolve", ep.UpdateBodyPick)
-		}
-		item = picked
-	} else if ep.ItemExpr != "" && ep.ItemExpr != "it" {
-		if v, ok := exprenv.EvalExprAny(exprenv.WithIt(exprEnv, getResult), ep.ItemExpr); ok {
-			item = v
-		}
-	}
-
-	b, err := json.Marshal(item)
-	if err != nil {
-		return nil, fmt.Errorf("get-then-patch: marshaling picked item: %w", err)
-	}
-	var mutable map[string]any
-	if err := json.Unmarshal(b, &mutable); err != nil {
-		return nil, fmt.Errorf("get-then-patch: unmarshaling picked item: %w", err)
-	}
-
-	fieldPaths := map[string]spec.FieldDef{}
-	for _, f := range MutableFields(resolveNounDef(ctx)) {
-		fieldPaths[f.ID] = f
-	}
-
-	if err := applyMutations(mutable, ctx.SetArgs, ctx.DelArgs, fieldPaths); err != nil {
-		return nil, err
-	}
-
-	var patchBody any = mutable
-	if ep.UpdateBodyWrap != "" {
-		patchBody = map[string]any{ep.UpdateBodyWrap: mutable}
-	}
-	patchQP := evalQueryParams(ctx, ep.QueryParams, true)
+	updateQP := evalQueryParams(ctx, ep.QueryParams, true)
 	result, _, err := c.DoRequest(client.Request{
-		Method:          "PATCH",
+		Method:          method,
 		Path:            path,
-		QueryParams:     patchQP,
-		Body:            patchBody,
-		BodyContentType: "application/merge-patch+json",
+		QueryParams:     updateQP,
+		Body:            updateBody,
+		BodyContentType: resolveContentType(ep, method),
 	})
 	return result, err
 }

--- a/pkg/registry/endpoint.go
+++ b/pkg/registry/endpoint.go
@@ -104,6 +104,16 @@ func callEndpointFull(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, extraQueryParams m
 			}
 			return c.PutRaw(path, qp, body, ct)
 		}
+		if method == "PATCH" {
+			if ep.UpdateBodyWrap != "" {
+				var parsed any
+				if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+					return nil, nil, fmt.Errorf("parsing -f body: %w", err)
+				}
+				return c.Patch(path, qp, map[string]any{ep.UpdateBodyWrap: parsed})
+			}
+			return c.PatchRaw(path, qp, body, ct)
+		}
 		if ep.CreateBodyWrap != "" || len(ep.CreateBodyInit) > 0 {
 			var parsed map[string]any
 			if err := json.Unmarshal([]byte(body), &parsed); err != nil {

--- a/pkg/registry/endpoint.go
+++ b/pkg/registry/endpoint.go
@@ -140,6 +140,10 @@ func callEndpointFull(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, extraQueryParams m
 		result, err := runGetThenPutKV(ctx, ep, c, path)
 		return result, nil, err
 	}
+	if ep.UpdateStrategy == spec.UpdateStrategyGetThenPatch && method == "PATCH" {
+		result, err := runGetThenPatch(ctx, ep, c, path)
+		return result, nil, err
+	}
 	if ep.CreateStrategy == spec.CreateStrategySetFields && method == "POST" {
 		result, err := runSetFields(ctx, ep, c, path)
 		return result, nil, err
@@ -600,6 +604,76 @@ func runGetThenPut(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, pat
 	}
 	putQP := evalQueryParams(ctx, ep.QueryParams, true)
 	result, _, err := c.Put(path, putQP, putBody)
+	return result, err
+}
+
+// runGetThenPatch implements the "get-then-patch" update strategy:
+//  1. GET the resource using get_path (falls back to path)
+//  2. Extract ep.UpdateBodyPick subtree from the response
+//  3. Apply --set/--del mutations using noun field paths
+//  4. Re-wrap under ep.UpdateBodyWrap key (if set)
+//  5. PATCH the result with Content-Type: application/merge-patch+json
+func runGetThenPatch(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, path string) (any, error) {
+	exprEnv := exprenv.Make(ctx)
+
+	getPath := path
+	if ep.GetPath != "" {
+		var err error
+		getPath, err = exprenv.ResolvePath(exprEnv, ep.GetPath)
+		if err != nil {
+			return nil, fmt.Errorf("get-then-patch: resolving get_path %q: %w", ep.GetPath, err)
+		}
+	}
+
+	getQP := evalQueryParams(ctx, firstNonEmptyMap(ep.GetQueryParams, ep.QueryParams), true)
+	getResult, _, err := c.Get(getPath, getQP)
+	if err != nil {
+		return nil, fmt.Errorf("get-then-patch: GET failed: %w", err)
+	}
+
+	item := getResult
+	if ep.UpdateBodyPick != "" {
+		picked, ok := exprenv.EvalExprAny(exprenv.WithIt(exprEnv, getResult), ep.UpdateBodyPick)
+		if !ok {
+			return nil, fmt.Errorf("get-then-patch: update_body_pick %q did not resolve", ep.UpdateBodyPick)
+		}
+		item = picked
+	} else if ep.ItemExpr != "" && ep.ItemExpr != "it" {
+		if v, ok := exprenv.EvalExprAny(exprenv.WithIt(exprEnv, getResult), ep.ItemExpr); ok {
+			item = v
+		}
+	}
+
+	b, err := json.Marshal(item)
+	if err != nil {
+		return nil, fmt.Errorf("get-then-patch: marshaling picked item: %w", err)
+	}
+	var mutable map[string]any
+	if err := json.Unmarshal(b, &mutable); err != nil {
+		return nil, fmt.Errorf("get-then-patch: unmarshaling picked item: %w", err)
+	}
+
+	fieldPaths := map[string]spec.FieldDef{}
+	for _, f := range MutableFields(resolveNounDef(ctx)) {
+		fieldPaths[f.ID] = f
+	}
+
+	if err := applyMutations(mutable, ctx.SetArgs, ctx.DelArgs, fieldPaths); err != nil {
+		return nil, err
+	}
+
+	var patchBody any = mutable
+	if ep.UpdateBodyWrap != "" {
+		patchBody = map[string]any{ep.UpdateBodyWrap: mutable}
+	}
+	patchQP := evalQueryParams(ctx, ep.QueryParams, true)
+	result, _, err := c.DoRequest(client.Request{
+		Method:          "PATCH",
+		Path:            path,
+		QueryParams:     patchQP,
+		Body:            patchBody,
+		BodyContentType: "application/merge-patch+json",
+	})
 	return result, err
 }
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -64,11 +64,11 @@ const (
 
 // Valid paging_strategy values for PagingSpec.
 const (
-	PagingStrategyPageIndex  = "page_index"   // API accepts pageIndex + pageSize; response has totalItems, content, empty
-	PagingStrategyPageHeader = "page_header"  // v1 API: bare array body; total/page info in X-Total-Elements / X-Page-Number / X-Page-Size response headers
-	PagingStrategyFlatList   = "flat_list"    // API returns all items in one shot; offset/limit applied client-side
-	PagingStrategyNone       = "none"         // API returns everything; offset/limit applied client-side
-	PagingStrategyCursor     = "cursor"       // token-based iteration; no random access, not countable (not yet implemented)
+	PagingStrategyPageIndex   = "page_index"   // API accepts pageIndex + pageSize; response has totalItems, content, empty
+	PagingStrategyPageHeader  = "page_header"  // v1 API: bare array body; total/page info in X-Total-Elements / X-Page-Number / X-Page-Size response headers
+	PagingStrategyFlatList    = "flat_list"    // API returns all items in one shot; offset/limit applied client-side
+	PagingStrategyNone        = "none"         // API returns everything; offset/limit applied client-side
+	PagingStrategyCursor      = "cursor"       // token-based iteration; no random access, not countable (not yet implemented)
 	PagingStrategyOffsetLimit = "offset_limit" // API accepts offset (items to skip) + limit; response has totalCount
 )
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -47,6 +47,7 @@ const (
 const (
 	UpdateStrategyGetThenPut   = "get-then-put"
 	UpdateStrategyGetThenPutKV = "get-then-put-kv"
+	UpdateStrategyGetThenPatch = "get-then-patch"
 )
 
 // Valid create_strategy values for EndpointSpec.
@@ -63,11 +64,12 @@ const (
 
 // Valid paging_strategy values for PagingSpec.
 const (
-	PagingStrategyPageIndex  = "page_index"  // API accepts pageIndex + pageSize; response has totalItems, content, empty
-	PagingStrategyPageHeader = "page_header" // v1 API: bare array body; total/page info in X-Total-Elements / X-Page-Number / X-Page-Size response headers
-	PagingStrategyFlatList   = "flat_list"   // API returns all items in one shot; offset/limit applied client-side
-	PagingStrategyNone       = "none"        // API returns everything; offset/limit applied client-side
-	PagingStrategyCursor     = "cursor"      // token-based iteration; no random access, not countable (not yet implemented)
+	PagingStrategyPageIndex  = "page_index"   // API accepts pageIndex + pageSize; response has totalItems, content, empty
+	PagingStrategyPageHeader = "page_header"  // v1 API: bare array body; total/page info in X-Total-Elements / X-Page-Number / X-Page-Size response headers
+	PagingStrategyFlatList   = "flat_list"    // API returns all items in one shot; offset/limit applied client-side
+	PagingStrategyNone       = "none"         // API returns everything; offset/limit applied client-side
+	PagingStrategyCursor     = "cursor"       // token-based iteration; no random access, not countable (not yet implemented)
+	PagingStrategyOffsetLimit = "offset_limit" // API accepts offset (items to skip) + limit; response has totalCount
 )
 
 // BuiltinFlags enables predefined system flags that have fixed registration and dispatch behavior.


### PR DESCRIPTION
## Summary

- Adds `offset_limit` paging strategy: sends `offset=pageIndex*pageSize` and `limit=pageSize` for APIs that use item-count offsets rather than page numbers (used by FME). Last-page detection via `total_expr`.
- Adds `get-then-patch` update strategy: mirrors `get-then-put` but issues `PATCH` with `Content-Type: application/merge-patch+json`. Supports `--set`/`--del` and `-f`.
- Adds `PagingStrategyOffsetLimit` and `UpdateStrategyGetThenPatch` constants to `pkg/spec/spec.go`.

> **Stack note**: PR 2 (FME spec module) is stacked on top of this branch — merge this first.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/endpoint/...` passes
- [ ] Integration: `harness list ff` uses offset_limit paging correctly (after PR 2 merges)
- [ ] Integration: `harness update ff <name> --set description=foo` issues PATCH with `application/merge-patch+json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)