### PR TITLE
Hint profile added in the auth status

### DIFF
--- a/modules/core/auth/login.go
+++ b/modules/core/auth/login.go
@@ -251,7 +251,7 @@ func validateToken(apiURL, token, accountID string) error {
 	case 200:
 		return nil
 	case 401:
-		return fmt.Errorf("token rejected (401) — check that your API token is valid")
+		return fmt.Errorf("token rejected (401) — check that your API token is valid\n\nTip: run 'harness auth profiles' to see available profiles, then retry with --profile <name>")
 	case 403:
 		return fmt.Errorf("token valid but access denied (403) — check account ID or RBAC permissions")
 	default:

--- a/modules/core/auth/status.go
+++ b/modules/core/auth/status.go
@@ -424,24 +424,34 @@ func checkErrors(r statusResult) error {
 		return c.Error
 	}
 	if failed(r.Status.Profile) {
-		return fmt.Errorf("\nError: %s", msg(r.Status.Profile))
+		return fmt.Errorf("\nError: %s", maybeAppendProfileHint(msg(r.Status.Profile)))
 	}
 	if failed(r.Status.API) {
-		return fmt.Errorf("\nError: %s", msg(r.Status.API))
+		return fmt.Errorf("\nError: %s", maybeAppendProfileHint(msg(r.Status.API)))
 	}
 	if failed(r.Status.User) {
-		return fmt.Errorf("\nError: %s", msg(r.Status.User))
+		return fmt.Errorf("\nError: %s", maybeAppendProfileHint(msg(r.Status.User)))
 	}
 	if failed(r.Status.Account) {
-		return fmt.Errorf("\nError: %s", msg(r.Status.Account))
+		return fmt.Errorf("\nError: %s", maybeAppendProfileHint(msg(r.Status.Account)))
 	}
 	if r.Status.Org != nil && failed(*r.Status.Org) {
-		return fmt.Errorf("\nError: %s", msg(*r.Status.Org))
+		return fmt.Errorf("\nError: %s", maybeAppendProfileHint(msg(*r.Status.Org)))
 	}
 	if r.Status.Project != nil && failed(*r.Status.Project) {
-		return fmt.Errorf("\nError: %s", msg(*r.Status.Project))
+		return fmt.Errorf("\nError: %s", maybeAppendProfileHint(msg(*r.Status.Project)))
 	}
 	return nil
+}
+
+// maybeAppendProfileHint appends a hint pointing the user to 'harness auth profiles'
+// when the failure looks like a rejected/invalid token (401), so they have an
+// actionable next step instead of a dead-end error.
+func maybeAppendProfileHint(msg string) string {
+	if strings.Contains(msg, "401") {
+		return msg + "\n\nTip: run 'harness auth profiles' to see available profiles, then retry with --profile <name>"
+	}
+	return msg
 }
 
 func currentUserFields(u any) (email, uuid string) {


### PR DESCRIPTION
## Summary

Closes harness/cli#55 — `harness auth status` and `harness auth login` now append an actionable hint when a token is rejected (401), instead of leaving the user with a dead-end error.

## Changes

- `modules/core/auth/status.go`: added `maybeAppendProfileHint`, appended to all `checkErrors` failure branches (Profile, API, User, Account, Org, Project) so any 401-flavored check failure gets the hint.
- `modules/core/auth/login.go`: appended the same hint to the 401 branch of `validateToken`.
