### PR TITLE
Added CRUD commands for input_sets

### DIFF
--- a/pkg/spec/pipeline.spec.yaml
+++ b/pkg/spec/pipeline.spec.yaml
@@ -805,6 +805,64 @@ commands:
       query_params:
         pipelineIdentifier: ctx.idParts[0]
 
+  - command: create input_set
+    verb: create
+    noun: input_set
+    short: Create an input set for a pipeline (-f input-set.yaml)
+    requires_id: true
+    completion_noun: pipeline
+    handler_type: endpoint
+    endpoint:
+      method: POST
+      path: /pipeline/api/inputSets
+      file_body: required
+      content_type: application/yaml
+      item_expr: it.data
+      text_header: "\nCreated input set in pipeline {{ctx.id}}\n"
+      query_params:
+        pipelineIdentifier: ctx.id
+
+  - command: update input_set
+    verb: update
+    noun: input_set
+    short: Update an input set's YAML definition (-f input-set.yaml)
+    id_parts: 2
+    id_label: "<pipeline/id>"
+    completion_seq:
+      - completion_noun: pipeline
+      - completion_noun: input_set
+        keep_order: true
+    handler_type: endpoint
+    endpoint:
+      method: PUT
+      path: /pipeline/api/inputSets/{{lastPart(ctx.id)}}
+      file_body: required
+      content_type: application/yaml
+      no_fields: true
+      text_header: "\nUpdated input set {{lastPart(ctx.id)}}\n"
+      query_params:
+        pipelineIdentifier: ctx.idParts[0]
+
+  - command: delete input_set
+    verb: delete
+    noun: input_set
+    confirm_mode: prompt
+    short: Delete an input set by identifier
+    id_parts: 2
+    id_label: "<pipeline/id>"
+    completion_seq:
+      - completion_noun: pipeline
+      - completion_noun: input_set
+        keep_order: true
+    handler_type: endpoint
+    endpoint:
+      method: DELETE
+      path: /pipeline/api/inputSets/{{lastPart(ctx.id)}}
+      item_expr: it
+      text_header: "\nDeleted input set {{lastPart(ctx.id)}}\n"
+      query_params:
+        pipelineIdentifier: ctx.idParts[0]
+
   - command: get runtime_input_template
     verb: get
     noun: runtime_input_template


### PR DESCRIPTION
## Summary
- Adds `create input_set`, `update input_set`, and `delete input_set` to the pipeline spec.
- Endpoints: `POST /pipeline/api/inputSets` (create), `PUT|DELETE /pipeline/api/inputSets/{id}` (update/delete) — all scoped via the `pipelineIdentifier` query param.

## Notes
- `update`/`delete input_set` address the input set as `<pipeline_id>/<input_set_id>`, reading the pipeline from `ctx.idParts[0]`.


## Test plan
- [x] Full manual lifecycle against a live pipeline: create → list → get → update → delete → list (confirms removal) → create again → negative get (404 on nonexistent input set)