### PR TITLE
Feat/Add unit tests for registry endpoint layer, auth login, gitops, and pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ CLAUDE.local.md
 internal-docs/
 *~
 .claude/settings.local.md
+.claude/
 .cursor/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,6 +74,21 @@ tasks:
     cmds:
       - HARNESS_CHECKSPECS=1 ./bin/harness
 
+  test:
+    desc: Run all unit tests
+    deps: [test:main, test:har]
+
+  test:main:
+    desc: Run unit tests for the main module
+    cmds:
+      - go test ./...
+
+  test:har:
+    desc: Run unit tests for the HAR external module
+    dir: modules/har
+    cmds:
+      - go test ./...
+
   tidy:
     desc: Tidy all modules and sync go.work
     cmds:

--- a/modules/core/auth/login_test.go
+++ b/modules/core/auth/login_test.go
@@ -1,0 +1,465 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/hbase"
+)
+
+// testCtx builds a bare Ctx with only FlagValues set.
+func testCtx(flags map[string]any) *cmdctx.Ctx {
+	return &cmdctx.Ctx{FlagValues: flags}
+}
+
+// isolatedCtx redirects HARNESS_CLI_HOME to a fresh temp dir so LoadConfig /
+// SaveConfig never touch the real ~/.harness.
+func isolatedCtx(t *testing.T, flags map[string]any) *cmdctx.Ctx {
+	t.Helper()
+	t.Setenv(hbase.EnvCLIHome, t.TempDir())
+	return testCtx(flags)
+}
+
+// isolatedDir sets HARNESS_CLI_HOME to dir and returns the dir.
+func isolatedDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv(hbase.EnvCLIHome, dir)
+	return dir
+}
+
+func writeTestConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+}
+
+// validToken is a syntactically valid PAT whose account segment is "acctid".
+const validToken = "pat.acctid.tokenid.secret123"
+
+// --------------------------------------------------------------------------
+// LoginHandler — early-return validation branches
+// --------------------------------------------------------------------------
+
+func TestLoginHandler_mutualExclusiveOverwrite(t *testing.T) {
+	ctx := testCtx(map[string]any{"overwrite": true, "no-overwrite": true})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %q, want %q", err, "mutually exclusive")
+	}
+}
+
+func TestLoginHandler_profileNameValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		profile      string
+		wantErrSub   string
+		wantNoErrSub string
+	}{
+		{name: "special chars rejected", profile: "bad name!", wantErrSub: "invalid profile name"},
+		{name: "space rejected", profile: "bad profile", wantErrSub: "invalid profile name"},
+		{name: "at-sign rejected", profile: "user@domain", wantErrSub: "invalid profile name"},
+		{name: "dot rejected", profile: "my.profile", wantErrSub: "invalid profile name"},
+		{name: "valid alphanumeric-dash", profile: "my-profile1", wantNoErrSub: "invalid profile name"},
+		{name: "valid with underscores", profile: "my_profile_1", wantNoErrSub: "invalid profile name"},
+		{name: "single char valid", profile: "a", wantNoErrSub: "invalid profile name"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx(map[string]any{"profile": tc.profile})
+			err := LoginHandler(ctx)
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error = %q, want substring %q", err, tc.wantErrSub)
+				}
+			}
+			if tc.wantNoErrSub != "" && err != nil {
+				if strings.Contains(err.Error(), tc.wantNoErrSub) {
+					t.Fatalf("valid profile triggered profile-name error: %q", err)
+				}
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// LoginHandler — non-interactive (no TTY) path
+// --------------------------------------------------------------------------
+
+func TestLoginHandler_nonInteractive_noToken(t *testing.T) {
+	// IsPty=false (default), no api-token → "not a terminal"
+	ctx := isolatedCtx(t, map[string]any{"profile": "default"})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if !strings.Contains(err.Error(), "not a terminal") {
+		t.Fatalf("error = %q, want %q", err, "not a terminal")
+	}
+}
+
+func TestLoginHandler_nonInteractive_existingProfile_noOverwriteFlag(t *testing.T) {
+	dir := isolatedDir(t)
+	writeTestConfig(t, dir, `profiles:
+  default:
+    api_url: https://app.harness.io
+    account_id: acct
+`)
+	ctx := testCtx(map[string]any{
+		"no-overwrite": true,
+		"api-token":    validToken,
+	})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %q, want %q", err, "already exists")
+	}
+}
+
+func TestLoginHandler_nonInteractive_existingProfile_noFlag(t *testing.T) {
+	// Neither --overwrite nor --no-overwrite → "already exists — pass --overwrite or --no-overwrite"
+	dir := isolatedDir(t)
+	writeTestConfig(t, dir, `profiles:
+  default:
+    api_url: https://app.harness.io
+    account_id: acct
+`)
+	ctx := testCtx(map[string]any{"api-token": validToken})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %q, want %q", err, "already exists")
+	}
+}
+
+func TestLoginHandler_nonInteractive_badPATFormat(t *testing.T) {
+	ctx := isolatedCtx(t, map[string]any{"api-token": "notapat"})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("error = %q, want %q", err, "invalid token")
+	}
+}
+
+func TestLoginHandler_nonInteractive_accountMismatch(t *testing.T) {
+	// Token has account "acctid", flag passes "otheracct" → mismatch error.
+	ctx := isolatedCtx(t, map[string]any{
+		"api-token": validToken,
+		"account":   "otheracct",
+		"no-validate": true,
+	})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "does not match account ID in token") {
+		t.Fatalf("error = %q, want %q", err, "does not match account ID in token")
+	}
+}
+
+func TestLoginHandler_nonInteractive_badAPIURL(t *testing.T) {
+	// Provide a token so we reach URL validation; use IsPty=false and a non-empty
+	// api-url that doesn't look like a Harness URL.
+	ctx := isolatedCtx(t, map[string]any{
+		"api-token": validToken,
+		"api-url":   "ftp://bad.url",
+	})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error for invalid API URL")
+	}
+	// ValidateAPIURL returns an error about the URL not being a valid Harness URL.
+	if !strings.Contains(strings.ToLower(err.Error()), "url") && !strings.Contains(strings.ToLower(err.Error()), "harness") {
+		t.Fatalf("error = %q, expected URL-related error", err)
+	}
+}
+
+func TestLoginHandler_nonInteractive_overwriteExistingProfile(t *testing.T) {
+	// --overwrite on existing profile: hits the "silent" branch and continues.
+	// With a valid-format token and --no-validate, it should proceed past that
+	// branch and reach fetchRegistryURL (HTTP) — we use a test server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"registryUrl": ""}})
+	}))
+	defer srv.Close()
+
+	dir := isolatedDir(t)
+	writeTestConfig(t, dir, `profiles:
+  default:
+    api_url: https://app.harness.io
+    account_id: acctid
+`)
+	ctx := testCtx(map[string]any{
+		"overwrite":   true,
+		"api-token":   validToken,
+		"api-url":     srv.URL,
+		"no-validate": true,
+	})
+	err := LoginHandler(ctx)
+	// Should not fail with "already exists" — the overwrite branch must be silent.
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("--overwrite should not return already-exists error, got: %v", err)
+	}
+}
+
+func TestLoginHandler_IsPty_emptyURL_noToken(t *testing.T) {
+	// IsPty=true + empty api-url → apiURL defaults to app.harness.io.
+	// No token → "API token is required" (line 152, distinct from the non-IsPty "not a terminal").
+	ctx := isolatedCtx(t, nil)
+	ctx.IsPty = true
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "API token is required") {
+		t.Fatalf("error = %q, want %q", err, "API token is required")
+	}
+}
+
+func TestLoginHandler_IsPty_badAPIURL(t *testing.T) {
+	// IsPty=true + non-empty bad api-url → ValidateAPIURL error.
+	ctx := isolatedCtx(t, map[string]any{
+		"api-url":   "ftp://not-harness.example.com",
+		"api-token": validToken,
+	})
+	ctx.IsPty = true
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error for invalid API URL")
+	}
+	if !strings.Contains(err.Error(), "not a valid Harness API URL") {
+		t.Fatalf("error = %q, want %q", err, "not a valid Harness API URL")
+	}
+}
+
+func TestLoginHandler_configLoadError(t *testing.T) {
+	// Point HARNESS_CLI_HOME at a file (not a dir), so config.LoadConfig
+	// gets a path that ends in /config.yaml but the parent is a file, causing
+	// an error when it tries to read it.
+	tmp := t.TempDir()
+	// Write a file where config.yaml would be expected.
+	configPath := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("not: [valid yaml"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Setenv(hbase.EnvCLIHome, tmp)
+
+	ctx := testCtx(map[string]any{"profile": "default"})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error for corrupt config")
+	}
+	// Error must come from config parsing, not from profile-name validation.
+	if strings.Contains(err.Error(), "invalid profile name") {
+		t.Fatalf("got profile-name error instead of config error: %v", err)
+	}
+}
+
+func TestLoginHandler_nonInteractive_validateTokenCalled(t *testing.T) {
+	// Without --no-validate, validateToken is called. Point it at a test server
+	// that returns 401 so we can confirm the validation error is surfaced.
+	// NOTE: api-url must pass ValidateAPIURL (requires *.harness.io host) which
+	// prevents using a local httptest.Server URL here. The remaining happy-path
+	// branches (lines 165-198) that require a valid api-url + network are covered
+	// by validateToken and fetchRegistryURL unit tests below instead.
+	ctx := isolatedCtx(t, map[string]any{
+		"api-token": validToken,
+		// api-url empty → defaults to https://app.harness.io; validateToken will
+		// fail with a network error (not a "validation failed" message).
+	})
+	err := LoginHandler(ctx)
+	if err == nil {
+		t.Fatal("expected error when token validation fails")
+	}
+	// Must NOT be a profile-name or PAT-format error — those would mean we regressed
+	// to an earlier gate.
+	if strings.Contains(err.Error(), "invalid profile name") || strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("error at wrong stage: %q", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// validateToken — all HTTP status branches
+// --------------------------------------------------------------------------
+
+func TestValidateToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErrSub string
+		wantNil    bool
+	}{
+		{
+			name:       "200 OK returns nil",
+			statusCode: 200,
+			wantNil:    true,
+		},
+		{
+			name:       "401 returns token rejected",
+			statusCode: 401,
+			wantErrSub: "token rejected (401)",
+		},
+		{
+			name:       "403 returns access denied",
+			statusCode: 403,
+			wantErrSub: "access denied (403)",
+		},
+		{
+			name:       "500 with JSON message returns message",
+			statusCode: 500,
+			body:       `{"message":"internal error"}`,
+			wantErrSub: "internal error",
+		},
+		{
+			name:       "500 without JSON message returns status code",
+			statusCode: 500,
+			body:       `not json`,
+			wantErrSub: "validation failed with status 500",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				if tc.body != "" {
+					w.Write([]byte(tc.body))
+				}
+			}))
+			defer srv.Close()
+
+			err := validateToken(srv.URL, "tok", "acct")
+			if tc.wantNil {
+				if err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestValidateToken_unreachableServer(t *testing.T) {
+	// Use a server that is immediately closed so the HTTP request fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	err := validateToken(srv.URL, "tok", "acct")
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+	if !strings.Contains(err.Error(), "cannot reach") {
+		t.Fatalf("error = %q, want %q", err, "cannot reach")
+	}
+}
+
+// --------------------------------------------------------------------------
+// fetchRegistryURL — all branches
+// --------------------------------------------------------------------------
+
+func TestFetchRegistryURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantURL    string
+		wantErrSub string
+	}{
+		{
+			name:       "200 with registryUrl",
+			statusCode: 200,
+			body:       `{"data":{"registryUrl":"https://pkg.harness.io"}}`,
+			wantURL:    "https://pkg.harness.io",
+		},
+		{
+			name:       "200 without registryUrl returns empty",
+			statusCode: 200,
+			body:       `{"data":{}}`,
+			wantURL:    "",
+		},
+		{
+			name:       "non-200 returns error",
+			statusCode: 404,
+			wantErrSub: "status 404",
+		},
+		{
+			name:       "200 with invalid JSON returns decode error",
+			statusCode: 200,
+			body:       `not json`,
+			wantErrSub: "decoding response",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				if tc.body != "" {
+					w.Write([]byte(tc.body))
+				}
+			}))
+			defer srv.Close()
+
+			got, err := fetchRegistryURL(srv.URL, "tok", "acct")
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error = %q, want substring %q", err, tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantURL {
+				t.Fatalf("fetchRegistryURL = %q, want %q", got, tc.wantURL)
+			}
+		})
+	}
+}
+
+func TestFetchRegistryURL_unreachableServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	_, err := fetchRegistryURL(srv.URL, "tok", "acct")
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+	if !strings.Contains(err.Error(), "request failed") {
+		t.Fatalf("error = %q, want %q", err, "request failed")
+	}
+}

--- a/modules/core/auth/login_test.go
+++ b/modules/core/auth/login_test.go
@@ -167,8 +167,8 @@ func TestLoginHandler_nonInteractive_badPATFormat(t *testing.T) {
 func TestLoginHandler_nonInteractive_accountMismatch(t *testing.T) {
 	// Token has account "acctid", flag passes "otheracct" → mismatch error.
 	ctx := isolatedCtx(t, map[string]any{
-		"api-token": validToken,
-		"account":   "otheracct",
+		"api-token":   validToken,
+		"account":     "otheracct",
 		"no-validate": true,
 	})
 	err := LoginHandler(ctx)

--- a/modules/gitops/gitops_test.go
+++ b/modules/gitops/gitops_test.go
@@ -1,0 +1,371 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitops
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/auth"
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/registry"
+	"github.com/harness/cli/pkg/spec"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+type noopResolver struct{}
+
+func (noopResolver) ResolveTextFormatter(id string) cmdctx.TextFormatterFn                        { return nil }
+func (noopResolver) ResolveBodyFn(id string) cmdctx.CreateBodyFn                                  { return nil }
+func (noopResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn                          { return nil }
+func (noopResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn                          { return nil }
+func (noopResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)                             { return nil, nil }
+func (noopResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn                { return nil }
+func (noopResolver) GetSpec(verb, noun string) *spec.CommandSpec                                  { return nil }
+func (noopResolver) GetNoun(noun string) *spec.NounDef                                            { return nil }
+func (noopResolver) ResolveNounAlias(alias string) string                                         { return "" }
+func (noopResolver) RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error)              { return nil, nil }
+func (noopResolver) FormatList(*cmdctx.Ctx, []any, []spec.FieldDef, []string) error               { return nil }
+func (noopResolver) FetchItems(*cmdctx.Ctx, *spec.EndpointSpec, cmdctx.PagingFlags) ([]any, error) { return nil, nil }
+func (noopResolver) GetModuleMetas() []spec.ModuleMeta                                            { return nil }
+func (noopResolver) GetSpecsForModule(string) []*spec.CommandSpec                                 { return nil }
+func (noopResolver) GetAllSpecs() []*spec.CommandSpec                                             { return nil }
+func (noopResolver) GetVerbInfos() []spec.VerbInfo                                                { return nil }
+func (noopResolver) ResolveCommandFields(*spec.CommandSpec) []spec.FieldDef                       { return nil }
+
+type spyResolver struct {
+	noopResolver
+	getSpec func(verb, noun string) *spec.CommandSpec
+}
+
+func (s spyResolver) GetSpec(verb, noun string) *spec.CommandSpec {
+	if s.getSpec != nil {
+		return s.getSpec(verb, noun)
+	}
+	return nil
+}
+
+func agentGetSpec(path string) *spec.CommandSpec {
+	return &spec.CommandSpec{
+		Command: "get gitops_agent", Verb: "get", VerbHandler: "get",
+		Noun: "gitops_agent", Module: "gitops", HandlerType: spec.HandlerEndpoint,
+		Endpoint: &spec.EndpointSpec{Method: "GET", Path: path, ItemExpr: "it"},
+	}
+}
+
+func resolvedAuth(apiURL string) *auth.ResolvedAuth {
+	return &auth.ResolvedAuth{
+		AuthType: auth.AuthTypePAT, APIUrl: apiURL,
+		AccountID: "acct", OrgID: "org", ProjectID: "proj", PATToken: "test-token",
+	}
+}
+
+func testCtx(flags map[string]any) *cmdctx.Ctx {
+	return &cmdctx.Ctx{
+		FlagValues: flags,
+		Auth:       &auth.ResolvedAuth{AccountID: "acct", OrgID: "org", ProjectID: "proj"},
+		Context:    context.Background(),
+	}
+}
+
+// newAgentCtx wires a spy resolver and resolved auth pointing at srvURL.
+func newAgentCtx(flags map[string]any, srvURL string) *cmdctx.Ctx {
+	ctx := testCtx(flags)
+	ctx.Id = "my-agent"
+	ctx.Auth = resolvedAuth(srvURL)
+	ctx.Resolver = spyResolver{getSpec: func(_, _ string) *spec.CommandSpec {
+		return agentGetSpec("/gitops/api/v1/agents/my-agent")
+	}}
+	return ctx
+}
+
+func jsonOf(v any) []byte { b, _ := json.Marshal(v); return b }
+
+// agentBody is a reusable agent GET response with a namespace.
+var agentBody = jsonOf(map[string]any{"metadata": map[string]any{"namespace": "ns"}})
+
+// ---------------------------------------------------------------------------
+// validation — no HTTP needed
+// ---------------------------------------------------------------------------
+
+func TestExecuteAgentInstall_validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		flags      map[string]any
+		resolver   cmdctx.Resolver
+		wantErrSub string
+		wantNoSub  string
+	}{
+		{name: "missing agent id", wantErrSub: "requires a positional"},
+		{name: "invalid method docker", id: "my-agent", flags: map[string]any{"method": "docker"}, wantErrSub: `must be "helm" or "yaml"`},
+		{name: "invalid method kubectl", id: "my-agent", flags: map[string]any{"method": "kubectl"}, wantErrSub: `must be "helm" or "yaml"`},
+		{name: "default method ok", id: "my-agent", wantNoSub: "invalid --method"},
+		{name: "helm method ok", id: "my-agent", flags: map[string]any{"method": "helm"}, wantNoSub: "invalid --method"},
+		{name: "yaml method ok", id: "my-agent", flags: map[string]any{"method": "yaml"}, wantNoSub: "invalid --method"},
+		{name: "spec not found", id: "my-agent", wantErrSub: "spec not found"},
+		{
+			name:       "spec endpoint nil",
+			id:         "my-agent",
+			resolver:   spyResolver{getSpec: func(_, _ string) *spec.CommandSpec { return &spec.CommandSpec{} }},
+			wantErrSub: "spec not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx(tc.flags)
+			ctx.Id = tc.id
+			if tc.resolver != nil {
+				ctx.Resolver = tc.resolver
+			} else {
+				ctx.Resolver = noopResolver{}
+			}
+			err := executeAgentInstall(ctx)
+			if tc.wantErrSub != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error = %v, want %q", err, tc.wantErrSub)
+				}
+			}
+			if tc.wantNoSub != "" && err != nil && strings.Contains(err.Error(), tc.wantNoSub) {
+				t.Fatalf("error %q must not contain %q", err, tc.wantNoSub)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP GET path — tests that fail before or without reaching the POST call
+// ---------------------------------------------------------------------------
+
+func TestExecuteAgentInstall_GETPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		getStatus  int    // defaults to 200
+		getBody    []byte // defaults to agentBody
+		setup      func(dir string) map[string]any
+		wantErrSub string
+	}{
+		{
+			name:       "CallEndpoint error on 500",
+			getStatus:  500,
+			wantErrSub: "fetching agent",
+		},
+		{
+			name:       "namespace from agent metadata",
+			getBody:    jsonOf(map[string]any{"metadata": map[string]any{"namespace": "harness"}}),
+			wantErrSub: "output file is required",
+		},
+		{
+			name:    "namespace from install file",
+			getBody: jsonOf(map[string]any{"metadata": map[string]any{}}),
+			setup: func(dir string) map[string]any {
+				f := filepath.Join(dir, "install.yaml")
+				os.WriteFile(f, []byte("namespace: my-ns\n"), 0o600)
+				return map[string]any{"file": f}
+			},
+			wantErrSub: "output file is required",
+		},
+		{
+			name:    "bad YAML in install file",
+			getBody: agentBody,
+			setup: func(dir string) map[string]any {
+				f := filepath.Join(dir, "bad.yaml")
+				os.WriteFile(f, []byte(":\n  - [\n"), 0o600)
+				return map[string]any{"file": f}
+			},
+			wantErrSub: "parsing -f install file",
+		},
+		{
+			name:       "no namespace anywhere",
+			getBody:    jsonOf(map[string]any{}),
+			wantErrSub: "namespace is required",
+		},
+		{
+			name:       "bad output file extension",
+			setup:      func(dir string) map[string]any { return map[string]any{"output_file": "out.json"} },
+			wantErrSub: "output file must end with .yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := tc.getStatus
+			if status == 0 {
+				status = 200
+			}
+			body := tc.getBody
+			if body == nil {
+				body = agentBody
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				w.Write(body)
+			}))
+			defer srv.Close()
+
+			dir := t.TempDir()
+			var flags map[string]any
+			if tc.setup != nil {
+				flags = tc.setup(dir)
+			}
+			err := executeAgentInstall(newAgentCtx(flags, srv.URL))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("error = %v, want %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// full end-to-end: GET agent → POST helm-overrides → write file
+// ---------------------------------------------------------------------------
+
+func TestExecuteAgentInstall_fullPath(t *testing.T) {
+	stdPost := jsonOf(map[string]any{"value": "data\n"})
+
+	tests := []struct {
+		name       string
+		postStatus int    // defaults to 200
+		postBody   []byte // defaults to stdPost
+		level      string
+		setup      func(dir string) map[string]any
+		wantErrSub string
+		wantFile   string
+	}{
+		{
+			name:     "helm happy path writes JSON-wrapped value",
+			postBody: jsonOf(map[string]any{"value": "helm: override\n"}),
+			setup:    func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml")} },
+			wantFile: "helm: override\n",
+		},
+		{
+			name: "yaml method writes raw body",
+			setup: func(dir string) map[string]any {
+				return map[string]any{"output_file": filepath.Join(dir, "out.yaml"), "method": "yaml"}
+			},
+			wantFile: "data\n",
+		},
+		{
+			name:       "POST 403 returns API error",
+			postStatus: 403,
+			postBody:   []byte(`{"message":"forbidden"}`),
+			setup:      func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml")} },
+			wantErrSub: "API error",
+		},
+		{
+			name: "optional install fields accepted",
+			setup: func(dir string) map[string]any {
+				f := filepath.Join(dir, "install.yaml")
+				os.WriteFile(f, []byte("namespace: custom-ns\nskipCrds: true\ncaData: ca\nprivateKey: pk\nproxy:\n  http: p\nargocdSettings:\n  k: v\n"), 0o600)
+				return map[string]any{"file": f, "output_file": filepath.Join(dir, "out.yaml")}
+			},
+		},
+		{
+			name:  "org level strips project",
+			level: "org",
+			setup: func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml")} },
+		},
+		{
+			name:  "account level strips org and project",
+			level: "account",
+			setup: func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml")} },
+		},
+		{
+			name:  ".yaml.txt extension accepted",
+			setup: func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml.txt")} },
+		},
+		{
+			name:       "write error on bad path",
+			setup:      func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "nodir", "out.yaml")} },
+			wantErrSub: "writing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			postStatus := tc.postStatus
+			if postStatus == 0 {
+				postStatus = 200
+			}
+			postBody := tc.postBody
+			if postBody == nil {
+				postBody = stdPost
+			}
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" {
+					w.Write(agentBody)
+				} else {
+					w.WriteHeader(postStatus)
+					w.Write(postBody)
+				}
+			}))
+			defer srv.Close()
+
+			dir := t.TempDir()
+			var flags map[string]any
+			if tc.setup != nil {
+				flags = tc.setup(dir)
+			}
+			ctx := newAgentCtx(flags, srv.URL)
+			ctx.Level = tc.level
+
+			err := executeAgentInstall(ctx)
+			if tc.wantErrSub != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error = %v, want %q", err, tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantFile != "" {
+				outFile := flags["output_file"].(string)
+				written, _ := os.ReadFile(outFile)
+				if string(written) != tc.wantFile {
+					t.Fatalf("file content = %q, want %q", written, tc.wantFile)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ModuleInit
+// ---------------------------------------------------------------------------
+
+func TestModuleInit_RegistersWorkflow(t *testing.T) {
+	registered := map[string]bool{}
+	spy := &moduleInitSpy{register: func(id string) { registered[id] = true }}
+	ModuleInit(spy)
+	if !registered[installWorkflowID] {
+		t.Fatalf("ModuleInit did not register workflow %q", installWorkflowID)
+	}
+}
+
+type moduleInitSpy struct{ register func(id string) }
+
+func (s *moduleInitSpy) Register(*spec.CommandSpec) error                                        { return nil }
+func (s *moduleInitSpy) RegisterWorkflow(id string, _ registry.WorkflowFn)                      { if s.register != nil { s.register(id) } }
+func (s *moduleInitSpy) RegisterTextFormatter(string, cmdctx.TextFormatterFn)                   {}
+func (s *moduleInitSpy) RegisterBodyFn(string, cmdctx.CreateBodyFn)                             {}
+func (s *moduleInitSpy) RegisterQueryParamsFn(string, cmdctx.QueryParamsFn)                     {}
+func (s *moduleInitSpy) RegisterFollowFn(string, cmdctx.FollowFn)                               {}
+func (s *moduleInitSpy) RegisterFetchFn(string, cmdctx.FetchFn)                                 {}
+func (s *moduleInitSpy) RegisterFlagCompletionFn(string, registry.FlagCompletionFn)             {}
+func (s *moduleInitSpy) RegisterFlagResolveFn(string, cmdctx.FlagResolveFn)                     {}
+func (s *moduleInitSpy) RegisterEndpointValidatorFn(string, cmdctx.EndpointValidatorFn)         {}

--- a/modules/gitops/gitops_test.go
+++ b/modules/gitops/gitops_test.go
@@ -25,23 +25,25 @@ import (
 
 type noopResolver struct{}
 
-func (noopResolver) ResolveTextFormatter(id string) cmdctx.TextFormatterFn                        { return nil }
-func (noopResolver) ResolveBodyFn(id string) cmdctx.CreateBodyFn                                  { return nil }
-func (noopResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn                          { return nil }
-func (noopResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn                          { return nil }
-func (noopResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)                             { return nil, nil }
-func (noopResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn                { return nil }
-func (noopResolver) GetSpec(verb, noun string) *spec.CommandSpec                                  { return nil }
-func (noopResolver) GetNoun(noun string) *spec.NounDef                                            { return nil }
-func (noopResolver) ResolveNounAlias(alias string) string                                         { return "" }
-func (noopResolver) RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error)              { return nil, nil }
-func (noopResolver) FormatList(*cmdctx.Ctx, []any, []spec.FieldDef, []string) error               { return nil }
-func (noopResolver) FetchItems(*cmdctx.Ctx, *spec.EndpointSpec, cmdctx.PagingFlags) ([]any, error) { return nil, nil }
-func (noopResolver) GetModuleMetas() []spec.ModuleMeta                                            { return nil }
-func (noopResolver) GetSpecsForModule(string) []*spec.CommandSpec                                 { return nil }
-func (noopResolver) GetAllSpecs() []*spec.CommandSpec                                             { return nil }
-func (noopResolver) GetVerbInfos() []spec.VerbInfo                                                { return nil }
-func (noopResolver) ResolveCommandFields(*spec.CommandSpec) []spec.FieldDef                       { return nil }
+func (noopResolver) ResolveTextFormatter(id string) cmdctx.TextFormatterFn           { return nil }
+func (noopResolver) ResolveBodyFn(id string) cmdctx.CreateBodyFn                     { return nil }
+func (noopResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn             { return nil }
+func (noopResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn             { return nil }
+func (noopResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)                { return nil, nil }
+func (noopResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn   { return nil }
+func (noopResolver) GetSpec(verb, noun string) *spec.CommandSpec                     { return nil }
+func (noopResolver) GetNoun(noun string) *spec.NounDef                               { return nil }
+func (noopResolver) ResolveNounAlias(alias string) string                            { return "" }
+func (noopResolver) RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error) { return nil, nil }
+func (noopResolver) FormatList(*cmdctx.Ctx, []any, []spec.FieldDef, []string) error  { return nil }
+func (noopResolver) FetchItems(*cmdctx.Ctx, *spec.EndpointSpec, cmdctx.PagingFlags) ([]any, error) {
+	return nil, nil
+}
+func (noopResolver) GetModuleMetas() []spec.ModuleMeta                      { return nil }
+func (noopResolver) GetSpecsForModule(string) []*spec.CommandSpec           { return nil }
+func (noopResolver) GetAllSpecs() []*spec.CommandSpec                       { return nil }
+func (noopResolver) GetVerbInfos() []spec.VerbInfo                          { return nil }
+func (noopResolver) ResolveCommandFields(*spec.CommandSpec) []spec.FieldDef { return nil }
 
 type spyResolver struct {
 	noopResolver
@@ -283,12 +285,16 @@ func TestExecuteAgentInstall_fullPath(t *testing.T) {
 			setup: func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml")} },
 		},
 		{
-			name:  ".yaml.txt extension accepted",
-			setup: func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "out.yaml.txt")} },
+			name: ".yaml.txt extension accepted",
+			setup: func(dir string) map[string]any {
+				return map[string]any{"output_file": filepath.Join(dir, "out.yaml.txt")}
+			},
 		},
 		{
-			name:       "write error on bad path",
-			setup:      func(dir string) map[string]any { return map[string]any{"output_file": filepath.Join(dir, "nodir", "out.yaml")} },
+			name: "write error on bad path",
+			setup: func(dir string) map[string]any {
+				return map[string]any{"output_file": filepath.Join(dir, "nodir", "out.yaml")}
+			},
 			wantErrSub: "writing",
 		},
 	}
@@ -359,13 +365,17 @@ func TestModuleInit_RegistersWorkflow(t *testing.T) {
 
 type moduleInitSpy struct{ register func(id string) }
 
-func (s *moduleInitSpy) Register(*spec.CommandSpec) error                                        { return nil }
-func (s *moduleInitSpy) RegisterWorkflow(id string, _ registry.WorkflowFn)                      { if s.register != nil { s.register(id) } }
-func (s *moduleInitSpy) RegisterTextFormatter(string, cmdctx.TextFormatterFn)                   {}
-func (s *moduleInitSpy) RegisterBodyFn(string, cmdctx.CreateBodyFn)                             {}
-func (s *moduleInitSpy) RegisterQueryParamsFn(string, cmdctx.QueryParamsFn)                     {}
-func (s *moduleInitSpy) RegisterFollowFn(string, cmdctx.FollowFn)                               {}
-func (s *moduleInitSpy) RegisterFetchFn(string, cmdctx.FetchFn)                                 {}
-func (s *moduleInitSpy) RegisterFlagCompletionFn(string, registry.FlagCompletionFn)             {}
-func (s *moduleInitSpy) RegisterFlagResolveFn(string, cmdctx.FlagResolveFn)                     {}
-func (s *moduleInitSpy) RegisterEndpointValidatorFn(string, cmdctx.EndpointValidatorFn)         {}
+func (s *moduleInitSpy) Register(*spec.CommandSpec) error { return nil }
+func (s *moduleInitSpy) RegisterWorkflow(id string, _ registry.WorkflowFn) {
+	if s.register != nil {
+		s.register(id)
+	}
+}
+func (s *moduleInitSpy) RegisterTextFormatter(string, cmdctx.TextFormatterFn)           {}
+func (s *moduleInitSpy) RegisterBodyFn(string, cmdctx.CreateBodyFn)                     {}
+func (s *moduleInitSpy) RegisterQueryParamsFn(string, cmdctx.QueryParamsFn)             {}
+func (s *moduleInitSpy) RegisterFollowFn(string, cmdctx.FollowFn)                       {}
+func (s *moduleInitSpy) RegisterFetchFn(string, cmdctx.FetchFn)                         {}
+func (s *moduleInitSpy) RegisterFlagCompletionFn(string, registry.FlagCompletionFn)     {}
+func (s *moduleInitSpy) RegisterFlagResolveFn(string, cmdctx.FlagResolveFn)             {}
+func (s *moduleInitSpy) RegisterEndpointValidatorFn(string, cmdctx.EndpointValidatorFn) {}

--- a/modules/pipeline/execution_log_test.go
+++ b/modules/pipeline/execution_log_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
+
 	"github.com/harness/cli/pkg/auth"
 	"github.com/harness/cli/pkg/cmdctx"
-	"github.com/spf13/pflag"
 )
 
 func testCtx(flags map[string]any) *cmdctx.Ctx {

--- a/modules/pipeline/execution_log_test.go
+++ b/modules/pipeline/execution_log_test.go
@@ -1,0 +1,105 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pipeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/auth"
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/spf13/pflag"
+)
+
+func testCtx(flags map[string]any) *cmdctx.Ctx {
+	return &cmdctx.Ctx{
+		FlagValues: flags,
+		Auth:       &auth.ResolvedAuth{AccountID: "acct", OrgID: "org", ProjectID: "proj"},
+	}
+}
+
+func TestGetPipelineLogHandler_validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		flags      map[string]any
+		wantErrSub string
+	}{
+		{
+			name:       "missing exec id",
+			flags:      nil,
+			wantErrSub: "missing required argument",
+		},
+		{
+			name:       "unparseable exec id",
+			id:         "/",
+			flags:      nil,
+			wantErrSub: "could not parse execId",
+		},
+		{
+			name:       "step without stage",
+			id:         "abc123",
+			flags:      map[string]any{"step": "Build"},
+			wantErrSub: "--step requires --stage",
+		},
+		{
+			// --ui in a non-TTY environment (always the case in tests) returns
+			// "requires an interactive terminal" — not a "not compatible" error.
+			// This covers the ui+non-TTY branch of getPipelineLogHandler.
+			name:       "ui flag requires TTY",
+			id:         "abc123",
+			flags:      map[string]any{"ui": true},
+			wantErrSub: "--ui requires an interactive terminal",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx(tc.flags)
+			ctx.Id = tc.id
+			err := getPipelineLogHandler(ctx)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestListExecutionLogsFetchFn_missingParentId(t *testing.T) {
+	ctx := testCtx(nil)
+	_, err := listExecutionLogsFetchFn(ctx, nil, 0, 0, nil)
+	if err == nil {
+		t.Fatal("expected error for missing parent id")
+	}
+	if !strings.Contains(err.Error(), "missing required argument") {
+		t.Fatalf("error = %q, want substring %q", err, "missing required argument")
+	}
+}
+
+func TestPipelineLogStageCompletion_emptyOnNoExecId(t *testing.T) {
+	ctx := testCtx(nil)
+	stages, err := pipelineLogStageCompletion(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stages) != 0 {
+		t.Fatalf("expected no stages, got %v", stages)
+	}
+}
+
+func TestPipelineLogStepCompletion_emptyWhenNoStage(t *testing.T) {
+	ctx := testCtx(nil)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("stage", "", "")
+	steps, err := pipelineLogStepCompletion(ctx, nil, fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(steps) != 0 {
+		t.Fatalf("expected no steps, got %v", steps)
+	}
+}

--- a/pkg/registry/buildctx_workflow_test.go
+++ b/pkg/registry/buildctx_workflow_test.go
@@ -1,0 +1,749 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/spec"
+)
+
+func buildWorkflowTestCmd(t *testing.T, r *Registry, cs *spec.CommandSpec) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "Command timeout in seconds")
+	return cmd
+}
+
+func registerWorkflowNoun(t *testing.T, r *Registry, noun string) {
+	t.Helper()
+	if err := r.RegisterNoun(spec.NounDef{Noun: noun, NounAliases: []string{noun + "s"}}); err != nil {
+		t.Fatalf("RegisterNoun %q: %v", noun, err)
+	}
+}
+
+func registerWorkflowExecute(t *testing.T, r *Registry, noun string, cs *spec.CommandSpec) string {
+	t.Helper()
+	registerWorkflowNoun(t, r, noun)
+	wfID := "test:" + noun
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs.Command = "execute " + noun
+	cs.Verb = VerbExecute
+	cs.VerbHandler = VerbExecute
+	cs.Noun = noun
+	cs.Module = "test"
+	cs.HandlerType = spec.HandlerWorkflow
+	cs.WorkflowID = wfID
+	cs.NoAuth = true
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register execute %s: %v", noun, err)
+	}
+	return wfID
+}
+
+func TestBuildCtx_WorkflowFormatFlags(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "fmtthing", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "fmtthing")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "json and yaml mutually exclusive",
+			args:    []string{"--json", "--yaml"},
+			wantErr: "--json and --yaml are mutually exclusive",
+		},
+		{
+			name:    "json and format mutually exclusive",
+			args:    []string{"--json", "--format", "table"},
+			wantErr: "--json/--yaml and --format are mutually exclusive",
+		},
+		{
+			name:    "yaml and format mutually exclusive",
+			args:    []string{"--yaml", "--format", "json"},
+			wantErr: "--json/--yaml and --format are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildWorkflowTestCmd(t, r, cs)
+			cmd.SetArgs(tt.args)
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			_, err := buildCtx(cmd, cs, nil, r)
+			if err == nil {
+				t.Fatal("buildCtx() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("buildCtx() error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+
+	t.Run("fields and json mutually exclusive", func(t *testing.T) {
+		cmd := buildWorkflowTestCmd(t, r, cs)
+		addFlag(cmd.Flags(), specFields)
+		flagArgs := []string{"--fields", "name", "--json"}
+		if err := cmd.ParseFlags(flagArgs); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		_, err := buildCtx(cmd, cs, nil, r)
+		if err == nil {
+			t.Fatal("buildCtx() = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "--fields and --json/--yaml are mutually exclusive") {
+			t.Fatalf("buildCtx() error %q missing expected substring", err)
+		}
+	})
+
+}
+
+func TestBuildCtx_WorkflowTimeout(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "timeoutthing", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "timeoutthing")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--timeout", "-1"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := buildCtx(cmd, cs, []string{"id"}, r)
+	if err == nil {
+		t.Fatal("buildCtx() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "--timeout must be >= 0") {
+		t.Fatalf("buildCtx() error %q missing expected substring", err)
+	}
+}
+
+func TestBuildCtx_WorkflowMissingRequiredID(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "missingid", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "missingid")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	_, err := buildCtx(cmd, cs, nil, r)
+	if err == nil {
+		t.Fatal("buildCtx() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "requires a positional") {
+		t.Fatalf("buildCtx() error %q missing expected substring", err)
+	}
+}
+
+func TestBuildCtx_WorkflowRequiredFlag(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "reqflag", &spec.CommandSpec{
+		Flags: []spec.Flag{
+			{Name: "method", Required: true, Description: "install method"},
+		},
+	})
+	cs := r.GetSpec(VerbExecute, "reqflag")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err == nil {
+		t.Fatal("buildCtx() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "flag --method is required") {
+		t.Fatalf("buildCtx() error %q missing expected substring", err)
+	}
+}
+
+func TestBuildCtx_WorkflowIdPartsTooMany(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "cluster", &spec.CommandSpec{
+		IdParts: 2,
+		IdLabel: "<agent/cluster_id>",
+	})
+	cs := r.GetSpec(VerbExecute, "cluster")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	_, err := buildCtx(cmd, cs, []string{"agent/cluster/extra"}, r)
+	if err == nil {
+		t.Fatal("buildCtx() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "exactly 2 parts") {
+		t.Fatalf("buildCtx() error %q missing expected substring", err)
+	}
+}
+
+func TestBuildCtx_WorkflowIdSlashNotAllowed(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "noslash", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "noslash")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	_, err := buildCtx(cmd, cs, []string{"foo/bar"}, r)
+	if err == nil {
+		t.Fatal("buildCtx() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "must not contain '/'") {
+		t.Fatalf("buildCtx() error %q missing expected substring", err)
+	}
+}
+
+func TestBuildCtx_WorkflowIdSlashAllowed(t *testing.T) {
+	// IdAllowSlash=true: slashes in id are permitted, validateIdParts returns nil.
+	r := New()
+	registerWorkflowExecute(t, r, "slashok", &spec.CommandSpec{IdAllowSlash: true})
+	cs := r.GetSpec(VerbExecute, "slashok")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	ctx, err := buildCtx(cmd, cs, []string{"foo/bar/baz"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Id != "foo/bar/baz" {
+		t.Fatalf("ctx.Id = %q, want %q", ctx.Id, "foo/bar/baz")
+	}
+}
+
+func TestBuildCtx_WorkflowFieldsAndFormatMutuallyExclusive(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "fmtfields2", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "fmtfields2")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	addFlag(cmd.Flags(), specFields)
+	if err := cmd.ParseFlags([]string{"--fields", "name", "--format", "table"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := buildCtx(cmd, cs, nil, r)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--fields and --format are mutually exclusive") {
+		t.Fatalf("error = %q, want substring", err)
+	}
+}
+
+func TestBuildCtx_WorkflowYamlSetsFormat(t *testing.T) {
+	// --yaml with no conflicting flags should succeed and set FormatFlags.Format="yaml".
+	r := New()
+	registerWorkflowExecute(t, r, "yamlfmt", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "yamlfmt")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--yaml"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	ctx, err := buildCtx(cmd, cs, []string{"myid"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.FormatFlags.Format != "yaml" {
+		t.Fatalf("FormatFlags.Format = %q, want %q", ctx.FormatFlags.Format, "yaml")
+	}
+}
+
+func TestBuildCtx_WorkflowJsonSetsFormat(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "jsonfmt", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "jsonfmt")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--json"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	ctx, err := buildCtx(cmd, cs, []string{"myid"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.FormatFlags.Format != "json" {
+		t.Fatalf("FormatFlags.Format = %q, want %q", ctx.FormatFlags.Format, "json")
+	}
+}
+
+func TestBuildCtx_WorkflowRequiredFlagWithCompletionValues(t *testing.T) {
+	// Required flag with CompletionValues produces "(val1, val2)" hint in the error.
+	r := New()
+	registerWorkflowExecute(t, r, "reqcomp", &spec.CommandSpec{
+		Flags: []spec.Flag{
+			{Name: "env", Required: true, Description: "target env", CompletionValues: []string{"dev", "prod"}},
+		},
+	})
+	cs := r.GetSpec(VerbExecute, "reqcomp")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "dev") || !strings.Contains(err.Error(), "prod") {
+		t.Fatalf("error = %q, want completion values in message", err)
+	}
+}
+
+// ---- List verb: AllowsParentId ----
+
+// registerWorkflowList registers a list-verb workflow spec for the given noun.
+func registerWorkflowList(t *testing.T, r *Registry, noun string, cs *spec.CommandSpec) {
+	t.Helper()
+	registerWorkflowNoun(t, r, noun)
+	wfID := "test:list:" + noun
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs.Command = "list " + noun
+	cs.Verb = VerbList
+	cs.VerbHandler = VerbList
+	cs.Noun = noun
+	cs.Module = "test"
+	cs.HandlerType = spec.HandlerWorkflow
+	cs.WorkflowID = wfID
+	cs.NoAuth = true
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register list %s: %v", noun, err)
+	}
+}
+
+func TestBuildCtx_ListAllowsParentId(t *testing.T) {
+	// VerbList has AllowsParentId=true. An optional parent arg sets ctx.ParentId.
+	r := New()
+	registerWorkflowList(t, r, "listable", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbList, "listable")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	ctx, err := buildCtx(cmd, cs, []string{"parent-123"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.ParentId != "parent-123" {
+		t.Fatalf("ctx.ParentId = %q, want %q", ctx.ParentId, "parent-123")
+	}
+}
+
+func TestBuildCtx_ListNoParentIdOK(t *testing.T) {
+	// VerbList with no args and no RequiresParentId should succeed with empty ParentId.
+	r := New()
+	registerWorkflowList(t, r, "listnoparent", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbList, "listnoparent")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	ctx, err := buildCtx(cmd, cs, nil, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.ParentId != "" {
+		t.Fatalf("ctx.ParentId = %q, want empty", ctx.ParentId)
+	}
+}
+
+func TestBuildCtx_ListRequiresParentId(t *testing.T) {
+	// RequiresParentId=true with no args must error.
+	r := New()
+	registerWorkflowList(t, r, "listrequired", &spec.CommandSpec{
+		RequiresParentId: true,
+		ParentIdLabel:    "pipeline-id",
+	})
+	cs := r.GetSpec(VerbList, "listrequired")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	_, err := buildCtx(cmd, cs, nil, r)
+	if err == nil {
+		t.Fatal("expected error for missing required parent id")
+	}
+	if !strings.Contains(err.Error(), "requires a positional") {
+		t.Fatalf("error = %q, want %q", err, "requires a positional")
+	}
+}
+
+func TestBuildCtx_ListTooManyArgs(t *testing.T) {
+	// VerbGet/VerbList reject more than 1 positional arg.
+	r := New()
+	registerWorkflowList(t, r, "listargs", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbList, "listargs")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	_, err := buildCtx(cmd, cs, []string{"p1", "p2"}, r)
+	if err == nil {
+		t.Fatal("expected error for extra argument")
+	}
+	if !strings.Contains(err.Error(), "unexpected argument") {
+		t.Fatalf("error = %q, want %q", err, "unexpected argument")
+	}
+}
+
+// ---- Create verb: AllowsId ----
+
+func registerWorkflowCreate(t *testing.T, r *Registry, noun string, cs *spec.CommandSpec) {
+	t.Helper()
+	registerWorkflowNoun(t, r, noun)
+	wfID := "test:create:" + noun
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs.Command = "create " + noun
+	cs.Verb = VerbCreate
+	cs.VerbHandler = VerbCreate
+	cs.Noun = noun
+	cs.Module = "test"
+	cs.HandlerType = spec.HandlerWorkflow
+	cs.WorkflowID = wfID
+	cs.NoAuth = true
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register create %s: %v", noun, err)
+	}
+}
+
+func TestBuildCtx_CreateAllowsIdOptional(t *testing.T) {
+	// VerbCreate AllowsId=true; omitting the id is fine.
+	r := New()
+	registerWorkflowCreate(t, r, "created", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbCreate, "created")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	ctx, err := buildCtx(cmd, cs, nil, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Id != "" {
+		t.Fatalf("ctx.Id = %q, want empty", ctx.Id)
+	}
+}
+
+func TestBuildCtx_CreateRequiresIdError(t *testing.T) {
+	// VerbCreate + RequiresId=true: omitting id should error.
+	r := New()
+	registerWorkflowCreate(t, r, "reqcreate", &spec.CommandSpec{RequiresId: true})
+	cs := r.GetSpec(VerbCreate, "reqcreate")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	_, err := buildCtx(cmd, cs, nil, r)
+	if err == nil {
+		t.Fatal("expected error for missing required id")
+	}
+	if !strings.Contains(err.Error(), "requires a positional") {
+		t.Fatalf("error = %q, want %q", err, "requires a positional")
+	}
+}
+
+// ---- BuiltinFlags.Set and .Del ----
+
+func TestBuildCtx_SetArgs(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "setargs", &spec.CommandSpec{
+		BuiltinFlags: spec.BuiltinFlags{Set: true},
+	})
+	cs := r.GetSpec(VerbExecute, "setargs")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--set", "key=value", "--set", "other=val2"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	ctx, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.SetArgs["key"] != "value" || ctx.SetArgs["other"] != "val2" {
+		t.Fatalf("SetArgs = %v, unexpected", ctx.SetArgs)
+	}
+}
+
+func TestBuildCtx_SetArgsBadFormat(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "setbad", &spec.CommandSpec{
+		BuiltinFlags: spec.BuiltinFlags{Set: true},
+	})
+	cs := r.GetSpec(VerbExecute, "setbad")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--set", "noequals"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err == nil {
+		t.Fatal("expected error for bad key=value")
+	}
+	if !strings.Contains(err.Error(), "key=value") {
+		t.Fatalf("error = %q, want key=value format hint", err)
+	}
+}
+
+func TestBuildCtx_DelArgs(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "delargs", &spec.CommandSpec{
+		BuiltinFlags: spec.BuiltinFlags{Del: true},
+	})
+	cs := r.GetSpec(VerbExecute, "delargs")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--del", "field1", "--del", "field2"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	ctx, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ctx.DelArgs) != 2 || ctx.DelArgs[0] != "field1" {
+		t.Fatalf("DelArgs = %v, unexpected", ctx.DelArgs)
+	}
+}
+
+// ---- HasArgs ----
+
+func TestBuildCtx_HasArgs(t *testing.T) {
+	// HasArgs=true: extra positional args beyond the id go into ctx.Args.
+	r := New()
+	registerWorkflowExecute(t, r, "hasargs", &spec.CommandSpec{HasArgs: true})
+	cs := r.GetSpec(VerbExecute, "hasargs")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	ctx, err := buildCtx(cmd, cs, []string{"my-id", "extra1", "extra2"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ctx.Args) != 2 || ctx.Args[0] != "extra1" {
+		t.Fatalf("ctx.Args = %v, want [extra1 extra2]", ctx.Args)
+	}
+}
+
+// ---- MultiLevel + --level flag ----
+
+func TestBuildCtx_MultiLevel_LevelFlagValid(t *testing.T) {
+	r := New()
+	if err := r.RegisterNoun(spec.NounDef{Noun: "mlres", MultiLevel: true}); err != nil {
+		t.Fatalf("RegisterNoun: %v", err)
+	}
+	wfID := "test:execute:mlres"
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs := &spec.CommandSpec{
+		Command: "execute mlres", Verb: VerbExecute, VerbHandler: VerbExecute,
+		Noun: "mlres", Module: "test", HandlerType: spec.HandlerWorkflow,
+		WorkflowID: wfID, NoAuth: true,
+	}
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	cs = r.GetSpec(VerbExecute, "mlres")
+
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+	if err := cmd.ParseFlags([]string{"--level", "org"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	ctx, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Level != "org" {
+		t.Fatalf("ctx.Level = %q, want %q", ctx.Level, "org")
+	}
+}
+
+func TestBuildCtx_MultiLevel_LevelFlagInvalid(t *testing.T) {
+	r := New()
+	if err := r.RegisterNoun(spec.NounDef{Noun: "mlres2", MultiLevel: true}); err != nil {
+		t.Fatalf("RegisterNoun: %v", err)
+	}
+	wfID := "test:execute:mlres2"
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs := &spec.CommandSpec{
+		Command: "execute mlres2", Verb: VerbExecute, VerbHandler: VerbExecute,
+		Noun: "mlres2", Module: "test", HandlerType: spec.HandlerWorkflow,
+		WorkflowID: wfID, NoAuth: true,
+	}
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	cs = r.GetSpec(VerbExecute, "mlres2")
+
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+	if err := cmd.ParseFlags([]string{"--level", "galaxy"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err == nil {
+		t.Fatal("expected error for invalid --level")
+	}
+	if !strings.Contains(err.Error(), "invalid --level") {
+		t.Fatalf("error = %q, want invalid --level", err)
+	}
+}
+
+func TestBuildCtx_MultiLevel_PrefixConflictsWithLevelFlag(t *testing.T) {
+	// id with "org." prefix + --level account should conflict.
+	r := New()
+	if err := r.RegisterNoun(spec.NounDef{Noun: "mlres3", MultiLevel: true}); err != nil {
+		t.Fatalf("RegisterNoun: %v", err)
+	}
+	wfID := "test:execute:mlres3"
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs := &spec.CommandSpec{
+		Command: "execute mlres3", Verb: VerbExecute, VerbHandler: VerbExecute,
+		Noun: "mlres3", Module: "test", HandlerType: spec.HandlerWorkflow,
+		WorkflowID: wfID, NoAuth: true,
+	}
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	cs = r.GetSpec(VerbExecute, "mlres3")
+
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+	if err := cmd.ParseFlags([]string{"--level", "account"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	// "org.myid" sets level=org from prefix; --level=account conflicts.
+	_, err := buildCtx(cmd, cs, []string{"org.myid"}, r)
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "conflicts with") {
+		t.Fatalf("error = %q, want conflicts with", err)
+	}
+}
+
+// ---- resolveFlagValues ----
+
+func TestBuildCtx_ResolveFlagValues_FnNotRegistered(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "resolvefn", &spec.CommandSpec{
+		Flags: []spec.Flag{
+			{Name: "myarg", FlagResolveFn: "unregistered_fn", Description: "test"},
+		},
+	})
+	cs := r.GetSpec(VerbExecute, "resolvefn")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--myarg", "somevalue"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err == nil {
+		t.Fatal("expected error for unregistered flag_resolve_fn")
+	}
+	if !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("error = %q, want 'not registered'", err)
+	}
+}
+
+func TestBuildCtx_ResolveFlagValues_FnReturnsError(t *testing.T) {
+	r := New()
+	r.RegisterFlagResolveFn("fail_fn", func(_ *cmdctx.Ctx, raw string) (string, error) {
+		return "", fmt.Errorf("resolve failed: %s", raw)
+	})
+	registerWorkflowExecute(t, r, "resolveerr", &spec.CommandSpec{
+		Flags: []spec.Flag{
+			{Name: "myarg", FlagResolveFn: "fail_fn", Description: "test"},
+		},
+	})
+	cs := r.GetSpec(VerbExecute, "resolveerr")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--myarg", "somevalue"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err == nil {
+		t.Fatal("expected error from flag resolve fn")
+	}
+	if !strings.Contains(err.Error(), "resolve failed") {
+		t.Fatalf("error = %q, want 'resolve failed'", err)
+	}
+}
+
+func TestBuildCtx_ResolveFlagValues_FnTransforms(t *testing.T) {
+	r := New()
+	r.RegisterFlagResolveFn("upper_fn", func(_ *cmdctx.Ctx, raw string) (string, error) {
+		return strings.ToUpper(raw), nil
+	})
+	registerWorkflowExecute(t, r, "resolveok", &spec.CommandSpec{
+		Flags: []spec.Flag{
+			{Name: "myarg", FlagResolveFn: "upper_fn", Description: "test"},
+		},
+	})
+	cs := r.GetSpec(VerbExecute, "resolveok")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	if err := cmd.ParseFlags([]string{"--myarg", "hello"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	ctx, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmdctx.GetString(ctx.FlagValues, "myarg") != "HELLO" {
+		t.Fatalf("FlagValues[myarg] = %q, want %q", cmdctx.GetString(ctx.FlagValues, "myarg"), "HELLO")
+	}
+}
+
+// ---- buildDetailCtx ----
+
+func TestBuildDetailCtx(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "detailnoun", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbExecute, "detailnoun")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	parent, err := buildCtx(cmd, cs, []string{"parent-id"}, r)
+	if err != nil {
+		t.Fatalf("setup buildCtx: %v", err)
+	}
+	parent.Level = "org"
+
+	detailCS := &spec.CommandSpec{
+		Verb: VerbGet, VerbHandler: VerbGet, Noun: "detailnoun",
+	}
+	detail := buildDetailCtx(parent, detailCS, "child-id")
+
+	if detail.Id != "child-id" {
+		t.Fatalf("detail.Id = %q, want %q", detail.Id, "child-id")
+	}
+	if detail.Level != "org" {
+		t.Fatalf("detail.Level = %q, want %q", detail.Level, "org")
+	}
+	if detail.Verb != VerbGet {
+		t.Fatalf("detail.Verb = %q, want %q", detail.Verb, VerbGet)
+	}
+	if detail.FormatFlags.Format != "text" {
+		t.Fatalf("detail.FormatFlags.Format = %q, want %q", detail.FormatFlags.Format, "text")
+	}
+	if detail.Context == nil {
+		t.Fatal("detail.Context is nil")
+	}
+}
+
+// ---- validateIdParts via AllowsParentId ----
+
+func TestValidateIdParts_ParentIdSlashNotAllowed(t *testing.T) {
+	r := New()
+	registerWorkflowList(t, r, "parentslash", &spec.CommandSpec{})
+	cs := r.GetSpec(VerbList, "parentslash")
+	cmd := &cobra.Command{Use: cs.Command}
+	r.bindWorkflowCmd(cmd, cs, func(*cmdctx.Ctx) error { return nil })
+	cmd.Flags().Float64("timeout", 0, "timeout")
+
+	_, err := buildCtx(cmd, cs, []string{"parent/bad"}, r)
+	if err == nil {
+		t.Fatal("expected error for slash in parent id")
+	}
+	if !strings.Contains(err.Error(), "must not contain '/'") {
+		t.Fatalf("error = %q, want must not contain '/'", err)
+	}
+}
+
+func TestValidateIdParts_IdPartsPopulated(t *testing.T) {
+	// IdParts=2 and exactly 2 slash-separated parts: IdParts slice should be populated.
+	r := New()
+	registerWorkflowExecute(t, r, "twoparts", &spec.CommandSpec{
+		IdParts: 2,
+		IdLabel: "<a/b>",
+	})
+	cs := r.GetSpec(VerbExecute, "twoparts")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	ctx, err := buildCtx(cmd, cs, []string{"agentA/clusterB"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ctx.IdParts) != 2 || ctx.IdParts[0] != "agentA" || ctx.IdParts[1] != "clusterB" {
+		t.Fatalf("ctx.IdParts = %v, want [agentA clusterB]", ctx.IdParts)
+	}
+}

--- a/pkg/registry/checks_workflow_test.go
+++ b/pkg/registry/checks_workflow_test.go
@@ -1,0 +1,602 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/spec"
+)
+
+// ---------------------------------------------------------------------------
+// checkFunctionsSpec — all fn-reference branches
+// ---------------------------------------------------------------------------
+
+func TestCheckFunctions_TextFormatterMissing(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "thing"})
+	r.specs[VerbGet] = append(r.specs[VerbGet], &spec.CommandSpec{
+		Command:     "get thing",
+		Verb:        VerbGet,
+		Noun:        "thing",
+		Module:      "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint: &spec.EndpointSpec{
+			Method:        "GET",
+			TextFormatter: "missing_formatter",
+			ItemExpr:      "it",
+		},
+	})
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error for missing text_formatter")
+	}
+	if !strings.Contains(err.Error(), "text_formatter") {
+		t.Fatalf("error = %q, want text_formatter mention", err)
+	}
+}
+
+func TestCheckFunctions_BodyFnMissing(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "thing2"})
+	r.specs[VerbCreate] = append(r.specs[VerbCreate], &spec.CommandSpec{
+		Command:     "create thing2",
+		Verb:        VerbCreate,
+		Noun:        "thing2",
+		Module:      "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint: &spec.EndpointSpec{
+			Method: "POST",
+			BodyFn: "missing_body_fn",
+		},
+	})
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error for missing body_fn")
+	}
+	if !strings.Contains(err.Error(), "body_fn") {
+		t.Fatalf("error = %q, want body_fn mention", err)
+	}
+}
+
+func TestCheckFunctions_QueryParamsFnMissing(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "thing3"})
+	r.specs[VerbList] = append(r.specs[VerbList], &spec.CommandSpec{
+		Command:     "list thing3",
+		Verb:        VerbList,
+		Noun:        "thing3",
+		Module:      "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint: &spec.EndpointSpec{
+			Method:        "GET",
+			ItemsExpr:     "it",
+			QueryParamsFn: "missing_qp_fn",
+		},
+	})
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error for missing query_params_fn")
+	}
+	if !strings.Contains(err.Error(), "query_params_fn") {
+		t.Fatalf("error = %q, want query_params_fn mention", err)
+	}
+}
+
+func TestCheckFunctions_FollowFnMissing(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "thing4"})
+	r.specs[VerbExecute] = append(r.specs[VerbExecute], &spec.CommandSpec{
+		Command:     "execute thing4",
+		Verb:        VerbExecute,
+		Noun:        "thing4",
+		Module:      "test",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  "test:noop_follow",
+		FollowFn:    "missing_follow_fn",
+	})
+	r.RegisterWorkflow("test:noop_follow", func(*cmdctx.Ctx) error { return nil })
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error for missing follow_fn")
+	}
+	if !strings.Contains(err.Error(), "follow_fn") {
+		t.Fatalf("error = %q, want follow_fn mention", err)
+	}
+}
+
+func TestCheckFunctions_FlagCompletionFnMissing(t *testing.T) {
+	r := New()
+	wfID := "test:noop_completion"
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	r.specs[VerbExecute] = append(r.specs[VerbExecute], &spec.CommandSpec{
+		Command:     "execute thing5",
+		Verb:        VerbExecute,
+		Noun:        "thing5",
+		Module:      "test",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  wfID,
+		Flags: []spec.Flag{
+			{Name: "env", CompletionFn: "missing_completion_fn"},
+		},
+	})
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error for missing completion_fn")
+	}
+	if !strings.Contains(err.Error(), "completion_fn") {
+		t.Fatalf("error = %q, want completion_fn mention", err)
+	}
+}
+
+func TestCheckFunctions_FlagResolveFnMissing(t *testing.T) {
+	r := New()
+	wfID := "test:noop_resolvefn"
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	r.specs[VerbExecute] = append(r.specs[VerbExecute], &spec.CommandSpec{
+		Command:     "execute thing6",
+		Verb:        VerbExecute,
+		Noun:        "thing6",
+		Module:      "test",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  wfID,
+		Flags: []spec.Flag{
+			{Name: "myarg", FlagResolveFn: "missing_resolve_fn"},
+		},
+	})
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error for missing flag_resolve_fn")
+	}
+	if !strings.Contains(err.Error(), "flag_resolve_fn") {
+		t.Fatalf("error = %q, want flag_resolve_fn mention", err)
+	}
+}
+
+func TestCheckFunctions_InitErrsIncluded(t *testing.T) {
+	r := New()
+	r.initErrs = append(r.initErrs, "synthetic init error")
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("expected error from initErrs")
+	}
+	if !strings.Contains(err.Error(), "synthetic init error") {
+		t.Fatalf("error = %q, want init error text", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CheckWarnings
+// ---------------------------------------------------------------------------
+
+func TestCheckWarnings_ListMissingPaging(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "nopaging"})
+	r.specs[VerbList] = append(r.specs[VerbList], &spec.CommandSpec{
+		Command:     "list nopaging",
+		Verb:        VerbList,
+		VerbHandler: VerbList,
+		Noun:        "nopaging",
+		Module:      "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "GET", ItemsExpr: "it"},
+	})
+	warns := r.CheckWarnings()
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "paging_strategy") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("CheckWarnings() = %v, want paging_strategy warning", warns)
+	}
+}
+
+func TestCheckWarnings_ListMissingGetIdExpr(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "nogetid"})
+	r.specs[VerbList] = append(r.specs[VerbList], &spec.CommandSpec{
+		Command:     "list nogetid",
+		Verb:        VerbList,
+		VerbHandler: VerbList,
+		Noun:        "nogetid",
+		Module:      "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint: &spec.EndpointSpec{
+			Method:    "GET",
+			ItemsExpr: "it",
+			Paging:    &spec.PagingSpec{PagingStrategy: spec.PagingStrategyFlatList},
+		},
+	})
+	warns := r.CheckWarnings()
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "get_id_expr") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("CheckWarnings() = %v, want get_id_expr warning", warns)
+	}
+}
+
+func TestCheckWarnings_ModuleMissingHelpText(t *testing.T) {
+	r := New()
+	r.SetModuleMeta(spec.ModuleMeta{Name: "mymod"}) // no HelpText
+	warns := r.CheckWarnings()
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "missing help_text") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("CheckWarnings() = %v, want missing help_text warning", warns)
+	}
+}
+
+func TestCheckWarnings_SkipsDevOnly(t *testing.T) {
+	r := New()
+	r.specs[VerbList] = append(r.specs[VerbList], &spec.CommandSpec{
+		Command:     "list devonly",
+		Verb:        VerbList,
+		VerbHandler: VerbList,
+		Noun:        "devonly",
+		Module:      "test",
+		HandlerType: spec.HandlerEndpoint,
+		DevOnly:     true,
+		Endpoint:    &spec.EndpointSpec{Method: "GET", ItemsExpr: "it"},
+	})
+	warns := r.CheckWarnings()
+	for _, w := range warns {
+		if strings.Contains(w, "devonly") {
+			t.Fatalf("CheckWarnings() should skip DevOnly, got: %v", w)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateSpec / validateVerbNounShape / validateConfirmMode / validateEndpointConstraints / validatePaging
+// ---------------------------------------------------------------------------
+
+func TestValidateSpec_CommandMismatch(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create wrong",
+		Verb:    VerbCreate,
+		Noun:    "pipeline",
+		Module:  "test",
+	}
+	vs := verbRegistry[VerbCreate]
+	if err := validateVerbNounShape(cs, vs); err == nil || !strings.Contains(err.Error(), "must equal") {
+		t.Fatalf("expected command-mismatch error, got: %v", err)
+	}
+}
+
+func TestValidateSpec_LeafVerbWithNoun(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "version extra", // command matches verb+noun so the shape check sees the noun
+		Verb:    VerbVersion,
+		Noun:    "extra",
+		Module:  "core",
+	}
+	vs := verbRegistry[VerbVersion]
+	if err := validateVerbNounShape(cs, vs); err == nil || !strings.Contains(err.Error(), "cannot have a noun") {
+		t.Fatalf("expected leaf-verb-with-noun error, got: %v", err)
+	}
+}
+
+func TestValidateSpec_CoreVerbNoNoun(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create",
+		Verb:    VerbCreate,
+		Noun:    "",
+		Module:  "test",
+	}
+	vs := verbRegistry[VerbCreate]
+	if err := validateVerbNounShape(cs, vs); err == nil || !strings.Contains(err.Error(), "requires a noun") {
+		t.Fatalf("expected core-verb-no-noun error, got: %v", err)
+	}
+}
+
+func TestValidateSpec_IdPartsOutOfRange(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create pipeline",
+		Verb:    VerbCreate,
+		Noun:    "pipeline",
+		Module:  "test",
+		IdParts: 5,
+	}
+	vs := verbRegistry[VerbCreate]
+	if err := validateVerbNounShape(cs, vs); err == nil || !strings.Contains(err.Error(), "id_parts") {
+		t.Fatalf("expected id_parts error, got: %v", err)
+	}
+}
+
+func TestValidateConfirmMode_InvalidValue(t *testing.T) {
+	cs := &spec.CommandSpec{Command: "delete pipeline", Verb: VerbDelete, Noun: "pipeline", Module: "test", ConfirmMode: "bad_mode"}
+	if err := validateConfirmMode(cs); err == nil || !strings.Contains(err.Error(), "invalid confirm_mode") {
+		t.Fatalf("expected invalid confirm_mode error, got: %v", err)
+	}
+}
+
+func TestValidateConfirmMode_OnListVerb(t *testing.T) {
+	cs := &spec.CommandSpec{Command: "list pipeline", Verb: VerbList, VerbHandler: VerbList, Noun: "pipeline", Module: "test", ConfirmMode: spec.ConfirmPrompt}
+	if err := validateConfirmMode(cs); err == nil || !strings.Contains(err.Error(), "not supported on list") {
+		t.Fatalf("expected confirm_mode-on-list error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_PagingOnNonList(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "get pipeline", Verb: VerbGet, VerbHandler: VerbGet, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint: &spec.EndpointSpec{
+			Method:   "GET",
+			ItemExpr: "it",
+			Paging:   &spec.PagingSpec{PagingStrategy: spec.PagingStrategyFlatList},
+		},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "only allowed on list") {
+		t.Fatalf("expected paging-on-non-list error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_ItemsExprOnNonList(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "get pipeline", Verb: VerbGet, VerbHandler: VerbGet, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "GET", ItemExpr: "it", ItemsExpr: "it.items"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "only allowed on list") {
+		t.Fatalf("expected items_expr-on-non-list error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_ListMissingItemsExpr(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "list pipeline", Verb: VerbList, VerbHandler: VerbList, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "GET"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "items_expr") {
+		t.Fatalf("expected missing items_expr error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_GetMissingItemExpr(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "get pipeline", Verb: VerbGet, VerbHandler: VerbGet, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "GET"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "item_expr") {
+		t.Fatalf("expected missing item_expr error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_BodyOnGETNotAllowed(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "get pipeline", Verb: VerbGet, VerbHandler: VerbGet, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "GET", ItemExpr: "it", BodyParams: map[string]string{"x": "it"}},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "not allowed on GET") {
+		t.Fatalf("expected body-on-GET error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_InvalidFileBody(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create pipeline", Verb: VerbCreate, VerbHandler: VerbCreate, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "POST", FileBody: "bad"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "invalid file_body") {
+		t.Fatalf("expected invalid file_body error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_InvalidContentType(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create pipeline", Verb: VerbCreate, VerbHandler: VerbCreate, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "POST", FileBody: spec.FileBodyOptional, ContentType: "text/plain"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "invalid content_type") {
+		t.Fatalf("expected invalid content_type error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_ContentTypeRequiresFileBody(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create pipeline", Verb: VerbCreate, VerbHandler: VerbCreate, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "POST", ContentType: "application/yaml"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "content_type requires file_body") {
+		t.Fatalf("expected content_type-requires-file_body error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_FileBodyContentTypeRequiresFileBody(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create pipeline", Verb: VerbCreate, VerbHandler: VerbCreate, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "POST", FileBodyContentType: "application/yaml"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "file_body_content_type requires file_body") {
+		t.Fatalf("expected file_body_content_type-requires-file_body error, got: %v", err)
+	}
+}
+
+func TestValidateEndpointConstraints_FileBodyWrapRequiresFileBody(t *testing.T) {
+	cs := &spec.CommandSpec{
+		Command: "create pipeline", Verb: VerbCreate, VerbHandler: VerbCreate, Noun: "pipeline", Module: "test",
+		HandlerType: spec.HandlerEndpoint,
+		Endpoint:    &spec.EndpointSpec{Method: "POST", FileBodyWrapAsString: "yaml_key"},
+	}
+	if err := validateEndpointConstraints(cs); err == nil || !strings.Contains(err.Error(), "file_body_wrap_as_string requires file_body") {
+		t.Fatalf("expected file_body_wrap error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validatePaging
+// ---------------------------------------------------------------------------
+
+func TestValidatePaging(t *testing.T) {
+	tests := []struct {
+		name       string
+		pg         *spec.PagingSpec
+		wantErrSub string
+	}{
+		{
+			name:       "unknown strategy",
+			pg:         &spec.PagingSpec{PagingStrategy: "banana"},
+			wantErrSub: "unknown paging model",
+		},
+		{
+			name: "flat_list passes with no extra fields",
+			pg:   &spec.PagingSpec{PagingStrategy: spec.PagingStrategyFlatList},
+		},
+		{
+			name:       "page_index missing page_size_max",
+			pg:         &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex},
+			wantErrSub: "page_size_max > 0",
+		},
+		{
+			name:       "page_index missing page_size_default",
+			pg:         &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex, PageSizeMax: 100},
+			wantErrSub: "page_size_default > 0",
+		},
+		{
+			name:       "page_index max < default",
+			pg:         &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex, PageSizeMax: 10, PageSizeDefault: 50, PageIndexParam: "p", PageSizeParam: "s"},
+			wantErrSub: "page_size_max",
+		},
+		{
+			name:       "page_index missing page_index_param",
+			pg:         &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex, PageSizeMax: 100, PageSizeDefault: 20},
+			wantErrSub: "page_index_param",
+		},
+		{
+			name:       "page_index missing page_size_param",
+			pg:         &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex, PageSizeMax: 100, PageSizeDefault: 20, PageIndexParam: "p"},
+			wantErrSub: "page_size_param",
+		},
+		{
+			name:       "page_index missing total_expr",
+			pg:         &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex, PageSizeMax: 100, PageSizeDefault: 20, PageIndexParam: "p", PageSizeParam: "s"},
+			wantErrSub: "total_expr",
+		},
+		{
+			name: "page_index fully valid passes",
+			pg: &spec.PagingSpec{
+				PagingStrategy:  spec.PagingStrategyPageIndex,
+				PageSizeMax:     100,
+				PageSizeDefault: 20,
+				PageIndexParam:  "pageIndex",
+				PageSizeParam:   "pageSize",
+				TotalExpr:       "it.totalItems",
+			},
+		},
+		{
+			name: "offset_limit only needs page_size_max",
+			pg: &spec.PagingSpec{
+				PagingStrategy: spec.PagingStrategyOffsetLimit,
+				PageSizeMax:    100,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePaging("test command", tc.pg)
+			if tc.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("error = %q, want %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestCheckFunctions_WorkflowRegistered(t *testing.T) {
+	r := New()
+	wfID := "test:noop"
+	r.RegisterWorkflow(wfID, func(*cmdctx.Ctx) error { return nil })
+	cs := &spec.CommandSpec{
+		Command:     "execute thing",
+		Verb:        VerbExecute,
+		Noun:        "thing",
+		Module:      "test",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  wfID,
+	}
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := r.CheckFunctions(); err != nil {
+		t.Fatalf("CheckFunctions() = %v, want nil", err)
+	}
+}
+
+func TestCheckFunctions_WorkflowMissing(t *testing.T) {
+	r := New()
+	cs := &spec.CommandSpec{
+		Command:     "execute thing",
+		Verb:        VerbExecute,
+		Noun:        "thing",
+		Module:      "test",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  "missing_handler",
+	}
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	err := r.CheckFunctions()
+	if err == nil {
+		t.Fatal("CheckFunctions() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), `workflow_id "missing_handler" not registered`) {
+		t.Fatalf("CheckFunctions() error %q does not contain expected substring", err)
+	}
+}
+
+func TestCheckFunctions_SkipsDevOnlyAndExternal(t *testing.T) {
+	r := New()
+	r.specs[VerbExecute] = append(r.specs[VerbExecute],
+		&spec.CommandSpec{
+			Command:     "execute devonly",
+			Verb:        VerbExecute,
+			Noun:        "devonly",
+			Module:      "test",
+			HandlerType: spec.HandlerWorkflow,
+			WorkflowID:  "missing_handler",
+			DevOnly:     true,
+		},
+		&spec.CommandSpec{
+			Command:     "execute external",
+			Verb:        VerbExecute,
+			Noun:        "external",
+			Module:      "test",
+			HandlerType: spec.HandlerWorkflow,
+			WorkflowID:  "missing_handler",
+			External:    true,
+		},
+	)
+	if err := r.CheckFunctions(); err != nil {
+		t.Fatalf("CheckFunctions() = %v, want nil (DevOnly/External skipped)", err)
+	}
+}

--- a/pkg/registry/endpoint_test.go
+++ b/pkg/registry/endpoint_test.go
@@ -157,11 +157,11 @@ func testNounRegistry(t *testing.T) *Registry {
 
 func TestCallEndpointFull_ErrorPaths(t *testing.T) {
 	tests := []struct {
-		name     string
-		setup    func(*cmdctx.Ctx) // optional ctx mutation
-		flags    map[string]any
-		ep       *spec.EndpointSpec
-		wantErr  string
+		name    string
+		setup   func(*cmdctx.Ctx) // optional ctx mutation
+		flags   map[string]any
+		ep      *spec.EndpointSpec
+		wantErr string
 	}{
 		{
 			name:    "nil_auth",
@@ -229,9 +229,9 @@ func TestCallEndpointFull_ErrorPaths(t *testing.T) {
 
 func TestCallEndpointFull_ValidatorAbort(t *testing.T) {
 	tests := []struct {
-		name    string
-		ep      *spec.EndpointSpec
-		flags   map[string]any
+		name  string
+		ep    *spec.EndpointSpec
+		flags map[string]any
 	}{
 		{
 			// validator in the standard file-body path (Priority 1, non-envelope)
@@ -248,11 +248,11 @@ func TestCallEndpointFull_ValidatorAbort(t *testing.T) {
 			// validator in the yaml-envelope path (Priority 1, envelope branch)
 			name: "yaml_envelope_path",
 			ep: &spec.EndpointSpec{
-				Path:                "/x",
-				Method:              "POST",
-				FileBody:            spec.FileBodyOptional,
+				Path:                 "/x",
+				Method:               "POST",
+				FileBody:             spec.FileBodyOptional,
 				FileBodyYamlEnvelope: "service",
-				ValidatorsEndpoint:  []string{"test:abort"},
+				ValidatorsEndpoint:   []string{"test:abort"},
 			},
 			flags: map[string]any{"file": ""},
 		},
@@ -581,18 +581,18 @@ func TestCallEndpointFull_Priority2_UpdateStrategies(t *testing.T) {
 	getResp := `{"it":{"name":"old"},"name":"old"}`
 
 	tests := []struct {
-		name        string
-		ep          *spec.EndpointSpec
-		setArgs     map[string]string
-		delArgs     []string
-		resps       []string
-		checkCall   int // which call index to inspect
-		wantMethod  string
-		checkBody   func(t *testing.T, body []byte)
+		name       string
+		ep         *spec.EndpointSpec
+		setArgs    map[string]string
+		delArgs    []string
+		resps      []string
+		checkCall  int // which call index to inspect
+		wantMethod string
+		checkBody  func(t *testing.T, body []byte)
 	}{
 		{
-			name: "get_then_put_issues_get_first",
-			ep:   &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it"},
+			name:  "get_then_put_issues_get_first",
+			ep:    &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it"},
 			resps: []string{getResp, `{}`}, checkCall: 0, wantMethod: "GET",
 		},
 		{
@@ -607,8 +607,8 @@ func TestCallEndpointFull_Priority2_UpdateStrategies(t *testing.T) {
 			},
 		},
 		{
-			name: "get_then_put_with_wrap",
-			ep:   &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it", UpdateBodyWrap: "widget"},
+			name:  "get_then_put_with_wrap",
+			ep:    &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it", UpdateBodyWrap: "widget"},
 			resps: []string{getResp, `{}`}, checkCall: 1, wantMethod: "PUT",
 			checkBody: func(t *testing.T, body []byte) {
 				if _, ok := bodyMap(t, body)["widget"]; !ok {
@@ -726,9 +726,9 @@ func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
 
 func TestCallEndpointFull_Priority2_SetFields(t *testing.T) {
 	tests := []struct {
-		name     string
-		setArgs  map[string]string
-		ep       *spec.EndpointSpec
+		name      string
+		setArgs   map[string]string
+		ep        *spec.EndpointSpec
 		checkBody func(t *testing.T, m map[string]any)
 	}{
 		{
@@ -810,13 +810,13 @@ func TestCallEndpointFull_Priority3_DefaultDispatch(t *testing.T) {
 			wantBodyNil: true,
 		},
 		{
-			name: "POST_body_params",
-			ep:   &spec.EndpointSpec{Path: "/items", Method: "POST", BodyParams: map[string]string{"name": `"hello"`}},
+			name:       "POST_body_params",
+			ep:         &spec.EndpointSpec{Path: "/items", Method: "POST", BodyParams: map[string]string{"name": `"hello"`}},
 			wantMethod: "POST", wantBodyKey: "name", wantCT: "application/json",
 		},
 		{
-			name: "PUT_body_params",
-			ep:   &spec.EndpointSpec{Path: "/items/1", Method: "PUT", BodyParams: map[string]string{"val": `"v"`}},
+			name:       "PUT_body_params",
+			ep:         &spec.EndpointSpec{Path: "/items/1", Method: "PUT", BodyParams: map[string]string{"val": `"v"`}},
 			wantMethod: "PUT", wantBodyKey: "val",
 		},
 		{
@@ -826,8 +826,8 @@ func TestCallEndpointFull_Priority3_DefaultDispatch(t *testing.T) {
 			wantBodyNil: true,
 		},
 		{
-			name:    "DELETE_with_body",
-			ep:      &spec.EndpointSpec{Path: "/items/1", Method: "DELETE", BodyParams: map[string]string{"reason": `"gone"`}},
+			name:       "DELETE_with_body",
+			ep:         &spec.EndpointSpec{Path: "/items/1", Method: "DELETE", BodyParams: map[string]string{"reason": `"gone"`}},
 			wantMethod: "DELETE", wantBodyKey: "reason",
 		},
 		{
@@ -838,35 +838,35 @@ func TestCallEndpointFull_Priority3_DefaultDispatch(t *testing.T) {
 			wantMethod: "POST", wantBodyKey: "k",
 		},
 		{
-			name:    "extra_query_params_forwarded",
-			ep:      &spec.EndpointSpec{Path: "/items"},
-			extraQP: map[string]string{"page": "3"},
+			name:       "extra_query_params_forwarded",
+			ep:         &spec.EndpointSpec{Path: "/items"},
+			extraQP:    map[string]string{"page": "3"},
 			wantMethod: "GET", wantQPKey: "page",
 		},
 		{
-			name: "empty_expr_param_omitted",
-			ep:   &spec.EndpointSpec{Path: "/items", QueryParams: map[string]string{"missing": "flags.nonexistent"}},
+			name:       "empty_expr_param_omitted",
+			ep:         &spec.EndpointSpec{Path: "/items", QueryParams: map[string]string{"missing": "flags.nonexistent"}},
 			wantMethod: "GET",
 		},
 		// extraHeaders branches
 		{
-			name: "GET_with_extra_headers",
-			ep:   &spec.EndpointSpec{Path: "/items", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			name:       "GET_with_extra_headers",
+			ep:         &spec.EndpointSpec{Path: "/items", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
 			wantMethod: "GET", wantHeader: map[string]string{"X-Acct": "acct"},
 		},
 		{
-			name: "POST_with_extra_headers",
-			ep:   &spec.EndpointSpec{Path: "/items", Method: "POST", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			name:       "POST_with_extra_headers",
+			ep:         &spec.EndpointSpec{Path: "/items", Method: "POST", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
 			wantMethod: "POST", wantCT: "application/json", wantHeader: map[string]string{"X-Acct": "acct"},
 		},
 		{
-			name: "PUT_nil_body_with_extra_headers",
-			ep:   &spec.EndpointSpec{Path: "/items/1", Method: "PUT", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			name:       "PUT_nil_body_with_extra_headers",
+			ep:         &spec.EndpointSpec{Path: "/items/1", Method: "PUT", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
 			wantMethod: "PUT", wantCT: "application/json", wantHeader: map[string]string{"X-Acct": "acct"},
 		},
 		{
-			name: "DELETE_with_extra_headers",
-			ep:   &spec.EndpointSpec{Path: "/items/1", Method: "DELETE", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			name:       "DELETE_with_extra_headers",
+			ep:         &spec.EndpointSpec{Path: "/items/1", Method: "DELETE", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
 			wantMethod: "DELETE", wantHeader: map[string]string{"X-Acct": "acct"},
 		},
 	}
@@ -1202,7 +1202,7 @@ func TestParseArrayFlag(t *testing.T) {
 		want []string
 	}{
 		{`["a","b","c"]`, []string{"a", "b", "c"}},
-		{`[invalid`, []string{"[invalid"}},     // invalid JSON falls back to comma split
+		{`[invalid`, []string{"[invalid"}}, // invalid JSON falls back to comma split
 		{"a, b, c", []string{"a", "b", "c"}},
 		{"foo", []string{"foo"}},
 		{" a , b ", []string{"a", "b"}},
@@ -1554,9 +1554,9 @@ func TestFirstNonEmptyMap(t *testing.T) {
 
 func TestResolveContentType(t *testing.T) {
 	tests := []struct {
-		method      string
+		method        string
 		epContentType string
-		want        string
+		want          string
 	}{
 		{"POST", "", "application/json"},
 		{"PUT", "", "application/json"},
@@ -1664,10 +1664,10 @@ func TestGetDotPathMap(t *testing.T) {
 	}{
 		{"flat", false, "x"},
 		{"missing", true, ""},
-		{"str", true, ""},            // value is not a map
+		{"str", true, ""}, // value is not a map
 		{"nested.inner", false, "y"},
 		{"nested.missing", true, ""},
-		{"str.x", true, ""},          // intermediate not a map
+		{"str.x", true, ""}, // intermediate not a map
 	}
 	for _, tc := range tests {
 		got := getDotPathMap(m, tc.path)
@@ -1692,23 +1692,23 @@ func TestGetDotPathMap(t *testing.T) {
 
 func TestGetDotPathSlice(t *testing.T) {
 	m := map[string]any{
-		"list":  []any{"a", "b"},
-		"strs":  []string{"c", "d"},
-		"str":   "not-a-slice",
+		"list": []any{"a", "b"},
+		"strs": []string{"c", "d"},
+		"str":  "not-a-slice",
 		"nested": map[string]any{
 			"items": []any{"e"},
 		},
 	}
 
 	tests := []struct {
-		path     string
-		wantNil  bool
-		wantLen  int
+		path    string
+		wantNil bool
+		wantLen int
 	}{
 		{"list", false, 2},
-		{"strs", false, 2},       // []string converted to []any
+		{"strs", false, 2}, // []string converted to []any
 		{"missing", true, 0},
-		{"str", true, 0},         // not a slice
+		{"str", true, 0}, // not a slice
 		{"nested.items", false, 1},
 		{"nested.missing", true, 0},
 	}

--- a/pkg/registry/endpoint_test.go
+++ b/pkg/registry/endpoint_test.go
@@ -200,9 +200,6 @@ func TestCallEndpointFull_ErrorPaths(t *testing.T) {
 				flags = map[string]any{}
 			}
 			// slurp_file_error: file flag points at non-existent path — set inline
-			if tc.name == "slurp_file_error" {
-				// already set above
-			}
 			// normalize_file_body_error: write a JSON file but claim content-type yaml
 			if tc.name == "normalize_file_body_error" {
 				flags["file"] = tempFile(t, `{"key":"val"}`, ".json")

--- a/pkg/registry/endpoint_test.go
+++ b/pkg/registry/endpoint_test.go
@@ -1,0 +1,1197 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/harness/cli/pkg/auth"
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/spec"
+)
+
+// ---------------------------------------------------------------------------
+// Shared context builders
+// ---------------------------------------------------------------------------
+
+func testAuth(apiURL string) *auth.ResolvedAuth {
+	return &auth.ResolvedAuth{
+		APIUrl:    apiURL,
+		AccountID: "acct",
+		OrgID:     "org",
+		ProjectID: "proj",
+		PATToken:  "pat.test",
+		AuthType:  auth.AuthTypePAT,
+	}
+}
+
+func testEndpointCtx(apiURL string, flags map[string]any) *cmdctx.Ctx {
+	return &cmdctx.Ctx{
+		Context:    context.Background(),
+		Auth:       testAuth(apiURL),
+		FlagValues: flags,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// captureServer — records the single inbound request and returns a fixed body.
+// ---------------------------------------------------------------------------
+
+type captured struct {
+	method      string
+	path        string
+	rawQuery    string
+	body        []byte
+	contentType string
+	header      http.Header
+}
+
+func captureServer(t *testing.T, resp string) (*httptest.Server, *captured) {
+	t.Helper()
+	cap := &captured{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.method = r.Method
+		cap.path = r.URL.Path
+		cap.rawQuery = r.URL.RawQuery
+		cap.body, _ = io.ReadAll(r.Body)
+		cap.contentType = r.Header.Get("Content-Type")
+		cap.header = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
+
+// ---------------------------------------------------------------------------
+// sequenceServer — returns a different response for each successive call and
+// records all captured requests in order.
+// ---------------------------------------------------------------------------
+
+func sequenceServer(t *testing.T, resps []string) (*httptest.Server, *[]captured) {
+	t.Helper()
+	caps := &[]captured{}
+	var mu sync.Mutex
+	i := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		cap := captured{}
+		cap.method = r.Method
+		cap.path = r.URL.Path
+		cap.rawQuery = r.URL.RawQuery
+		cap.body, _ = io.ReadAll(r.Body)
+		cap.contentType = r.Header.Get("Content-Type")
+		cap.header = r.Header.Clone()
+		*caps = append(*caps, cap)
+		resp := "{}"
+		if i < len(resps) {
+			resp = resps[i]
+			i++
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, caps
+}
+
+// ---------------------------------------------------------------------------
+// writeTempFile helper — ext controls the file extension (e.g. ".json", ".yaml").
+// ---------------------------------------------------------------------------
+
+func writeTempFile(t *testing.T, content string) string {
+	return writeTempFileExt(t, content, ".json")
+}
+
+func writeTempFileExt(t *testing.T, content, ext string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "endpoint-*"+ext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
+
+// bodyMap unmarshals a JSON byte slice into map[string]any for assertions.
+func bodyMap(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("bodyMap: %v (raw: %s)", err, b)
+	}
+	return m
+}
+
+// queryValues parses a raw query string into url.Values for easy key lookups.
+func queryValues(t *testing.T, raw string) url.Values {
+	t.Helper()
+	v, err := url.ParseQuery(raw)
+	if err != nil {
+		t.Fatalf("queryValues: %v", err)
+	}
+	return v
+}
+
+// ---------------------------------------------------------------------------
+// TestCallEndpointFull_ErrorPaths — early-exit errors before any HTTP call
+// ---------------------------------------------------------------------------
+
+func TestCallEndpointFull_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupCtx  func(*cmdctx.Ctx)
+		ep        *spec.EndpointSpec
+		wantErr   string
+	}{
+		{
+			name: "nil_auth",
+			setupCtx: func(ctx *cmdctx.Ctx) { ctx.Auth = nil },
+			ep:       &spec.EndpointSpec{Path: "/x"},
+			wantErr:  "requires auth",
+		},
+		{
+			name:    "file_required_no_flag",
+			ep:      &spec.EndpointSpec{Path: "/x", FileBody: spec.FileBodyRequired},
+			wantErr: "-f/--file is required",
+		},
+		{
+			name:    "unclosed_path_template",
+			ep:      &spec.EndpointSpec{Path: "/items/{{unclosed"},
+			wantErr: "resolving path",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testEndpointCtx("http://unused", nil)
+			if tc.setupCtx != nil {
+				tc.setupCtx(ctx)
+			}
+			result, headers, err := callEndpointFull(ctx, tc.ep, nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantErr)
+			}
+			if result != nil || headers != nil {
+				t.Fatalf("expected nil result and headers on error, got result=%v headers=%v", result, headers)
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_ValidatorAbort verifies that a failing validator prevents
+// the HTTP call and propagates its error.
+func TestCallEndpointFull_ValidatorAbort(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+
+	r := New()
+	const id = "test:abort"
+	r.RegisterEndpointValidatorFn(id, func(_ *cmdctx.Ctx, _ cmdctx.EndpointRequest) error {
+		return errors.New("validator rejected")
+	})
+	ctx := testEndpointCtx(srv.URL, map[string]any{
+		"file": writeTempFile(t, `{}`),
+	})
+	ctx.Resolver = r
+	ep := &spec.EndpointSpec{
+		Path:               "/x",
+		Method:             "POST",
+		FileBody:           spec.FileBodyOptional,
+		ValidatorsEndpoint: []string{id},
+	}
+
+	_, _, err := callEndpointFull(ctx, ep, nil)
+	if err == nil || !strings.Contains(err.Error(), "validator rejected") {
+		t.Fatalf("err = %v, want validator rejected", err)
+	}
+	// Server must not have received any request.
+	if cap.method != "" {
+		t.Fatal("server received a request after validator abort")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCallEndpointFull_AuthScopeStripping — ctx.Level strips org/project from auth
+// ---------------------------------------------------------------------------
+
+func TestCallEndpointFull_AuthScopeStripping(t *testing.T) {
+	tests := []struct {
+		level           string
+		wantOrg         bool
+		wantProject     bool
+		// also verify ctx.Auth is restored after the call
+	}{
+		{"", true, true},
+		{"org", true, false},
+		{"account", false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run("level_"+tc.level, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			ctx := testEndpointCtx(srv.URL, nil)
+			ctx.Level = tc.level
+			origAuth := ctx.Auth
+
+			ep := &spec.EndpointSpec{Path: "/x"}
+			_, _, err := callEndpointFull(ctx, ep, nil)
+			fmt.Printf("err = %v\n", err)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			qv := queryValues(t, cap.rawQuery)
+			if tc.wantOrg {
+				if qv.Get("orgIdentifier") != "org" {
+					t.Fatalf("orgIdentifier = %q, want org", qv.Get("orgIdentifier"))
+				}
+			} else {
+				if qv.Get("orgIdentifier") != "" {
+					t.Fatalf("orgIdentifier = %q, want empty", qv.Get("orgIdentifier"))
+				}
+			}
+			if tc.wantProject {
+				if qv.Get("projectIdentifier") != "proj" {
+					t.Fatalf("projectIdentifier = %q, want proj", qv.Get("projectIdentifier"))
+				}
+			} else {
+				if qv.Get("projectIdentifier") != "" {
+					t.Fatalf("projectIdentifier = %q, want empty", qv.Get("projectIdentifier"))
+				}
+			}
+
+			// defer must have restored the original auth pointer
+			if ctx.Auth != origAuth {
+				t.Fatal("ctx.Auth was not restored after callEndpointFull returned")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCallEndpointFull_Priority3_DefaultDispatch — no file, no strategy
+// ---------------------------------------------------------------------------
+
+func TestCallEndpointFull_Priority3_DefaultDispatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		ep          *spec.EndpointSpec
+		extraQP     map[string]string
+		wantMethod  string
+		wantPath    string
+		wantBodyKey string // non-empty: check cap.body JSON contains this key
+		wantBodyNil bool   // true: body should be empty/nil
+		wantCT      string
+		wantQPKey   string // extra query param key to assert present
+	}{
+		{
+			name:        "GET_default_method",
+			ep:          &spec.EndpointSpec{Path: "/items"},
+			wantMethod:  "GET",
+			wantPath:    "/items",
+			wantBodyNil: true,
+		},
+		{
+			name: "POST_with_body_params",
+			ep: &spec.EndpointSpec{
+				Path:       "/items",
+				Method:     "POST",
+				BodyParams: map[string]string{"name": `"hello"`},
+			},
+			wantMethod:  "POST",
+			wantPath:    "/items",
+			wantBodyKey: "name",
+			wantCT:      "application/json",
+		},
+		{
+			name: "PUT_with_body_params",
+			ep: &spec.EndpointSpec{
+				Path:       "/items/1",
+				Method:     "PUT",
+				BodyParams: map[string]string{"val": `"v"`},
+			},
+			wantMethod:  "PUT",
+			wantPath:    "/items/1",
+			wantBodyKey: "val",
+		},
+		{
+			name: "DELETE_no_body",
+			ep: &spec.EndpointSpec{
+				Path:   "/items/1",
+				Method: "DELETE",
+			},
+			wantMethod:  "DELETE",
+			wantPath:    "/items/1",
+			wantBodyNil: true,
+		},
+		{
+			name: "extra_query_params_forwarded",
+			ep:   &spec.EndpointSpec{Path: "/items"},
+			extraQP: map[string]string{"page": "3"},
+			wantMethod: "GET",
+			wantPath:   "/items",
+			wantQPKey:  "page",
+		},
+		{
+			name: "empty_query_param_expr_omitted",
+			ep: &spec.EndpointSpec{
+				Path:        "/items",
+				QueryParams: map[string]string{"missing": "flags.nonexistent"},
+			},
+			wantMethod: "GET",
+			wantPath:   "/items",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			ctx := testEndpointCtx(srv.URL, nil)
+
+			result, _, err := callEndpointFull(ctx, tc.ep, tc.extraQP)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("result is nil, want non-nil")
+			}
+			if cap.method != tc.wantMethod {
+				t.Fatalf("method = %q, want %q", cap.method, tc.wantMethod)
+			}
+			if cap.path != tc.wantPath {
+				t.Fatalf("path = %q, want %q", cap.path, tc.wantPath)
+			}
+			if tc.wantBodyNil && len(cap.body) != 0 && string(cap.body) != "null" {
+				t.Fatalf("expected empty/nil body, got %s", cap.body)
+			}
+			if tc.wantBodyKey != "" {
+				m := bodyMap(t, cap.body)
+				if _, ok := m[tc.wantBodyKey]; !ok {
+					t.Fatalf("body missing key %q: %s", tc.wantBodyKey, cap.body)
+				}
+			}
+			if tc.wantCT != "" && !strings.Contains(cap.contentType, tc.wantCT) {
+				t.Fatalf("content-type = %q, want %q", cap.contentType, tc.wantCT)
+			}
+			if tc.wantQPKey != "" {
+				qv := queryValues(t, cap.rawQuery)
+				if qv.Get(tc.wantQPKey) == "" {
+					t.Fatalf("query param %q missing from %q", tc.wantQPKey, cap.rawQuery)
+				}
+			}
+			// assert empty expr param was NOT sent
+			if tc.ep.QueryParams != nil {
+				for _, expr := range tc.ep.QueryParams {
+					if strings.Contains(expr, "nonexistent") {
+						qv := queryValues(t, cap.rawQuery)
+						if qv.Get("missing") != "" {
+							t.Fatalf("empty expr param should be omitted, got %q", cap.rawQuery)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_Priority3_RequestHeaders verifies that request_headers
+// expressions are evaluated and injected into the outbound HTTP request.
+func TestCallEndpointFull_Priority3_RequestHeaders(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+	ctx := testEndpointCtx(srv.URL, nil)
+	ep := &spec.EndpointSpec{
+		Path:           "/items",
+		RequestHeaders: map[string]string{"X-Account": "auth.account"},
+	}
+	_, _, err := callEndpointFull(ctx, ep, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.header.Get("X-Account") != "acct" {
+		t.Fatalf("X-Account = %q, want acct", cap.header.Get("X-Account"))
+	}
+}
+
+// TestCallEndpointFull_Priority3_BodyFn verifies that a registered body_fn
+// is called and its return value is used as the POST body.
+func TestCallEndpointFull_Priority3_BodyFn(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+	r := New()
+	const fnID = "test:body"
+	r.RegisterBodyFn(fnID, func(*cmdctx.Ctx) (any, error) {
+		return map[string]any{"from": "fn"}, nil
+	})
+	ctx := testEndpointCtx(srv.URL, nil)
+	ctx.Resolver = r
+	ep := &spec.EndpointSpec{Path: "/items", Method: "POST", BodyFn: fnID}
+
+	_, _, err := callEndpointFull(ctx, ep, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := bodyMap(t, cap.body)
+	if m["from"] != "fn" {
+		t.Fatalf("body[from] = %v, want fn", m["from"])
+	}
+}
+
+// TestCallEndpointFull_Priority3_DeleteWithBody verifies that DELETE with
+// body_params sends the body rather than a plain DELETE.
+func TestCallEndpointFull_Priority3_DeleteWithBody(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+	ctx := testEndpointCtx(srv.URL, nil)
+	ep := &spec.EndpointSpec{
+		Path:       "/items/1",
+		Method:     "DELETE",
+		BodyParams: map[string]string{"reason": `"gone"`},
+	}
+	_, _, err := callEndpointFull(ctx, ep, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.method != "DELETE" {
+		t.Fatalf("method = %q, want DELETE", cap.method)
+	}
+	m := bodyMap(t, cap.body)
+	if m["reason"] != "gone" {
+		t.Fatalf("body[reason] = %v, want gone", m["reason"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCallEndpointFull_Priority1_FileBody — file body dispatch
+// ---------------------------------------------------------------------------
+
+func TestCallEndpointFull_Priority1_FileBody(t *testing.T) {
+	tests := []struct {
+		name          string
+		fileContent   string
+		fileExt       string // defaults to ".json" when empty
+		ep            *spec.EndpointSpec
+		wantMethod    string
+		wantBodyKey   string
+		wantBodyVal   any
+		wantCT        string
+		// for wrap tests: key whose value we inspect in the body map
+		wantWrapKey   string
+		wantWrapInner string // key inside the wrapped object
+	}{
+		{
+			name:        "json_post_no_wrapping",
+			fileContent: `{"id":"a","val":1}`,
+			ep: &spec.EndpointSpec{
+				Path:     "/items",
+				Method:   "POST",
+				FileBody: spec.FileBodyOptional,
+			},
+			wantMethod:  "POST",
+			wantBodyKey: "id",
+			wantBodyVal: "a",
+			wantCT:      "application/json",
+		},
+		{
+			name:        "file_body_wrap_as_string_post",
+			fileContent: "name: foo\ntype: step\n",
+			fileExt:     ".yaml",
+			ep: &spec.EndpointSpec{
+				Path:                 "/items",
+				Method:               "POST",
+				FileBody:             spec.FileBodyOptional,
+				FileBodyWrapAsString: "template_yaml",
+				FileBodyContentType:  "application/yaml",
+			},
+			wantMethod:  "POST",
+			wantWrapKey: "template_yaml",
+		},
+		{
+			name:        "file_body_wrap_as_string_put",
+			fileContent: "name: foo\ntype: step\n",
+			fileExt:     ".yaml",
+			ep: &spec.EndpointSpec{
+				Path:                 "/items/1",
+				Method:               "PUT",
+				FileBody:             spec.FileBodyOptional,
+				FileBodyWrapAsString: "template_yaml",
+				FileBodyContentType:  "application/yaml",
+			},
+			wantMethod:  "PUT",
+			wantWrapKey: "template_yaml",
+		},
+		{
+			name:        "update_body_wrap_put_not_wrapped",
+			fileContent: `{"name":"svc"}`,
+			ep: &spec.EndpointSpec{
+				Path:           "/items/1",
+				Method:         "PUT",
+				FileBody:       spec.FileBodyOptional,
+				UpdateBodyWrap: "service",
+			},
+			wantMethod:    "PUT",
+			wantWrapKey:   "service",
+			wantWrapInner: "name",
+		},
+		{
+			name:        "update_body_wrap_put_already_wrapped",
+			fileContent: `{"service":{"name":"svc"}}`,
+			ep: &spec.EndpointSpec{
+				Path:           "/items/1",
+				Method:         "PUT",
+				FileBody:       spec.FileBodyOptional,
+				UpdateBodyWrap: "service",
+			},
+			wantMethod:    "PUT",
+			wantWrapKey:   "service",
+			wantWrapInner: "name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			ext := tc.fileExt
+			if ext == "" {
+				ext = ".json"
+			}
+			ctx := testEndpointCtx(srv.URL, map[string]any{
+				"file": writeTempFileExt(t, tc.fileContent, ext),
+			})
+
+			_, _, err := callEndpointFull(ctx, tc.ep, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.method != tc.wantMethod {
+				t.Fatalf("method = %q, want %q", cap.method, tc.wantMethod)
+			}
+			if tc.wantBodyKey != "" {
+				m := bodyMap(t, cap.body)
+				if m[tc.wantBodyKey] != tc.wantBodyVal {
+					t.Fatalf("body[%s] = %v, want %v", tc.wantBodyKey, m[tc.wantBodyKey], tc.wantBodyVal)
+				}
+			}
+			if tc.wantCT != "" && !strings.Contains(cap.contentType, tc.wantCT) {
+				t.Fatalf("content-type = %q, want %q", cap.contentType, tc.wantCT)
+			}
+			if tc.wantWrapKey != "" {
+				m := bodyMap(t, cap.body)
+				if _, ok := m[tc.wantWrapKey]; !ok {
+					t.Fatalf("body missing wrap key %q: %s", tc.wantWrapKey, cap.body)
+				}
+				if tc.wantWrapInner != "" {
+					inner, ok := m[tc.wantWrapKey].(map[string]any)
+					if !ok {
+						t.Fatalf("body[%s] is not a map: %T", tc.wantWrapKey, m[tc.wantWrapKey])
+					}
+					if _, ok := inner[tc.wantWrapInner]; !ok {
+						t.Fatalf("inner map missing key %q: %v", tc.wantWrapInner, inner)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_Priority1_YamlEnvelope verifies that file_body_yaml_envelope
+// lifts identity fields and wraps the resource YAML.
+func TestCallEndpointFull_Priority1_YamlEnvelope(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+	ctx := testEndpointCtx(srv.URL, map[string]any{
+		"file": writeTempFile(t, "identifier: svc1\nname: My Service\n"),
+	})
+	ep := &spec.EndpointSpec{
+		Path:                "/services",
+		Method:              "POST",
+		FileBody:            spec.FileBodyOptional,
+		FileBodyYamlEnvelope: "service",
+	}
+
+	_, _, err := callEndpointFull(ctx, ep, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := bodyMap(t, cap.body)
+	if m["identifier"] != "svc1" {
+		t.Fatalf("envelope identifier = %v, want svc1", m["identifier"])
+	}
+	if _, ok := m["yaml"].(string); !ok {
+		t.Fatalf("envelope missing yaml string field: %v", m)
+	}
+}
+
+// TestCallEndpointFull_Priority1_CreateBodyWrap verifies that create_body_wrap +
+// create_body_init result in the correct POST body shape and that init fields
+// already set by the file are not overwritten.
+func TestCallEndpointFull_Priority1_CreateBodyWrap(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent string
+		ep          *spec.EndpointSpec
+		wantWrap    string
+		wantInner   map[string]any
+	}{
+		{
+			name:        "wrap_and_init",
+			fileContent: `{"name":"svc"}`,
+			ep: &spec.EndpointSpec{
+				Path:          "/items",
+				Method:        "POST",
+				FileBody:      spec.FileBodyOptional,
+				CreateBodyWrap: "service",
+				CreateBodyInit: map[string]string{
+					"type": `"Kubernetes"`,
+				},
+			},
+			wantWrap:  "service",
+			wantInner: map[string]any{"name": "svc", "type": "Kubernetes"},
+		},
+		{
+			name:        "init_does_not_overwrite_existing",
+			fileContent: `{"name":"existing","type":"Custom"}`,
+			ep: &spec.EndpointSpec{
+				Path:          "/items",
+				Method:        "POST",
+				FileBody:      spec.FileBodyOptional,
+				CreateBodyWrap: "service",
+				CreateBodyInit: map[string]string{
+					"type": `"Kubernetes"`,
+				},
+			},
+			wantWrap:  "service",
+			wantInner: map[string]any{"name": "existing", "type": "Custom"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			ctx := testEndpointCtx(srv.URL, map[string]any{
+				"file": writeTempFile(t, tc.fileContent),
+			})
+
+			_, _, err := callEndpointFull(ctx, tc.ep, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			m := bodyMap(t, cap.body)
+			inner, ok := m[tc.wantWrap].(map[string]any)
+			if !ok {
+				t.Fatalf("body missing wrap key %q: %s", tc.wantWrap, cap.body)
+			}
+			for k, want := range tc.wantInner {
+				if inner[k] != want {
+					t.Fatalf("inner[%s] = %v, want %v", k, inner[k], want)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCallEndpointFull_Priority2_UpdateStrategies — get-then-put/patch/kv
+// ---------------------------------------------------------------------------
+
+// testNounRegistry builds a *Registry with a "widget" noun that has a mutable
+// "name" field at path "name".
+func testNounRegistry(t *testing.T) *Registry {
+	t.Helper()
+	r := New()
+	if err := r.RegisterNoun(spec.NounDef{
+		Noun:        "widget",
+		NounAliases: []string{"widgets"},
+		Fields: []spec.FieldDef{
+			{ID: "name", Expr: "it.name", MutablePath: "name"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestCallEndpointFull_Priority2_UpdateStrategies(t *testing.T) {
+	// GET response fixture used as the base for all get-then-* tests.
+	getResp := `{"it":{"name":"old"},"name":"old"}`
+
+	tests := []struct {
+		name          string
+		ep            *spec.EndpointSpec
+		setArgs       map[string]string
+		delArgs       []string
+		resps         []string // sequenceServer responses: [GET resp, PUT/PATCH resp]
+		assertCall    int      // which captured call index to inspect (0=GET,1=PUT/PATCH)
+		wantMethod    string
+		wantBodyCheck func(t *testing.T, body []byte)
+	}{
+		{
+			name: "get_then_put_issues_get_first",
+			ep: &spec.EndpointSpec{
+				Path:           "/widgets/w1",
+				Method:         "PUT",
+				UpdateStrategy: spec.UpdateStrategyGetThenPut,
+				UpdateBodyPick: "it",
+			},
+			resps:      []string{getResp, `{}`},
+			assertCall: 0,
+			wantMethod: "GET",
+		},
+		{
+			name: "get_then_put_applies_set",
+			ep: &spec.EndpointSpec{
+				Path:           "/widgets/w1",
+				Method:         "PUT",
+				UpdateStrategy: spec.UpdateStrategyGetThenPut,
+				UpdateBodyPick: "it",
+			},
+			setArgs:    map[string]string{"name": "new"},
+			resps:      []string{getResp, `{}`},
+			assertCall: 1,
+			wantMethod: "PUT",
+			wantBodyCheck: func(t *testing.T, body []byte) {
+				m := bodyMap(t, body)
+				if m["name"] != "new" {
+					t.Fatalf("PUT body name = %v, want new", m["name"])
+				}
+			},
+		},
+		{
+			name: "get_then_put_with_wrap",
+			ep: &spec.EndpointSpec{
+				Path:           "/widgets/w1",
+				Method:         "PUT",
+				UpdateStrategy: spec.UpdateStrategyGetThenPut,
+				UpdateBodyPick: "it",
+				UpdateBodyWrap: "widget",
+			},
+			resps:      []string{getResp, `{}`},
+			assertCall: 1,
+			wantMethod: "PUT",
+			wantBodyCheck: func(t *testing.T, body []byte) {
+				m := bodyMap(t, body)
+				if _, ok := m["widget"]; !ok {
+					t.Fatalf("PUT body missing wrap key 'widget': %s", body)
+				}
+			},
+		},
+		{
+			name: "get_then_patch",
+			ep: &spec.EndpointSpec{
+				Path:           "/widgets/w1",
+				Method:         "PATCH",
+				UpdateStrategy: spec.UpdateStrategyGetThenPatch,
+				UpdateBodyPick: "it",
+			},
+			resps:      []string{getResp, `{}`},
+			assertCall: 1,
+			wantMethod: "PATCH",
+			wantBodyCheck: func(t *testing.T, body []byte) {
+				// PATCH uses merge-patch+json content type
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, caps := sequenceServer(t, tc.resps)
+			ctx := testEndpointCtx(srv.URL, nil)
+			ctx.Noun = "widget"
+			ctx.Id = "w1"
+			ctx.SetArgs = tc.setArgs
+			ctx.DelArgs = tc.delArgs
+			ctx.Resolver = testNounRegistry(t)
+
+			_, _, err := callEndpointFull(ctx, tc.ep, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(*caps) <= tc.assertCall {
+				t.Fatalf("expected at least %d calls, got %d", tc.assertCall+1, len(*caps))
+			}
+			got := (*caps)[tc.assertCall]
+			if got.method != tc.wantMethod {
+				t.Fatalf("call[%d] method = %q, want %q", tc.assertCall, got.method, tc.wantMethod)
+			}
+			if tc.wantBodyCheck != nil {
+				tc.wantBodyCheck(t, got.body)
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_Priority2_GetThenPutKV verifies the kv-array strategy:
+// GET returns existing pairs, --set upserts, --del removes, PUT sends full array.
+func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
+	kvGetResp := `[{"key":"env","value":"prod"},{"key":"team","value":"ops"}]`
+
+	tests := []struct {
+		name        string
+		setArgs     map[string]string
+		delArgs     []string
+		wantPresent map[string]string // key → value expected in PUT body pairs
+		wantAbsent  []string          // keys expected absent from PUT body pairs
+	}{
+		{
+			name:        "upsert_existing_key",
+			setArgs:     map[string]string{"env": "staging"},
+			wantPresent: map[string]string{"env": "staging", "team": "ops"},
+		},
+		{
+			name:        "add_new_key",
+			setArgs:     map[string]string{"region": "us-east"},
+			wantPresent: map[string]string{"region": "us-east", "env": "prod"},
+		},
+		{
+			name:       "del_key",
+			delArgs:    []string{"team"},
+			wantAbsent: []string{"team"},
+			wantPresent: map[string]string{"env": "prod"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, caps := sequenceServer(t, []string{kvGetResp, `{}`})
+			ctx := testEndpointCtx(srv.URL, nil)
+			ctx.Noun = "widget"
+			ctx.SetArgs = tc.setArgs
+			ctx.DelArgs = tc.delArgs
+			ctx.Resolver = testNounRegistry(t)
+
+			ep := &spec.EndpointSpec{
+				Path:           "/widgets/kv",
+				Method:         "PUT",
+				UpdateStrategy: spec.UpdateStrategyGetThenPutKV,
+				UpdateBodyWrap: "metadata",
+			}
+			_, _, err := callEndpointFull(ctx, ep, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(*caps) < 2 {
+				t.Fatalf("expected 2 calls (GET+PUT), got %d", len(*caps))
+			}
+
+			// Decode PUT body: {"metadata": [{key,value},...]}
+			putBody := bodyMap(t, (*caps)[1].body)
+			pairsRaw, ok := putBody["metadata"].([]any)
+			if !ok {
+				t.Fatalf("PUT body missing metadata array: %s", (*caps)[1].body)
+			}
+			kvMap := map[string]string{}
+			for _, p := range pairsRaw {
+				if pm, ok := p.(map[string]any); ok {
+					kvMap[pm["key"].(string)] = pm["value"].(string)
+				}
+			}
+			for k, want := range tc.wantPresent {
+				if kvMap[k] != want {
+					t.Fatalf("kv[%s] = %q, want %q", k, kvMap[k], want)
+				}
+			}
+			for _, k := range tc.wantAbsent {
+				if _, found := kvMap[k]; found {
+					t.Fatalf("key %q should be absent after --del, but found in PUT body", k)
+				}
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_Priority2_SetFields verifies the set-fields create strategy:
+// body is seeded from create_body_init, --set args are applied, result is POSTed.
+func TestCallEndpointFull_Priority2_SetFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		setArgs     map[string]string
+		ep          *spec.EndpointSpec
+		wantBody    map[string]any
+	}{
+		{
+			name:    "create_body_init_seeded",
+			setArgs: map[string]string{"name": "my-widget"},
+			ep: &spec.EndpointSpec{
+				Path:           "/widgets",
+				Method:         "POST",
+				CreateStrategy: spec.CreateStrategySetFields,
+				CreateBodyInit: map[string]string{
+					"type": `"KUBERNETES"`,
+				},
+			},
+			wantBody: map[string]any{"type": "KUBERNETES", "name": "my-widget"},
+		},
+		{
+			name:    "create_body_wrap",
+			setArgs: map[string]string{"name": "my-widget"},
+			ep: &spec.EndpointSpec{
+				Path:           "/widgets",
+				Method:         "POST",
+				CreateStrategy: spec.CreateStrategySetFields,
+				CreateBodyWrap: "widget",
+				CreateBodyInit: map[string]string{
+					"type": `"KUBERNETES"`,
+				},
+			},
+			wantBody: nil, // checked via wrap key below
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			ctx := testEndpointCtx(srv.URL, nil)
+			ctx.Noun = "widget"
+			ctx.SetArgs = tc.setArgs
+			ctx.Resolver = testNounRegistry(t)
+
+			_, _, err := callEndpointFull(ctx, tc.ep, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.method != "POST" {
+				t.Fatalf("method = %q, want POST", cap.method)
+			}
+
+			m := bodyMap(t, cap.body)
+
+			// If wrapped, unwrap first.
+			if tc.ep.CreateBodyWrap != "" {
+				inner, ok := m[tc.ep.CreateBodyWrap].(map[string]any)
+				if !ok {
+					t.Fatalf("body missing wrap key %q: %s", tc.ep.CreateBodyWrap, cap.body)
+				}
+				m = inner
+			}
+
+			if tc.wantBody != nil {
+				for k, want := range tc.wantBody {
+					if m[k] != want {
+						t.Fatalf("body[%s] = %v, want %v", k, m[k], want)
+					}
+				}
+			}
+			// --set name should always be applied
+			if m["name"] != tc.setArgs["name"] {
+				t.Fatalf("body[name] = %v, want %v", m["name"], tc.setArgs["name"])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEvalQueryParams — isolated unit tests for evalQueryParams
+// ---------------------------------------------------------------------------
+
+func TestEvalQueryParams(t *testing.T) {
+	ctx := testEndpointCtx("http://unused", map[string]any{"q": "find"})
+	ctx.Auth.OrgID = "my-org"
+	ctx.Auth.ProjectID = "my-proj"
+
+	t.Run("seeds_scope", func(t *testing.T) {
+		params := evalQueryParams(ctx, map[string]string{"search": "flags.q"}, true)
+		if params["orgIdentifier"] != "my-org" {
+			t.Fatalf("orgIdentifier = %q, want my-org", params["orgIdentifier"])
+		}
+		if params["projectIdentifier"] != "my-proj" {
+			t.Fatalf("projectIdentifier = %q, want my-proj", params["projectIdentifier"])
+		}
+		if params["search"] != "find" {
+			t.Fatalf("search = %q, want find", params["search"])
+		}
+	})
+
+	t.Run("merges_extra", func(t *testing.T) {
+		params := evalQueryParams(ctx, nil, true, map[string]string{"page": "2"})
+		if params["page"] != "2" {
+			t.Fatalf("page = %q, want 2", params["page"])
+		}
+	})
+
+	t.Run("omits_empty_expr", func(t *testing.T) {
+		params := evalQueryParams(ctx, map[string]string{"empty": `flags.missing`}, true)
+		if _, ok := params["empty"]; ok {
+			t.Fatalf("empty param should be omitted, got %v", params)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildYamlEnvelope — isolated unit tests for buildYamlEnvelope
+// ---------------------------------------------------------------------------
+
+func TestBuildYamlEnvelope(t *testing.T) {
+	ctx := testEndpointCtx("http://unused", nil)
+
+	t.Run("flat_yaml", func(t *testing.T) {
+		raw := "identifier: id1\nname: svc1\n"
+		env, err := buildYamlEnvelope(ctx, "service", raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if env["identifier"] != "id1" {
+			t.Fatalf("identifier = %v, want id1", env["identifier"])
+		}
+		if _, ok := env["yaml"].(string); !ok {
+			t.Fatalf("yaml field missing or not string: %v", env["yaml"])
+		}
+	})
+
+	t.Run("passthrough_existing_yaml_field", func(t *testing.T) {
+		raw := "identifier: id1\nyaml: \"already wrapped\"\n"
+		env, err := buildYamlEnvelope(ctx, "service", raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if env["yaml"] != "already wrapped" {
+			t.Fatalf("yaml = %v, want already wrapped", env["yaml"])
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestUnwrapIfAlreadyWrapped
+// ---------------------------------------------------------------------------
+
+func TestUnwrapIfAlreadyWrapped(t *testing.T) {
+	inner := map[string]any{"name": "x"}
+	wrapped := map[string]any{"project": inner}
+	got := unwrapIfAlreadyWrapped(wrapped, "project")
+	if m, ok := got.(map[string]any); !ok || m["name"] != "x" {
+		t.Fatalf("got = %v, want inner map", got)
+	}
+	bare := map[string]any{"name": "y"}
+	got = unwrapIfAlreadyWrapped(bare, "project")
+	if m, ok := got.(map[string]any); !ok || m["name"] != "y" {
+		t.Fatalf("got = %v, want bare map", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestResolveBody — isolated unit tests for resolveBody
+// ---------------------------------------------------------------------------
+
+func TestResolveBody(t *testing.T) {
+	t.Run("body_params", func(t *testing.T) {
+		ctx := testEndpointCtx("http://unused", nil)
+		ep := &spec.EndpointSpec{
+			BodyParams: map[string]string{
+				"name":       `"hello"`,
+				"opts.count": "3",
+			},
+		}
+		body, err := resolveBody(ep, ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		m, ok := body.(map[string]any)
+		if !ok {
+			t.Fatalf("body type = %T, want map", body)
+		}
+		if m["name"] != "hello" {
+			t.Fatalf("name = %v, want hello", m["name"])
+		}
+		opts, ok := m["opts"].(map[string]any)
+		if !ok {
+			t.Fatalf("opts missing or not map: %v", m["opts"])
+		}
+		// expr evaluator returns float64 for numeric literals
+		switch v := opts["count"].(type) {
+		case float64:
+			if v != 3 {
+				t.Fatalf("opts.count = %v, want 3", v)
+			}
+		case int:
+			if v != 3 {
+				t.Fatalf("opts.count = %v, want 3", v)
+			}
+		default:
+			t.Fatalf("opts.count unexpected type %T = %v", opts["count"], opts["count"])
+		}
+	})
+
+	t.Run("body_fn", func(t *testing.T) {
+		r := New()
+		const fnID = "test:body"
+		r.RegisterBodyFn(fnID, func(*cmdctx.Ctx) (any, error) {
+			return map[string]any{"from": "fn"}, nil
+		})
+		ctx := testEndpointCtx("http://unused", nil)
+		ctx.Resolver = r
+		ep := &spec.EndpointSpec{BodyFn: fnID}
+		body, err := resolveBody(ep, ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := body.(map[string]any)
+		if m["from"] != "fn" {
+			t.Fatalf("from = %v, want fn", m["from"])
+		}
+	})
+
+	t.Run("no_resolver", func(t *testing.T) {
+		ctx := testEndpointCtx("http://unused", nil)
+		ep := &spec.EndpointSpec{BodyFn: "test:missing"}
+		_, err := resolveBody(ep, ctx)
+		if err == nil || !strings.Contains(err.Error(), "no resolver") {
+			t.Fatalf("err = %v, want no resolver", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestRunEndpointValidators — isolated unit tests for runEndpointValidators
+// ---------------------------------------------------------------------------
+
+func TestRunEndpointValidators(t *testing.T) {
+	t.Run("none_registered", func(t *testing.T) {
+		ctx := testEndpointCtx("http://unused", nil)
+		ep := &spec.EndpointSpec{}
+		if err := runEndpointValidators(ctx, ep, cmdctx.EndpointRequest{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("missing_fn", func(t *testing.T) {
+		r := New()
+		ctx := testEndpointCtx("http://unused", nil)
+		ctx.Resolver = r
+		ep := &spec.EndpointSpec{ValidatorsEndpoint: []string{"test:missing"}}
+		err := runEndpointValidators(ctx, ep, cmdctx.EndpointRequest{})
+		if err == nil || !strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("err = %v, want not registered", err)
+		}
+	})
+
+	t.Run("first_error_wins", func(t *testing.T) {
+		r := New()
+		const id = "test:fail"
+		r.RegisterEndpointValidatorFn(id, func(_ *cmdctx.Ctx, _ cmdctx.EndpointRequest) error {
+			return fmt.Errorf("boom")
+		})
+		ctx := testEndpointCtx("http://unused", nil)
+		ctx.Resolver = r
+		ep := &spec.EndpointSpec{ValidatorsEndpoint: []string{id}}
+		err := runEndpointValidators(ctx, ep, cmdctx.EndpointRequest{})
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("err = %v, want boom", err)
+		}
+	})
+}

--- a/pkg/registry/endpoint_test.go
+++ b/pkg/registry/endpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -23,7 +24,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Shared context builders
+// Test helpers
 // ---------------------------------------------------------------------------
 
 func testAuth(apiURL string) *auth.ResolvedAuth {
@@ -37,7 +38,7 @@ func testAuth(apiURL string) *auth.ResolvedAuth {
 	}
 }
 
-func testEndpointCtx(apiURL string, flags map[string]any) *cmdctx.Ctx {
+func testCtx(apiURL string, flags map[string]any) *cmdctx.Ctx {
 	return &cmdctx.Ctx{
 		Context:    context.Background(),
 		Auth:       testAuth(apiURL),
@@ -45,10 +46,7 @@ func testEndpointCtx(apiURL string, flags map[string]any) *cmdctx.Ctx {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// captureServer — records the single inbound request and returns a fixed body.
-// ---------------------------------------------------------------------------
-
+// captureServer records the single inbound request and returns a fixed JSON body.
 type captured struct {
 	method      string
 	path        string
@@ -75,11 +73,7 @@ func captureServer(t *testing.T, resp string) (*httptest.Server, *captured) {
 	return srv, cap
 }
 
-// ---------------------------------------------------------------------------
-// sequenceServer — returns a different response for each successive call and
-// records all captured requests in order.
-// ---------------------------------------------------------------------------
-
+// sequenceServer returns a different response per call and records all calls.
 func sequenceServer(t *testing.T, resps []string) (*httptest.Server, *[]captured) {
 	t.Helper()
 	caps := &[]captured{}
@@ -88,13 +82,14 @@ func sequenceServer(t *testing.T, resps []string) (*httptest.Server, *[]captured
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		defer mu.Unlock()
-		cap := captured{}
-		cap.method = r.Method
-		cap.path = r.URL.Path
-		cap.rawQuery = r.URL.RawQuery
+		cap := captured{
+			method:      r.Method,
+			path:        r.URL.Path,
+			rawQuery:    r.URL.RawQuery,
+			contentType: r.Header.Get("Content-Type"),
+			header:      r.Header.Clone(),
+		}
 		cap.body, _ = io.ReadAll(r.Body)
-		cap.contentType = r.Header.Get("Content-Type")
-		cap.header = r.Header.Clone()
 		*caps = append(*caps, cap)
 		resp := "{}"
 		if i < len(resps) {
@@ -108,30 +103,21 @@ func sequenceServer(t *testing.T, resps []string) (*httptest.Server, *[]captured
 	return srv, caps
 }
 
-// ---------------------------------------------------------------------------
-// writeTempFile helper — ext controls the file extension (e.g. ".json", ".yaml").
-// ---------------------------------------------------------------------------
-
-func writeTempFile(t *testing.T, content string) string {
-	return writeTempFileExt(t, content, ".json")
-}
-
-func writeTempFileExt(t *testing.T, content, ext string) string {
+// tempFile writes content to a temp file with the given extension and returns its path.
+func tempFile(t *testing.T, content, ext string) string {
 	t.Helper()
-	f, err := os.CreateTemp(t.TempDir(), "endpoint-*"+ext)
+	f, err := os.CreateTemp(t.TempDir(), "ep-*"+ext)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
+	_ = f.Close()
 	return f.Name()
 }
 
-// bodyMap unmarshals a JSON byte slice into map[string]any for assertions.
+// bodyMap parses a captured JSON body into a map for field assertions.
 func bodyMap(t *testing.T, b []byte) map[string]any {
 	t.Helper()
 	var m map[string]any
@@ -141,32 +127,47 @@ func bodyMap(t *testing.T, b []byte) map[string]any {
 	return m
 }
 
-// queryValues parses a raw query string into url.Values for easy key lookups.
-func queryValues(t *testing.T, raw string) url.Values {
+// qv parses a raw query string into url.Values.
+func qv(t *testing.T, raw string) url.Values {
 	t.Helper()
 	v, err := url.ParseQuery(raw)
 	if err != nil {
-		t.Fatalf("queryValues: %v", err)
+		t.Fatalf("qv: %v", err)
 	}
 	return v
 }
 
+// testNounRegistry returns a *Registry with a "widget" noun that has a mutable "name" field.
+func testNounRegistry(t *testing.T) *Registry {
+	t.Helper()
+	r := New()
+	if err := r.RegisterNoun(spec.NounDef{
+		Noun:        "widget",
+		NounAliases: []string{"widgets"},
+		Fields:      []spec.FieldDef{{ID: "name", Expr: "it.name", MutablePath: "name"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
 // ---------------------------------------------------------------------------
-// TestCallEndpointFull_ErrorPaths — early-exit errors before any HTTP call
+// TestCallEndpointFull_ErrorPaths — errors that abort before any HTTP call
 // ---------------------------------------------------------------------------
 
 func TestCallEndpointFull_ErrorPaths(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupCtx  func(*cmdctx.Ctx)
-		ep        *spec.EndpointSpec
-		wantErr   string
+		name     string
+		setup    func(*cmdctx.Ctx) // optional ctx mutation
+		flags    map[string]any
+		ep       *spec.EndpointSpec
+		wantErr  string
 	}{
 		{
-			name: "nil_auth",
-			setupCtx: func(ctx *cmdctx.Ctx) { ctx.Auth = nil },
-			ep:       &spec.EndpointSpec{Path: "/x"},
-			wantErr:  "requires auth",
+			name:    "nil_auth",
+			setup:   func(ctx *cmdctx.Ctx) { ctx.Auth = nil },
+			ep:      &spec.EndpointSpec{Path: "/x"},
+			wantErr: "requires auth",
 		},
 		{
 			name:    "file_required_no_flag",
@@ -175,72 +176,122 @@ func TestCallEndpointFull_ErrorPaths(t *testing.T) {
 		},
 		{
 			name:    "unclosed_path_template",
-			ep:      &spec.EndpointSpec{Path: "/items/{{unclosed"},
+			ep:      &spec.EndpointSpec{Path: "/x/{{unclosed"},
 			wantErr: "resolving path",
+		},
+		{
+			name:    "slurp_file_error",
+			flags:   map[string]any{"file": "/nonexistent/path/file.json"},
+			ep:      &spec.EndpointSpec{Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional},
+			wantErr: "",
+		},
+		{
+			name:    "normalize_file_body_error",
+			flags:   map[string]any{"file": ""},
+			ep:      &spec.EndpointSpec{Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional, ContentType: "application/yaml"},
+			wantErr: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testEndpointCtx("http://unused", nil)
-			if tc.setupCtx != nil {
-				tc.setupCtx(ctx)
+			flags := tc.flags
+			if flags == nil {
+				flags = map[string]any{}
+			}
+			// slurp_file_error: file flag points at non-existent path — set inline
+			if tc.name == "slurp_file_error" {
+				// already set above
+			}
+			// normalize_file_body_error: write a JSON file but claim content-type yaml
+			if tc.name == "normalize_file_body_error" {
+				flags["file"] = tempFile(t, `{"key":"val"}`, ".json")
+			}
+
+			ctx := testCtx("http://unused", flags)
+			if tc.setup != nil {
+				tc.setup(ctx)
 			}
 			result, headers, err := callEndpointFull(ctx, tc.ep, nil)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("error = %q, want substring %q", err, tc.wantErr)
-			}
 			if result != nil || headers != nil {
-				t.Fatalf("expected nil result and headers on error, got result=%v headers=%v", result, headers)
+				t.Fatalf("expected nil result+headers on error, got result=%v headers=%v", result, headers)
+			}
+			if tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantErr)
 			}
 		})
 	}
 }
 
-// TestCallEndpointFull_ValidatorAbort verifies that a failing validator prevents
-// the HTTP call and propagates its error.
+// ---------------------------------------------------------------------------
+// TestCallEndpointFull_ValidatorAbort — validator fires and blocks the request
+// ---------------------------------------------------------------------------
+
 func TestCallEndpointFull_ValidatorAbort(t *testing.T) {
-	srv, cap := captureServer(t, `{}`)
-
-	r := New()
-	const id = "test:abort"
-	r.RegisterEndpointValidatorFn(id, func(_ *cmdctx.Ctx, _ cmdctx.EndpointRequest) error {
-		return errors.New("validator rejected")
-	})
-	ctx := testEndpointCtx(srv.URL, map[string]any{
-		"file": writeTempFile(t, `{}`),
-	})
-	ctx.Resolver = r
-	ep := &spec.EndpointSpec{
-		Path:               "/x",
-		Method:             "POST",
-		FileBody:           spec.FileBodyOptional,
-		ValidatorsEndpoint: []string{id},
+	tests := []struct {
+		name    string
+		ep      *spec.EndpointSpec
+		flags   map[string]any
+	}{
+		{
+			// validator in the standard file-body path (Priority 1, non-envelope)
+			name: "file_body_path",
+			ep: &spec.EndpointSpec{
+				Path:               "/x",
+				Method:             "POST",
+				FileBody:           spec.FileBodyOptional,
+				ValidatorsEndpoint: []string{"test:abort"},
+			},
+			flags: map[string]any{"file": ""},
+		},
+		{
+			// validator in the yaml-envelope path (Priority 1, envelope branch)
+			name: "yaml_envelope_path",
+			ep: &spec.EndpointSpec{
+				Path:                "/x",
+				Method:              "POST",
+				FileBody:            spec.FileBodyOptional,
+				FileBodyYamlEnvelope: "service",
+				ValidatorsEndpoint:  []string{"test:abort"},
+			},
+			flags: map[string]any{"file": ""},
+		},
 	}
 
-	_, _, err := callEndpointFull(ctx, ep, nil)
-	if err == nil || !strings.Contains(err.Error(), "validator rejected") {
-		t.Fatalf("err = %v, want validator rejected", err)
-	}
-	// Server must not have received any request.
-	if cap.method != "" {
-		t.Fatal("server received a request after validator abort")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			r := New()
+			r.RegisterEndpointValidatorFn("test:abort", func(_ *cmdctx.Ctx, _ cmdctx.EndpointRequest) error {
+				return errors.New("validator rejected")
+			})
+			tc.flags["file"] = tempFile(t, "identifier: x\n", ".yaml")
+			ctx := testCtx(srv.URL, tc.flags)
+			ctx.Resolver = r
+
+			_, _, err := callEndpointFull(ctx, tc.ep, nil)
+			if err == nil || !strings.Contains(err.Error(), "validator rejected") {
+				t.Fatalf("err = %v, want validator rejected", err)
+			}
+			if cap.method != "" {
+				t.Fatal("server received request after validator abort")
+			}
+		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// TestCallEndpointFull_AuthScopeStripping — ctx.Level strips org/project from auth
+// TestCallEndpointFull_AuthScopeStripping — ctx.Level trims auth scope
 // ---------------------------------------------------------------------------
 
 func TestCallEndpointFull_AuthScopeStripping(t *testing.T) {
 	tests := []struct {
-		level           string
-		wantOrg         bool
-		wantProject     bool
-		// also verify ctx.Auth is restored after the call
+		level       string
+		wantOrg     bool
+		wantProject bool
 	}{
 		{"", true, true},
 		{"org", true, false},
@@ -250,317 +301,188 @@ func TestCallEndpointFull_AuthScopeStripping(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("level_"+tc.level, func(t *testing.T) {
 			srv, cap := captureServer(t, `{}`)
-			ctx := testEndpointCtx(srv.URL, nil)
+			ctx := testCtx(srv.URL, nil)
 			ctx.Level = tc.level
 			origAuth := ctx.Auth
 
-			ep := &spec.EndpointSpec{Path: "/x"}
-			_, _, err := callEndpointFull(ctx, ep, nil)
-			fmt.Printf("err = %v\n", err)
+			_, _, err := callEndpointFull(ctx, &spec.EndpointSpec{Path: "/x"}, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			qv := queryValues(t, cap.rawQuery)
+			got := qv(t, cap.rawQuery)
 			if tc.wantOrg {
-				if qv.Get("orgIdentifier") != "org" {
-					t.Fatalf("orgIdentifier = %q, want org", qv.Get("orgIdentifier"))
+				if got.Get("orgIdentifier") != "org" {
+					t.Fatalf("orgIdentifier = %q, want org", got.Get("orgIdentifier"))
 				}
-			} else {
-				if qv.Get("orgIdentifier") != "" {
-					t.Fatalf("orgIdentifier = %q, want empty", qv.Get("orgIdentifier"))
-				}
+			} else if got.Get("orgIdentifier") != "" {
+				t.Fatalf("orgIdentifier = %q, want empty", got.Get("orgIdentifier"))
 			}
+
 			if tc.wantProject {
-				if qv.Get("projectIdentifier") != "proj" {
-					t.Fatalf("projectIdentifier = %q, want proj", qv.Get("projectIdentifier"))
+				if got.Get("projectIdentifier") != "proj" {
+					t.Fatalf("projectIdentifier = %q, want proj", got.Get("projectIdentifier"))
 				}
-			} else {
-				if qv.Get("projectIdentifier") != "" {
-					t.Fatalf("projectIdentifier = %q, want empty", qv.Get("projectIdentifier"))
-				}
+			} else if got.Get("projectIdentifier") != "" {
+				t.Fatalf("projectIdentifier = %q, want empty", got.Get("projectIdentifier"))
 			}
 
-			// defer must have restored the original auth pointer
 			if ctx.Auth != origAuth {
-				t.Fatal("ctx.Auth was not restored after callEndpointFull returned")
+				t.Fatal("ctx.Auth not restored after call (defer broken)")
 			}
 		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// TestCallEndpointFull_Priority3_DefaultDispatch — no file, no strategy
-// ---------------------------------------------------------------------------
-
-func TestCallEndpointFull_Priority3_DefaultDispatch(t *testing.T) {
-	tests := []struct {
-		name        string
-		ep          *spec.EndpointSpec
-		extraQP     map[string]string
-		wantMethod  string
-		wantPath    string
-		wantBodyKey string // non-empty: check cap.body JSON contains this key
-		wantBodyNil bool   // true: body should be empty/nil
-		wantCT      string
-		wantQPKey   string // extra query param key to assert present
-	}{
-		{
-			name:        "GET_default_method",
-			ep:          &spec.EndpointSpec{Path: "/items"},
-			wantMethod:  "GET",
-			wantPath:    "/items",
-			wantBodyNil: true,
-		},
-		{
-			name: "POST_with_body_params",
-			ep: &spec.EndpointSpec{
-				Path:       "/items",
-				Method:     "POST",
-				BodyParams: map[string]string{"name": `"hello"`},
-			},
-			wantMethod:  "POST",
-			wantPath:    "/items",
-			wantBodyKey: "name",
-			wantCT:      "application/json",
-		},
-		{
-			name: "PUT_with_body_params",
-			ep: &spec.EndpointSpec{
-				Path:       "/items/1",
-				Method:     "PUT",
-				BodyParams: map[string]string{"val": `"v"`},
-			},
-			wantMethod:  "PUT",
-			wantPath:    "/items/1",
-			wantBodyKey: "val",
-		},
-		{
-			name: "DELETE_no_body",
-			ep: &spec.EndpointSpec{
-				Path:   "/items/1",
-				Method: "DELETE",
-			},
-			wantMethod:  "DELETE",
-			wantPath:    "/items/1",
-			wantBodyNil: true,
-		},
-		{
-			name: "extra_query_params_forwarded",
-			ep:   &spec.EndpointSpec{Path: "/items"},
-			extraQP: map[string]string{"page": "3"},
-			wantMethod: "GET",
-			wantPath:   "/items",
-			wantQPKey:  "page",
-		},
-		{
-			name: "empty_query_param_expr_omitted",
-			ep: &spec.EndpointSpec{
-				Path:        "/items",
-				QueryParams: map[string]string{"missing": "flags.nonexistent"},
-			},
-			wantMethod: "GET",
-			wantPath:   "/items",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			srv, cap := captureServer(t, `{}`)
-			ctx := testEndpointCtx(srv.URL, nil)
-
-			result, _, err := callEndpointFull(ctx, tc.ep, tc.extraQP)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result == nil {
-				t.Fatal("result is nil, want non-nil")
-			}
-			if cap.method != tc.wantMethod {
-				t.Fatalf("method = %q, want %q", cap.method, tc.wantMethod)
-			}
-			if cap.path != tc.wantPath {
-				t.Fatalf("path = %q, want %q", cap.path, tc.wantPath)
-			}
-			if tc.wantBodyNil && len(cap.body) != 0 && string(cap.body) != "null" {
-				t.Fatalf("expected empty/nil body, got %s", cap.body)
-			}
-			if tc.wantBodyKey != "" {
-				m := bodyMap(t, cap.body)
-				if _, ok := m[tc.wantBodyKey]; !ok {
-					t.Fatalf("body missing key %q: %s", tc.wantBodyKey, cap.body)
-				}
-			}
-			if tc.wantCT != "" && !strings.Contains(cap.contentType, tc.wantCT) {
-				t.Fatalf("content-type = %q, want %q", cap.contentType, tc.wantCT)
-			}
-			if tc.wantQPKey != "" {
-				qv := queryValues(t, cap.rawQuery)
-				if qv.Get(tc.wantQPKey) == "" {
-					t.Fatalf("query param %q missing from %q", tc.wantQPKey, cap.rawQuery)
-				}
-			}
-			// assert empty expr param was NOT sent
-			if tc.ep.QueryParams != nil {
-				for _, expr := range tc.ep.QueryParams {
-					if strings.Contains(expr, "nonexistent") {
-						qv := queryValues(t, cap.rawQuery)
-						if qv.Get("missing") != "" {
-							t.Fatalf("empty expr param should be omitted, got %q", cap.rawQuery)
-						}
-					}
-				}
-			}
-		})
-	}
-}
-
-// TestCallEndpointFull_Priority3_RequestHeaders verifies that request_headers
-// expressions are evaluated and injected into the outbound HTTP request.
-func TestCallEndpointFull_Priority3_RequestHeaders(t *testing.T) {
-	srv, cap := captureServer(t, `{}`)
-	ctx := testEndpointCtx(srv.URL, nil)
-	ep := &spec.EndpointSpec{
-		Path:           "/items",
-		RequestHeaders: map[string]string{"X-Account": "auth.account"},
-	}
-	_, _, err := callEndpointFull(ctx, ep, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cap.header.Get("X-Account") != "acct" {
-		t.Fatalf("X-Account = %q, want acct", cap.header.Get("X-Account"))
-	}
-}
-
-// TestCallEndpointFull_Priority3_BodyFn verifies that a registered body_fn
-// is called and its return value is used as the POST body.
-func TestCallEndpointFull_Priority3_BodyFn(t *testing.T) {
-	srv, cap := captureServer(t, `{}`)
-	r := New()
-	const fnID = "test:body"
-	r.RegisterBodyFn(fnID, func(*cmdctx.Ctx) (any, error) {
-		return map[string]any{"from": "fn"}, nil
-	})
-	ctx := testEndpointCtx(srv.URL, nil)
-	ctx.Resolver = r
-	ep := &spec.EndpointSpec{Path: "/items", Method: "POST", BodyFn: fnID}
-
-	_, _, err := callEndpointFull(ctx, ep, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	m := bodyMap(t, cap.body)
-	if m["from"] != "fn" {
-		t.Fatalf("body[from] = %v, want fn", m["from"])
-	}
-}
-
-// TestCallEndpointFull_Priority3_DeleteWithBody verifies that DELETE with
-// body_params sends the body rather than a plain DELETE.
-func TestCallEndpointFull_Priority3_DeleteWithBody(t *testing.T) {
-	srv, cap := captureServer(t, `{}`)
-	ctx := testEndpointCtx(srv.URL, nil)
-	ep := &spec.EndpointSpec{
-		Path:       "/items/1",
-		Method:     "DELETE",
-		BodyParams: map[string]string{"reason": `"gone"`},
-	}
-	_, _, err := callEndpointFull(ctx, ep, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cap.method != "DELETE" {
-		t.Fatalf("method = %q, want DELETE", cap.method)
-	}
-	m := bodyMap(t, cap.body)
-	if m["reason"] != "gone" {
-		t.Fatalf("body[reason] = %v, want gone", m["reason"])
-	}
-}
-
-// ---------------------------------------------------------------------------
-// TestCallEndpointFull_Priority1_FileBody — file body dispatch
+// TestCallEndpointFull_Priority1_FileBody — file body dispatch branches
 // ---------------------------------------------------------------------------
 
 func TestCallEndpointFull_Priority1_FileBody(t *testing.T) {
 	tests := []struct {
 		name          string
 		fileContent   string
-		fileExt       string // defaults to ".json" when empty
+		fileExt       string // defaults to ".json"
 		ep            *spec.EndpointSpec
 		wantMethod    string
-		wantBodyKey   string
-		wantBodyVal   any
-		wantCT        string
-		// for wrap tests: key whose value we inspect in the body map
-		wantWrapKey   string
-		wantWrapInner string // key inside the wrapped object
+		wantBodyKey   string // assert key present in body JSON
+		wantBodyVal   any    // assert exact value if non-nil
+		wantCT        string // assert content-type contains
+		wantWrapKey   string // assert outer wrap key present
+		wantWrapInner string // assert inner map has this key
+		wantNoWrap    bool   // assert body does NOT have a top-level wrapper
 	}{
+		// --- JSON POST: no wrapping, body passes through as-is ---
 		{
-			name:        "json_post_no_wrapping",
-			fileContent: `{"id":"a","val":1}`,
-			ep: &spec.EndpointSpec{
-				Path:     "/items",
-				Method:   "POST",
-				FileBody: spec.FileBodyOptional,
-			},
+			name:        "json_post_no_wrap",
+			fileContent: `{"id":"a"}`,
+			ep:          &spec.EndpointSpec{Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional},
 			wantMethod:  "POST",
 			wantBodyKey: "id",
 			wantBodyVal: "a",
 			wantCT:      "application/json",
 		},
+		// --- PostRaw fallback: POST, optional, no wrap fields at all ---
+		{
+			name:        "post_raw_fallback",
+			fileContent: `{"x":1}`,
+			ep:          &spec.EndpointSpec{Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional},
+			wantMethod:  "POST",
+			wantBodyKey: "x",
+			wantNoWrap:  false,
+		},
+		// --- FileBodyWrapAsString: POST ---
 		{
 			name:        "file_body_wrap_as_string_post",
 			fileContent: "name: foo\ntype: step\n",
 			fileExt:     ".yaml",
 			ep: &spec.EndpointSpec{
-				Path:                 "/items",
-				Method:               "POST",
-				FileBody:             spec.FileBodyOptional,
-				FileBodyWrapAsString: "template_yaml",
-				FileBodyContentType:  "application/yaml",
+				Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional,
+				FileBodyWrapAsString: "template_yaml", FileBodyContentType: "application/yaml",
 			},
 			wantMethod:  "POST",
 			wantWrapKey: "template_yaml",
 		},
+		// --- FileBodyWrapAsString: PUT ---
 		{
 			name:        "file_body_wrap_as_string_put",
 			fileContent: "name: foo\ntype: step\n",
 			fileExt:     ".yaml",
 			ep: &spec.EndpointSpec{
-				Path:                 "/items/1",
-				Method:               "PUT",
-				FileBody:             spec.FileBodyOptional,
-				FileBodyWrapAsString: "template_yaml",
-				FileBodyContentType:  "application/yaml",
+				Path: "/x", Method: "PUT", FileBody: spec.FileBodyOptional,
+				FileBodyWrapAsString: "template_yaml", FileBodyContentType: "application/yaml",
 			},
 			wantMethod:  "PUT",
 			wantWrapKey: "template_yaml",
 		},
+		// --- FileBodyWrapAsString: PATCH ---
 		{
-			name:        "update_body_wrap_put_not_wrapped",
-			fileContent: `{"name":"svc"}`,
+			name:        "file_body_wrap_as_string_patch",
+			fileContent: "name: foo\ntype: step\n",
+			fileExt:     ".yaml",
 			ep: &spec.EndpointSpec{
-				Path:           "/items/1",
-				Method:         "PUT",
-				FileBody:       spec.FileBodyOptional,
-				UpdateBodyWrap: "service",
+				Path: "/x", Method: "PATCH", FileBody: spec.FileBodyOptional,
+				FileBodyWrapAsString: "template_yaml", FileBodyContentType: "application/yaml",
 			},
+			wantMethod:  "PATCH",
+			wantWrapKey: "template_yaml",
+		},
+		// --- UpdateBodyWrap: PUT, file not yet wrapped ---
+		{
+			name:          "update_body_wrap_put_not_wrapped",
+			fileContent:   `{"name":"svc"}`,
+			ep:            &spec.EndpointSpec{Path: "/x", Method: "PUT", FileBody: spec.FileBodyOptional, UpdateBodyWrap: "service"},
 			wantMethod:    "PUT",
 			wantWrapKey:   "service",
 			wantWrapInner: "name",
 		},
+		// --- UpdateBodyWrap: PUT, file already wrapped (unwrap guard) ---
 		{
-			name:        "update_body_wrap_put_already_wrapped",
-			fileContent: `{"service":{"name":"svc"}}`,
-			ep: &spec.EndpointSpec{
-				Path:           "/items/1",
-				Method:         "PUT",
-				FileBody:       spec.FileBodyOptional,
-				UpdateBodyWrap: "service",
-			},
+			name:          "update_body_wrap_put_already_wrapped",
+			fileContent:   `{"service":{"name":"svc"}}`,
+			ep:            &spec.EndpointSpec{Path: "/x", Method: "PUT", FileBody: spec.FileBodyOptional, UpdateBodyWrap: "service"},
 			wantMethod:    "PUT",
+			wantWrapKey:   "service",
+			wantWrapInner: "name",
+		},
+		// --- UpdateBodyWrap: PATCH ---
+		{
+			name:        "update_body_wrap_patch",
+			fileContent: `{"name":"svc"}`,
+			ep:          &spec.EndpointSpec{Path: "/x", Method: "PATCH", FileBody: spec.FileBodyOptional, UpdateBodyWrap: "service"},
+			wantMethod:  "PATCH",
+			wantWrapKey: "service",
+		},
+		// --- PUT bare: no FileBodyWrapAsString, no UpdateBodyWrap ---
+		{
+			name:        "put_bare_no_wrap",
+			fileContent: `{"k":"v"}`,
+			ep:          &spec.EndpointSpec{Path: "/x", Method: "PUT", FileBody: spec.FileBodyOptional},
+			wantMethod:  "PUT",
+			wantBodyKey: "k",
+		},
+		// --- CreateBodyWrap + CreateBodyInit: file not yet wrapped ---
+		{
+			name:        "create_body_wrap_and_init",
+			fileContent: `{"name":"svc"}`,
+			ep: &spec.EndpointSpec{
+				Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional,
+				CreateBodyWrap: "service", CreateBodyInit: map[string]string{"type": `"K8s"`},
+			},
+			wantMethod:    "POST",
+			wantWrapKey:   "service",
+			wantWrapInner: "name",
+		},
+		// --- CreateBodyWrap: file already has wrapper key ---
+		{
+			name:          "create_body_wrap_file_already_wrapped",
+			fileContent:   `{"service":{"name":"inner"}}`,
+			ep:            &spec.EndpointSpec{Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional, CreateBodyWrap: "service"},
+			wantMethod:    "POST",
+			wantWrapKey:   "service",
+			wantWrapInner: "name",
+		},
+		// --- CreateBodyInit only, no CreateBodyWrap ---
+		{
+			name:        "create_body_init_no_wrap",
+			fileContent: `{"name":"svc"}`,
+			ep: &spec.EndpointSpec{
+				Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional,
+				CreateBodyInit: map[string]string{"type": `"K8s"`},
+			},
+			wantMethod:  "POST",
+			wantBodyKey: "name",
+			wantNoWrap:  true,
+		},
+		// --- CreateBodyInit does not overwrite existing field ---
+		{
+			name:        "create_body_init_no_overwrite",
+			fileContent: `{"name":"svc","type":"Custom"}`,
+			ep: &spec.EndpointSpec{
+				Path: "/x", Method: "POST", FileBody: spec.FileBodyOptional,
+				CreateBodyWrap: "service", CreateBodyInit: map[string]string{"type": `"K8s"`},
+			},
+			wantMethod:    "POST",
 			wantWrapKey:   "service",
 			wantWrapInner: "name",
 		},
@@ -573,9 +495,7 @@ func TestCallEndpointFull_Priority1_FileBody(t *testing.T) {
 			if ext == "" {
 				ext = ".json"
 			}
-			ctx := testEndpointCtx(srv.URL, map[string]any{
-				"file": writeTempFileExt(t, tc.fileContent, ext),
-			})
+			ctx := testCtx(srv.URL, map[string]any{"file": tempFile(t, tc.fileContent, ext)})
 
 			_, _, err := callEndpointFull(ctx, tc.ep, nil)
 			if err != nil {
@@ -584,45 +504,62 @@ func TestCallEndpointFull_Priority1_FileBody(t *testing.T) {
 			if cap.method != tc.wantMethod {
 				t.Fatalf("method = %q, want %q", cap.method, tc.wantMethod)
 			}
-			if tc.wantBodyKey != "" {
-				m := bodyMap(t, cap.body)
-				if m[tc.wantBodyKey] != tc.wantBodyVal {
-					t.Fatalf("body[%s] = %v, want %v", tc.wantBodyKey, m[tc.wantBodyKey], tc.wantBodyVal)
-				}
-			}
 			if tc.wantCT != "" && !strings.Contains(cap.contentType, tc.wantCT) {
 				t.Fatalf("content-type = %q, want %q", cap.contentType, tc.wantCT)
 			}
+			m := bodyMap(t, cap.body)
+			if tc.wantBodyKey != "" {
+				if _, ok := m[tc.wantBodyKey]; !ok {
+					t.Fatalf("body missing key %q: %s", tc.wantBodyKey, cap.body)
+				}
+				if tc.wantBodyVal != nil && m[tc.wantBodyKey] != tc.wantBodyVal {
+					t.Fatalf("body[%s] = %v, want %v", tc.wantBodyKey, m[tc.wantBodyKey], tc.wantBodyVal)
+				}
+			}
 			if tc.wantWrapKey != "" {
-				m := bodyMap(t, cap.body)
-				if _, ok := m[tc.wantWrapKey]; !ok {
+				inner, ok := m[tc.wantWrapKey]
+				if !ok {
 					t.Fatalf("body missing wrap key %q: %s", tc.wantWrapKey, cap.body)
 				}
 				if tc.wantWrapInner != "" {
-					inner, ok := m[tc.wantWrapKey].(map[string]any)
+					innerMap, ok := inner.(map[string]any)
 					if !ok {
-						t.Fatalf("body[%s] is not a map: %T", tc.wantWrapKey, m[tc.wantWrapKey])
+						t.Fatalf("body[%s] is not a map: %T", tc.wantWrapKey, inner)
 					}
-					if _, ok := inner[tc.wantWrapInner]; !ok {
-						t.Fatalf("inner map missing key %q: %v", tc.wantWrapInner, inner)
+					if _, ok := innerMap[tc.wantWrapInner]; !ok {
+						t.Fatalf("inner map missing key %q: %v", tc.wantWrapInner, innerMap)
 					}
+				}
+			}
+			// For create_body_init_no_wrap: verify the type field was injected but no outer wrapper
+			if tc.name == "create_body_init_no_wrap" {
+				if m["type"] == nil {
+					t.Fatalf("CreateBodyInit key 'type' missing from body: %s", cap.body)
+				}
+				// body should be a flat map, not wrapped
+				if _, hasService := m["service"]; hasService {
+					t.Fatalf("body should not have wrapper key 'service': %s", cap.body)
+				}
+			}
+			// For create_body_init_no_overwrite: verify init did not stomp existing value
+			if tc.name == "create_body_init_no_overwrite" {
+				inner, _ := m[tc.wantWrapKey].(map[string]any)
+				if inner["type"] != "Custom" {
+					t.Fatalf("CreateBodyInit overwrote existing type: got %v, want Custom", inner["type"])
 				}
 			}
 		})
 	}
 }
 
-// TestCallEndpointFull_Priority1_YamlEnvelope verifies that file_body_yaml_envelope
-// lifts identity fields and wraps the resource YAML.
+// TestCallEndpointFull_Priority1_YamlEnvelope — yaml_envelope lifts identity fields.
 func TestCallEndpointFull_Priority1_YamlEnvelope(t *testing.T) {
 	srv, cap := captureServer(t, `{}`)
-	ctx := testEndpointCtx(srv.URL, map[string]any{
-		"file": writeTempFile(t, "identifier: svc1\nname: My Service\n"),
+	ctx := testCtx(srv.URL, map[string]any{
+		"file": tempFile(t, "identifier: svc1\nname: My Service\n", ".yaml"),
 	})
 	ep := &spec.EndpointSpec{
-		Path:                "/services",
-		Method:              "POST",
-		FileBody:            spec.FileBodyOptional,
+		Path: "/services", Method: "POST", FileBody: spec.FileBodyOptional,
 		FileBodyYamlEnvelope: "service",
 	}
 
@@ -632,187 +569,67 @@ func TestCallEndpointFull_Priority1_YamlEnvelope(t *testing.T) {
 	}
 	m := bodyMap(t, cap.body)
 	if m["identifier"] != "svc1" {
-		t.Fatalf("envelope identifier = %v, want svc1", m["identifier"])
+		t.Fatalf("identifier = %v, want svc1", m["identifier"])
 	}
 	if _, ok := m["yaml"].(string); !ok {
 		t.Fatalf("envelope missing yaml string field: %v", m)
 	}
 }
 
-// TestCallEndpointFull_Priority1_CreateBodyWrap verifies that create_body_wrap +
-// create_body_init result in the correct POST body shape and that init fields
-// already set by the file are not overwritten.
-func TestCallEndpointFull_Priority1_CreateBodyWrap(t *testing.T) {
-	tests := []struct {
-		name        string
-		fileContent string
-		ep          *spec.EndpointSpec
-		wantWrap    string
-		wantInner   map[string]any
-	}{
-		{
-			name:        "wrap_and_init",
-			fileContent: `{"name":"svc"}`,
-			ep: &spec.EndpointSpec{
-				Path:          "/items",
-				Method:        "POST",
-				FileBody:      spec.FileBodyOptional,
-				CreateBodyWrap: "service",
-				CreateBodyInit: map[string]string{
-					"type": `"Kubernetes"`,
-				},
-			},
-			wantWrap:  "service",
-			wantInner: map[string]any{"name": "svc", "type": "Kubernetes"},
-		},
-		{
-			name:        "init_does_not_overwrite_existing",
-			fileContent: `{"name":"existing","type":"Custom"}`,
-			ep: &spec.EndpointSpec{
-				Path:          "/items",
-				Method:        "POST",
-				FileBody:      spec.FileBodyOptional,
-				CreateBodyWrap: "service",
-				CreateBodyInit: map[string]string{
-					"type": `"Kubernetes"`,
-				},
-			},
-			wantWrap:  "service",
-			wantInner: map[string]any{"name": "existing", "type": "Custom"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			srv, cap := captureServer(t, `{}`)
-			ctx := testEndpointCtx(srv.URL, map[string]any{
-				"file": writeTempFile(t, tc.fileContent),
-			})
-
-			_, _, err := callEndpointFull(ctx, tc.ep, nil)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			m := bodyMap(t, cap.body)
-			inner, ok := m[tc.wantWrap].(map[string]any)
-			if !ok {
-				t.Fatalf("body missing wrap key %q: %s", tc.wantWrap, cap.body)
-			}
-			for k, want := range tc.wantInner {
-				if inner[k] != want {
-					t.Fatalf("inner[%s] = %v, want %v", k, inner[k], want)
-				}
-			}
-		})
-	}
-}
-
 // ---------------------------------------------------------------------------
-// TestCallEndpointFull_Priority2_UpdateStrategies — get-then-put/patch/kv
+// TestCallEndpointFull_Priority2_UpdateStrategies — get-then-put/patch/kv/set-fields
 // ---------------------------------------------------------------------------
-
-// testNounRegistry builds a *Registry with a "widget" noun that has a mutable
-// "name" field at path "name".
-func testNounRegistry(t *testing.T) *Registry {
-	t.Helper()
-	r := New()
-	if err := r.RegisterNoun(spec.NounDef{
-		Noun:        "widget",
-		NounAliases: []string{"widgets"},
-		Fields: []spec.FieldDef{
-			{ID: "name", Expr: "it.name", MutablePath: "name"},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	return r
-}
 
 func TestCallEndpointFull_Priority2_UpdateStrategies(t *testing.T) {
-	// GET response fixture used as the base for all get-then-* tests.
 	getResp := `{"it":{"name":"old"},"name":"old"}`
 
 	tests := []struct {
-		name          string
-		ep            *spec.EndpointSpec
-		setArgs       map[string]string
-		delArgs       []string
-		resps         []string // sequenceServer responses: [GET resp, PUT/PATCH resp]
-		assertCall    int      // which captured call index to inspect (0=GET,1=PUT/PATCH)
-		wantMethod    string
-		wantBodyCheck func(t *testing.T, body []byte)
+		name        string
+		ep          *spec.EndpointSpec
+		setArgs     map[string]string
+		delArgs     []string
+		resps       []string
+		checkCall   int // which call index to inspect
+		wantMethod  string
+		checkBody   func(t *testing.T, body []byte)
 	}{
 		{
 			name: "get_then_put_issues_get_first",
-			ep: &spec.EndpointSpec{
-				Path:           "/widgets/w1",
-				Method:         "PUT",
-				UpdateStrategy: spec.UpdateStrategyGetThenPut,
-				UpdateBodyPick: "it",
-			},
-			resps:      []string{getResp, `{}`},
-			assertCall: 0,
-			wantMethod: "GET",
+			ep:   &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it"},
+			resps: []string{getResp, `{}`}, checkCall: 0, wantMethod: "GET",
 		},
 		{
-			name: "get_then_put_applies_set",
-			ep: &spec.EndpointSpec{
-				Path:           "/widgets/w1",
-				Method:         "PUT",
-				UpdateStrategy: spec.UpdateStrategyGetThenPut,
-				UpdateBodyPick: "it",
-			},
-			setArgs:    map[string]string{"name": "new"},
-			resps:      []string{getResp, `{}`},
-			assertCall: 1,
-			wantMethod: "PUT",
-			wantBodyCheck: func(t *testing.T, body []byte) {
-				m := bodyMap(t, body)
-				if m["name"] != "new" {
-					t.Fatalf("PUT body name = %v, want new", m["name"])
+			name:    "get_then_put_applies_set",
+			ep:      &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it"},
+			setArgs: map[string]string{"name": "new"},
+			resps:   []string{getResp, `{}`}, checkCall: 1, wantMethod: "PUT",
+			checkBody: func(t *testing.T, body []byte) {
+				if bodyMap(t, body)["name"] != "new" {
+					t.Fatalf("PUT body name = %v, want new", bodyMap(t, body)["name"])
 				}
 			},
 		},
 		{
 			name: "get_then_put_with_wrap",
-			ep: &spec.EndpointSpec{
-				Path:           "/widgets/w1",
-				Method:         "PUT",
-				UpdateStrategy: spec.UpdateStrategyGetThenPut,
-				UpdateBodyPick: "it",
-				UpdateBodyWrap: "widget",
-			},
-			resps:      []string{getResp, `{}`},
-			assertCall: 1,
-			wantMethod: "PUT",
-			wantBodyCheck: func(t *testing.T, body []byte) {
-				m := bodyMap(t, body)
-				if _, ok := m["widget"]; !ok {
+			ep:   &spec.EndpointSpec{Path: "/widgets/w1", Method: "PUT", UpdateStrategy: spec.UpdateStrategyGetThenPut, UpdateBodyPick: "it", UpdateBodyWrap: "widget"},
+			resps: []string{getResp, `{}`}, checkCall: 1, wantMethod: "PUT",
+			checkBody: func(t *testing.T, body []byte) {
+				if _, ok := bodyMap(t, body)["widget"]; !ok {
 					t.Fatalf("PUT body missing wrap key 'widget': %s", body)
 				}
 			},
 		},
 		{
-			name: "get_then_patch",
-			ep: &spec.EndpointSpec{
-				Path:           "/widgets/w1",
-				Method:         "PATCH",
-				UpdateStrategy: spec.UpdateStrategyGetThenPatch,
-				UpdateBodyPick: "it",
-			},
-			resps:      []string{getResp, `{}`},
-			assertCall: 1,
-			wantMethod: "PATCH",
-			wantBodyCheck: func(t *testing.T, body []byte) {
-				// PATCH uses merge-patch+json content type
-			},
+			name:  "get_then_patch",
+			ep:    &spec.EndpointSpec{Path: "/widgets/w1", Method: "PATCH", UpdateStrategy: spec.UpdateStrategyGetThenPatch, UpdateBodyPick: "it"},
+			resps: []string{getResp, `{}`}, checkCall: 1, wantMethod: "PATCH",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			srv, caps := sequenceServer(t, tc.resps)
-			ctx := testEndpointCtx(srv.URL, nil)
+			ctx := testCtx(srv.URL, nil)
 			ctx.Noun = "widget"
 			ctx.Id = "w1"
 			ctx.SetArgs = tc.setArgs
@@ -823,31 +640,29 @@ func TestCallEndpointFull_Priority2_UpdateStrategies(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if len(*caps) <= tc.assertCall {
-				t.Fatalf("expected at least %d calls, got %d", tc.assertCall+1, len(*caps))
+			if len(*caps) <= tc.checkCall {
+				t.Fatalf("expected ≥%d calls, got %d", tc.checkCall+1, len(*caps))
 			}
-			got := (*caps)[tc.assertCall]
+			got := (*caps)[tc.checkCall]
 			if got.method != tc.wantMethod {
-				t.Fatalf("call[%d] method = %q, want %q", tc.assertCall, got.method, tc.wantMethod)
+				t.Fatalf("call[%d] method = %q, want %q", tc.checkCall, got.method, tc.wantMethod)
 			}
-			if tc.wantBodyCheck != nil {
-				tc.wantBodyCheck(t, got.body)
+			if tc.checkBody != nil {
+				tc.checkBody(t, got.body)
 			}
 		})
 	}
 }
 
-// TestCallEndpointFull_Priority2_GetThenPutKV verifies the kv-array strategy:
-// GET returns existing pairs, --set upserts, --del removes, PUT sends full array.
 func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
-	kvGetResp := `[{"key":"env","value":"prod"},{"key":"team","value":"ops"}]`
+	getResp := `[{"key":"env","value":"prod"},{"key":"team","value":"ops"}]`
 
 	tests := []struct {
 		name        string
 		setArgs     map[string]string
 		delArgs     []string
-		wantPresent map[string]string // key → value expected in PUT body pairs
-		wantAbsent  []string          // keys expected absent from PUT body pairs
+		wantPresent map[string]string
+		wantAbsent  []string
 	}{
 		{
 			name:        "upsert_existing_key",
@@ -860,27 +675,24 @@ func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
 			wantPresent: map[string]string{"region": "us-east", "env": "prod"},
 		},
 		{
-			name:       "del_key",
-			delArgs:    []string{"team"},
-			wantAbsent: []string{"team"},
+			name:        "del_key",
+			delArgs:     []string{"team"},
 			wantPresent: map[string]string{"env": "prod"},
+			wantAbsent:  []string{"team"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			srv, caps := sequenceServer(t, []string{kvGetResp, `{}`})
-			ctx := testEndpointCtx(srv.URL, nil)
-			ctx.Noun = "widget"
+			srv, caps := sequenceServer(t, []string{getResp, `{}`})
+			ctx := testCtx(srv.URL, nil)
 			ctx.SetArgs = tc.setArgs
 			ctx.DelArgs = tc.delArgs
 			ctx.Resolver = testNounRegistry(t)
 
 			ep := &spec.EndpointSpec{
-				Path:           "/widgets/kv",
-				Method:         "PUT",
-				UpdateStrategy: spec.UpdateStrategyGetThenPutKV,
-				UpdateBodyWrap: "metadata",
+				Path: "/kv", Method: "PUT",
+				UpdateStrategy: spec.UpdateStrategyGetThenPutKV, UpdateBodyWrap: "metadata",
 			}
 			_, _, err := callEndpointFull(ctx, ep, nil)
 			if err != nil {
@@ -890,7 +702,6 @@ func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
 				t.Fatalf("expected 2 calls (GET+PUT), got %d", len(*caps))
 			}
 
-			// Decode PUT body: {"metadata": [{key,value},...]}
 			putBody := bodyMap(t, (*caps)[1].body)
 			pairsRaw, ok := putBody["metadata"].([]any)
 			if !ok {
@@ -899,7 +710,7 @@ func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
 			kvMap := map[string]string{}
 			for _, p := range pairsRaw {
 				if pm, ok := p.(map[string]any); ok {
-					kvMap[pm["key"].(string)] = pm["value"].(string)
+					kvMap[fmt.Sprint(pm["key"])] = fmt.Sprint(pm["value"])
 				}
 			}
 			for k, want := range tc.wantPresent {
@@ -909,55 +720,59 @@ func TestCallEndpointFull_Priority2_GetThenPutKV(t *testing.T) {
 			}
 			for _, k := range tc.wantAbsent {
 				if _, found := kvMap[k]; found {
-					t.Fatalf("key %q should be absent after --del, but found in PUT body", k)
+					t.Fatalf("key %q should be absent after --del, found in PUT body", k)
 				}
 			}
 		})
 	}
 }
 
-// TestCallEndpointFull_Priority2_SetFields verifies the set-fields create strategy:
-// body is seeded from create_body_init, --set args are applied, result is POSTed.
 func TestCallEndpointFull_Priority2_SetFields(t *testing.T) {
 	tests := []struct {
-		name        string
-		setArgs     map[string]string
-		ep          *spec.EndpointSpec
-		wantBody    map[string]any
+		name     string
+		setArgs  map[string]string
+		ep       *spec.EndpointSpec
+		checkBody func(t *testing.T, m map[string]any)
 	}{
 		{
-			name:    "create_body_init_seeded",
+			name:    "init_seeded_and_set_applied",
 			setArgs: map[string]string{"name": "my-widget"},
 			ep: &spec.EndpointSpec{
-				Path:           "/widgets",
-				Method:         "POST",
-				CreateStrategy: spec.CreateStrategySetFields,
-				CreateBodyInit: map[string]string{
-					"type": `"KUBERNETES"`,
-				},
+				Path: "/widgets", Method: "POST", CreateStrategy: spec.CreateStrategySetFields,
+				CreateBodyInit: map[string]string{"type": `"KUBERNETES"`},
 			},
-			wantBody: map[string]any{"type": "KUBERNETES", "name": "my-widget"},
+			checkBody: func(t *testing.T, m map[string]any) {
+				if m["type"] != "KUBERNETES" {
+					t.Fatalf("type = %v, want KUBERNETES", m["type"])
+				}
+				if m["name"] != "my-widget" {
+					t.Fatalf("name = %v, want my-widget", m["name"])
+				}
+			},
 		},
 		{
-			name:    "create_body_wrap",
+			name:    "with_create_body_wrap",
 			setArgs: map[string]string{"name": "my-widget"},
 			ep: &spec.EndpointSpec{
-				Path:           "/widgets",
-				Method:         "POST",
-				CreateStrategy: spec.CreateStrategySetFields,
-				CreateBodyWrap: "widget",
-				CreateBodyInit: map[string]string{
-					"type": `"KUBERNETES"`,
-				},
+				Path: "/widgets", Method: "POST", CreateStrategy: spec.CreateStrategySetFields,
+				CreateBodyWrap: "widget", CreateBodyInit: map[string]string{"type": `"KUBERNETES"`},
 			},
-			wantBody: nil, // checked via wrap key below
+			checkBody: func(t *testing.T, m map[string]any) {
+				inner, ok := m["widget"].(map[string]any)
+				if !ok {
+					t.Fatalf("body missing wrap key 'widget': %v", m)
+				}
+				if inner["name"] != "my-widget" {
+					t.Fatalf("inner name = %v, want my-widget", inner["name"])
+				}
+			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			srv, cap := captureServer(t, `{}`)
-			ctx := testEndpointCtx(srv.URL, nil)
+			ctx := testCtx(srv.URL, nil)
 			ctx.Noun = "widget"
 			ctx.SetArgs = tc.setArgs
 			ctx.Resolver = testNounRegistry(t)
@@ -969,39 +784,241 @@ func TestCallEndpointFull_Priority2_SetFields(t *testing.T) {
 			if cap.method != "POST" {
 				t.Fatalf("method = %q, want POST", cap.method)
 			}
-
-			m := bodyMap(t, cap.body)
-
-			// If wrapped, unwrap first.
-			if tc.ep.CreateBodyWrap != "" {
-				inner, ok := m[tc.ep.CreateBodyWrap].(map[string]any)
-				if !ok {
-					t.Fatalf("body missing wrap key %q: %s", tc.ep.CreateBodyWrap, cap.body)
-				}
-				m = inner
-			}
-
-			if tc.wantBody != nil {
-				for k, want := range tc.wantBody {
-					if m[k] != want {
-						t.Fatalf("body[%s] = %v, want %v", k, m[k], want)
-					}
-				}
-			}
-			// --set name should always be applied
-			if m["name"] != tc.setArgs["name"] {
-				t.Fatalf("body[name] = %v, want %v", m["name"], tc.setArgs["name"])
-			}
+			tc.checkBody(t, bodyMap(t, cap.body))
 		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// TestEvalQueryParams — isolated unit tests for evalQueryParams
+// TestCallEndpointFull_Priority3_DefaultDispatch — body_params, body_fn, headers
+// ---------------------------------------------------------------------------
+
+func TestCallEndpointFull_Priority3_DefaultDispatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		ep          *spec.EndpointSpec
+		extraQP     map[string]string
+		setupCtx    func(*cmdctx.Ctx, *Registry)
+		wantMethod  string
+		wantBodyKey string
+		wantBodyNil bool
+		wantCT      string
+		wantQPKey   string
+		wantHeader  map[string]string
+	}{
+		{
+			name:        "GET_default",
+			ep:          &spec.EndpointSpec{Path: "/items"},
+			wantMethod:  "GET",
+			wantBodyNil: true,
+		},
+		{
+			name: "POST_body_params",
+			ep:   &spec.EndpointSpec{Path: "/items", Method: "POST", BodyParams: map[string]string{"name": `"hello"`}},
+			wantMethod: "POST", wantBodyKey: "name", wantCT: "application/json",
+		},
+		{
+			name: "PUT_body_params",
+			ep:   &spec.EndpointSpec{Path: "/items/1", Method: "PUT", BodyParams: map[string]string{"val": `"v"`}},
+			wantMethod: "PUT", wantBodyKey: "val",
+		},
+		{
+			name:        "DELETE_no_body",
+			ep:          &spec.EndpointSpec{Path: "/items/1", Method: "DELETE"},
+			wantMethod:  "DELETE",
+			wantBodyNil: true,
+		},
+		{
+			name:    "DELETE_with_body",
+			ep:      &spec.EndpointSpec{Path: "/items/1", Method: "DELETE", BodyParams: map[string]string{"reason": `"gone"`}},
+			wantMethod: "DELETE", wantBodyKey: "reason",
+		},
+		{
+			// PATCH with no strategy falls through to c.Post in the default switch arm (line 253).
+			// The wire method becomes POST — this documents the current behaviour.
+			name:       "PATCH_non_strategy_fallthrough",
+			ep:         &spec.EndpointSpec{Path: "/items/1", Method: "PATCH", BodyParams: map[string]string{"k": `"v"`}},
+			wantMethod: "POST", wantBodyKey: "k",
+		},
+		{
+			name:    "extra_query_params_forwarded",
+			ep:      &spec.EndpointSpec{Path: "/items"},
+			extraQP: map[string]string{"page": "3"},
+			wantMethod: "GET", wantQPKey: "page",
+		},
+		{
+			name: "empty_expr_param_omitted",
+			ep:   &spec.EndpointSpec{Path: "/items", QueryParams: map[string]string{"missing": "flags.nonexistent"}},
+			wantMethod: "GET",
+		},
+		// extraHeaders branches
+		{
+			name: "GET_with_extra_headers",
+			ep:   &spec.EndpointSpec{Path: "/items", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			wantMethod: "GET", wantHeader: map[string]string{"X-Acct": "acct"},
+		},
+		{
+			name: "POST_with_extra_headers",
+			ep:   &spec.EndpointSpec{Path: "/items", Method: "POST", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			wantMethod: "POST", wantCT: "application/json", wantHeader: map[string]string{"X-Acct": "acct"},
+		},
+		{
+			name: "PUT_nil_body_with_extra_headers",
+			ep:   &spec.EndpointSpec{Path: "/items/1", Method: "PUT", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			wantMethod: "PUT", wantCT: "application/json", wantHeader: map[string]string{"X-Acct": "acct"},
+		},
+		{
+			name: "DELETE_with_extra_headers",
+			ep:   &spec.EndpointSpec{Path: "/items/1", Method: "DELETE", RequestHeaders: map[string]string{"X-Acct": "auth.account"}},
+			wantMethod: "DELETE", wantHeader: map[string]string{"X-Acct": "acct"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			r := New()
+			ctx := testCtx(srv.URL, nil)
+			ctx.Resolver = r
+			if tc.setupCtx != nil {
+				tc.setupCtx(ctx, r)
+			}
+
+			result, _, err := callEndpointFull(ctx, tc.ep, tc.extraQP)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("result is nil, want non-nil")
+			}
+			if cap.method != tc.wantMethod {
+				t.Fatalf("method = %q, want %q", cap.method, tc.wantMethod)
+			}
+			if tc.wantBodyNil && len(cap.body) > 0 && string(cap.body) != "null" && string(cap.body) != "{}" {
+				t.Fatalf("expected no/empty body, got %s", cap.body)
+			}
+			if tc.wantBodyKey != "" {
+				m := bodyMap(t, cap.body)
+				if _, ok := m[tc.wantBodyKey]; !ok {
+					t.Fatalf("body missing key %q: %s", tc.wantBodyKey, cap.body)
+				}
+			}
+			if tc.wantCT != "" && !strings.Contains(cap.contentType, tc.wantCT) {
+				t.Fatalf("content-type = %q, want %q", cap.contentType, tc.wantCT)
+			}
+			if tc.wantQPKey != "" {
+				if qv(t, cap.rawQuery).Get(tc.wantQPKey) == "" {
+					t.Fatalf("query param %q missing from %q", tc.wantQPKey, cap.rawQuery)
+				}
+			}
+			for k, want := range tc.wantHeader {
+				if got := cap.header.Get(k); got != want {
+					t.Fatalf("header %s = %q, want %q", k, got, want)
+				}
+			}
+			// empty expr param must be absent
+			if tc.name == "empty_expr_param_omitted" {
+				if qv(t, cap.rawQuery).Get("missing") != "" {
+					t.Fatalf("empty expr param should be omitted, got %q", cap.rawQuery)
+				}
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_Priority3_BodyFn — body_fn supplies the POST body.
+func TestCallEndpointFull_Priority3_BodyFn(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+	r := New()
+	r.RegisterBodyFn("test:body", func(*cmdctx.Ctx) (any, error) {
+		return map[string]any{"from": "fn"}, nil
+	})
+	ctx := testCtx(srv.URL, nil)
+	ctx.Resolver = r
+
+	_, _, err := callEndpointFull(ctx, &spec.EndpointSpec{Path: "/x", Method: "POST", BodyFn: "test:body"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bodyMap(t, cap.body)["from"] != "fn" {
+		t.Fatalf("body[from] = %v, want fn", bodyMap(t, cap.body)["from"])
+	}
+}
+
+// TestCallEndpointFull_Priority3_RawBody — body_fn returning *cmdctx.RawBody.
+func TestCallEndpointFull_Priority3_RawBody(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestHeaders map[string]string
+		wantCT         string
+	}{
+		{
+			name:   "raw_body_no_headers",
+			wantCT: "text/plain",
+		},
+		{
+			name:           "raw_body_with_extra_headers",
+			requestHeaders: map[string]string{"X-Acct": "auth.account"},
+			wantCT:         "text/plain",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, cap := captureServer(t, `{}`)
+			r := New()
+			r.RegisterBodyFn("test:raw", func(*cmdctx.Ctx) (any, error) {
+				return &cmdctx.RawBody{Content: "raw-data", ContentType: "text/plain"}, nil
+			})
+			ctx := testCtx(srv.URL, nil)
+			ctx.Resolver = r
+
+			ep := &spec.EndpointSpec{Path: "/x", Method: "POST", BodyFn: "test:raw", RequestHeaders: tc.requestHeaders}
+			_, _, err := callEndpointFull(ctx, ep, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(cap.contentType, tc.wantCT) {
+				t.Fatalf("content-type = %q, want %q", cap.contentType, tc.wantCT)
+			}
+			if string(cap.body) != "raw-data" {
+				t.Fatalf("body = %q, want raw-data", cap.body)
+			}
+			if tc.requestHeaders != nil {
+				if cap.header.Get("X-Acct") != "acct" {
+					t.Fatalf("X-Acct = %q, want acct", cap.header.Get("X-Acct"))
+				}
+			}
+		})
+	}
+}
+
+// TestCallEndpointFull_Priority3_QueryParamsFnError — query_params_fn returning error aborts.
+func TestCallEndpointFull_Priority3_QueryParamsFnError(t *testing.T) {
+	srv, cap := captureServer(t, `{}`)
+	r := New()
+	r.RegisterQueryParamsFn("test:qp-fail", func(*cmdctx.Ctx) (map[string]string, error) {
+		return nil, errors.New("qp fn failed")
+	})
+	ctx := testCtx(srv.URL, nil)
+	ctx.Resolver = r
+
+	ep := &spec.EndpointSpec{Path: "/x", QueryParamsFn: "test:qp-fail"}
+	_, _, err := callEndpointFull(ctx, ep, nil)
+	if err == nil || !strings.Contains(err.Error(), "qp fn failed") {
+		t.Fatalf("err = %v, want qp fn failed", err)
+	}
+	if cap.method != "" {
+		t.Fatal("server received request after query_params_fn error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEvalQueryParams — isolated tests for evalQueryParams
 // ---------------------------------------------------------------------------
 
 func TestEvalQueryParams(t *testing.T) {
-	ctx := testEndpointCtx("http://unused", map[string]any{"q": "find"})
+	ctx := testCtx("http://unused", map[string]any{"q": "find"})
 	ctx.Auth.OrgID = "my-org"
 	ctx.Auth.ProjectID = "my-proj"
 
@@ -1026,7 +1043,7 @@ func TestEvalQueryParams(t *testing.T) {
 	})
 
 	t.Run("omits_empty_expr", func(t *testing.T) {
-		params := evalQueryParams(ctx, map[string]string{"empty": `flags.missing`}, true)
+		params := evalQueryParams(ctx, map[string]string{"empty": "flags.missing"}, true)
 		if _, ok := params["empty"]; ok {
 			t.Fatalf("empty param should be omitted, got %v", params)
 		}
@@ -1034,15 +1051,14 @@ func TestEvalQueryParams(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestBuildYamlEnvelope — isolated unit tests for buildYamlEnvelope
+// TestBuildYamlEnvelope — isolated tests for buildYamlEnvelope
 // ---------------------------------------------------------------------------
 
 func TestBuildYamlEnvelope(t *testing.T) {
-	ctx := testEndpointCtx("http://unused", nil)
+	ctx := testCtx("http://unused", nil)
 
-	t.Run("flat_yaml", func(t *testing.T) {
-		raw := "identifier: id1\nname: svc1\n"
-		env, err := buildYamlEnvelope(ctx, "service", raw)
+	t.Run("flat_yaml_lifts_identity_fields", func(t *testing.T) {
+		env, err := buildYamlEnvelope(ctx, "service", "identifier: id1\nname: svc1\n")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1055,8 +1071,7 @@ func TestBuildYamlEnvelope(t *testing.T) {
 	})
 
 	t.Run("passthrough_existing_yaml_field", func(t *testing.T) {
-		raw := "identifier: id1\nyaml: \"already wrapped\"\n"
-		env, err := buildYamlEnvelope(ctx, "service", raw)
+		env, err := buildYamlEnvelope(ctx, "service", "identifier: id1\nyaml: \"already wrapped\"\n")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1071,48 +1086,40 @@ func TestBuildYamlEnvelope(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUnwrapIfAlreadyWrapped(t *testing.T) {
-	inner := map[string]any{"name": "x"}
-	wrapped := map[string]any{"project": inner}
-	got := unwrapIfAlreadyWrapped(wrapped, "project")
-	if m, ok := got.(map[string]any); !ok || m["name"] != "x" {
-		t.Fatalf("got = %v, want inner map", got)
-	}
-	bare := map[string]any{"name": "y"}
-	got = unwrapIfAlreadyWrapped(bare, "project")
-	if m, ok := got.(map[string]any); !ok || m["name"] != "y" {
-		t.Fatalf("got = %v, want bare map", got)
-	}
+	t.Run("unwraps_when_key_present", func(t *testing.T) {
+		inner := map[string]any{"name": "x"}
+		got := unwrapIfAlreadyWrapped(map[string]any{"project": inner}, "project")
+		if m, ok := got.(map[string]any); !ok || m["name"] != "x" {
+			t.Fatalf("got = %v, want inner map", got)
+		}
+	})
+
+	t.Run("passthrough_when_key_absent", func(t *testing.T) {
+		bare := map[string]any{"name": "y"}
+		got := unwrapIfAlreadyWrapped(bare, "project")
+		if m, ok := got.(map[string]any); !ok || m["name"] != "y" {
+			t.Fatalf("got = %v, want bare map", got)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
-// TestResolveBody — isolated unit tests for resolveBody
+// TestResolveBody — isolated tests for resolveBody
 // ---------------------------------------------------------------------------
 
 func TestResolveBody(t *testing.T) {
-	t.Run("body_params", func(t *testing.T) {
-		ctx := testEndpointCtx("http://unused", nil)
-		ep := &spec.EndpointSpec{
-			BodyParams: map[string]string{
-				"name":       `"hello"`,
-				"opts.count": "3",
-			},
-		}
+	t.Run("body_params_nested", func(t *testing.T) {
+		ctx := testCtx("http://unused", nil)
+		ep := &spec.EndpointSpec{BodyParams: map[string]string{"name": `"hello"`, "opts.count": "3"}}
 		body, err := resolveBody(ep, ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		m, ok := body.(map[string]any)
-		if !ok {
-			t.Fatalf("body type = %T, want map", body)
-		}
+		m := body.(map[string]any)
 		if m["name"] != "hello" {
 			t.Fatalf("name = %v, want hello", m["name"])
 		}
-		opts, ok := m["opts"].(map[string]any)
-		if !ok {
-			t.Fatalf("opts missing or not map: %v", m["opts"])
-		}
-		// expr evaluator returns float64 for numeric literals
+		opts := m["opts"].(map[string]any)
 		switch v := opts["count"].(type) {
 		case float64:
 			if v != 3 {
@@ -1127,29 +1134,25 @@ func TestResolveBody(t *testing.T) {
 		}
 	})
 
-	t.Run("body_fn", func(t *testing.T) {
+	t.Run("body_fn_called", func(t *testing.T) {
 		r := New()
-		const fnID = "test:body"
-		r.RegisterBodyFn(fnID, func(*cmdctx.Ctx) (any, error) {
+		r.RegisterBodyFn("test:body", func(*cmdctx.Ctx) (any, error) {
 			return map[string]any{"from": "fn"}, nil
 		})
-		ctx := testEndpointCtx("http://unused", nil)
+		ctx := testCtx("http://unused", nil)
 		ctx.Resolver = r
-		ep := &spec.EndpointSpec{BodyFn: fnID}
-		body, err := resolveBody(ep, ctx)
+		body, err := resolveBody(&spec.EndpointSpec{BodyFn: "test:body"}, ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		m := body.(map[string]any)
-		if m["from"] != "fn" {
-			t.Fatalf("from = %v, want fn", m["from"])
+		if body.(map[string]any)["from"] != "fn" {
+			t.Fatalf("from = %v, want fn", body.(map[string]any)["from"])
 		}
 	})
 
-	t.Run("no_resolver", func(t *testing.T) {
-		ctx := testEndpointCtx("http://unused", nil)
-		ep := &spec.EndpointSpec{BodyFn: "test:missing"}
-		_, err := resolveBody(ep, ctx)
+	t.Run("no_resolver_errors", func(t *testing.T) {
+		ctx := testCtx("http://unused", nil)
+		_, err := resolveBody(&spec.EndpointSpec{BodyFn: "test:missing"}, ctx)
 		if err == nil || !strings.Contains(err.Error(), "no resolver") {
 			t.Fatalf("err = %v, want no resolver", err)
 		}
@@ -1157,24 +1160,22 @@ func TestResolveBody(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestRunEndpointValidators — isolated unit tests for runEndpointValidators
+// TestRunEndpointValidators — isolated tests for runEndpointValidators
 // ---------------------------------------------------------------------------
 
 func TestRunEndpointValidators(t *testing.T) {
-	t.Run("none_registered", func(t *testing.T) {
-		ctx := testEndpointCtx("http://unused", nil)
-		ep := &spec.EndpointSpec{}
-		if err := runEndpointValidators(ctx, ep, cmdctx.EndpointRequest{}); err != nil {
+	t.Run("none_registered_ok", func(t *testing.T) {
+		ctx := testCtx("http://unused", nil)
+		if err := runEndpointValidators(ctx, &spec.EndpointSpec{}, cmdctx.EndpointRequest{}); err != nil {
 			t.Fatal(err)
 		}
 	})
 
-	t.Run("missing_fn", func(t *testing.T) {
+	t.Run("missing_fn_errors", func(t *testing.T) {
 		r := New()
-		ctx := testEndpointCtx("http://unused", nil)
+		ctx := testCtx("http://unused", nil)
 		ctx.Resolver = r
-		ep := &spec.EndpointSpec{ValidatorsEndpoint: []string{"test:missing"}}
-		err := runEndpointValidators(ctx, ep, cmdctx.EndpointRequest{})
+		err := runEndpointValidators(ctx, &spec.EndpointSpec{ValidatorsEndpoint: []string{"test:missing"}}, cmdctx.EndpointRequest{})
 		if err == nil || !strings.Contains(err.Error(), "not registered") {
 			t.Fatalf("err = %v, want not registered", err)
 		}
@@ -1182,16 +1183,963 @@ func TestRunEndpointValidators(t *testing.T) {
 
 	t.Run("first_error_wins", func(t *testing.T) {
 		r := New()
-		const id = "test:fail"
-		r.RegisterEndpointValidatorFn(id, func(_ *cmdctx.Ctx, _ cmdctx.EndpointRequest) error {
+		r.RegisterEndpointValidatorFn("test:fail", func(_ *cmdctx.Ctx, _ cmdctx.EndpointRequest) error {
 			return fmt.Errorf("boom")
 		})
-		ctx := testEndpointCtx("http://unused", nil)
+		ctx := testCtx("http://unused", nil)
 		ctx.Resolver = r
-		ep := &spec.EndpointSpec{ValidatorsEndpoint: []string{id}}
-		err := runEndpointValidators(ctx, ep, cmdctx.EndpointRequest{})
+		err := runEndpointValidators(ctx, &spec.EndpointSpec{ValidatorsEndpoint: []string{"test:fail"}}, cmdctx.EndpointRequest{})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("err = %v, want boom", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestParseArrayFlag
+// ---------------------------------------------------------------------------
+
+func TestParseArrayFlag(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{`["a","b","c"]`, []string{"a", "b", "c"}},
+		{`[invalid`, []string{"[invalid"}},     // invalid JSON falls back to comma split
+		{"a, b, c", []string{"a", "b", "c"}},
+		{"foo", []string{"foo"}},
+		{" a , b ", []string{"a", "b"}},
+		{"", []string{}},
+	}
+	for _, tc := range tests {
+		got := parseArrayFlag(tc.in)
+		if len(got) != len(tc.want) {
+			t.Fatalf("parseArrayFlag(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("parseArrayFlag(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestApplyMutations — covers all field types and --set/--del error paths
+// ---------------------------------------------------------------------------
+
+func TestApplyMutations(t *testing.T) {
+	// fieldPaths for a noun with scalar, tags, and set-type fields.
+	fields := map[string]spec.FieldDef{
+		"name":    {ID: "name", Expr: "it.name", MutablePath: "name"},
+		"labels":  {ID: "labels", Expr: "it.labels", MutablePath: "labels", FieldType: "tags"},
+		"modules": {ID: "modules", Expr: "it.modules", MutablePath: "modules", FieldType: "set"},
+	}
+
+	t.Run("set_scalar", func(t *testing.T) {
+		m := map[string]any{}
+		if err := applyMutations(m, map[string]string{"name": "new"}, nil, fields); err != nil {
+			t.Fatal(err)
+		}
+		if m["name"] != "new" {
+			t.Fatalf("name = %v, want new", m["name"])
+		}
+	})
+
+	t.Run("set_unknown_field_errors", func(t *testing.T) {
+		err := applyMutations(map[string]any{}, map[string]string{"bad": "x"}, nil, fields)
+		if err == nil || !strings.Contains(err.Error(), "unknown or read-only") {
+			t.Fatalf("err = %v, want unknown or read-only", err)
+		}
+	})
+
+	t.Run("set_tag_creates_entry", func(t *testing.T) {
+		m := map[string]any{}
+		if err := applyMutations(m, map[string]string{"labels.env": "prod"}, nil, fields); err != nil {
+			t.Fatal(err)
+		}
+		tags, ok := m["labels"].(map[string]any)
+		if !ok || tags["env"] != "prod" {
+			t.Fatalf("labels.env = %v, want prod", m["labels"])
+		}
+	})
+
+	t.Run("set_tag_no_subkey_errors", func(t *testing.T) {
+		err := applyMutations(map[string]any{}, map[string]string{"labels": "v"}, nil, fields)
+		if err == nil || !strings.Contains(err.Error(), "require a key") {
+			t.Fatalf("err = %v, want require a key", err)
+		}
+	})
+
+	t.Run("set_set_field_adds_member", func(t *testing.T) {
+		m := map[string]any{}
+		if err := applyMutations(m, map[string]string{"modules.CD": ""}, nil, fields); err != nil {
+			t.Fatal(err)
+		}
+		if !sliceContains(getDotPathSlice(m, "modules"), "CD") {
+			t.Fatalf("modules should contain CD: %v", m["modules"])
+		}
+	})
+
+	t.Run("set_set_field_dedup", func(t *testing.T) {
+		m := map[string]any{"modules": []any{"CD"}}
+		if err := applyMutations(m, map[string]string{"modules.CD": ""}, nil, fields); err != nil {
+			t.Fatal(err)
+		}
+		s := getDotPathSlice(m, "modules")
+		if len(s) != 1 {
+			t.Fatalf("modules should have 1 entry, got %v", s)
+		}
+	})
+
+	t.Run("set_set_field_no_member_errors", func(t *testing.T) {
+		err := applyMutations(map[string]any{}, map[string]string{"modules": ""}, nil, fields)
+		if err == nil || !strings.Contains(err.Error(), "require a member") {
+			t.Fatalf("err = %v, want require a member", err)
+		}
+	})
+
+	t.Run("del_scalar_sets_nil", func(t *testing.T) {
+		m := map[string]any{"name": "old"}
+		if err := applyMutations(m, nil, []string{"name"}, fields); err != nil {
+			t.Fatal(err)
+		}
+		if m["name"] != nil {
+			t.Fatalf("name = %v, want nil", m["name"])
+		}
+	})
+
+	t.Run("del_unknown_field_errors", func(t *testing.T) {
+		err := applyMutations(map[string]any{}, nil, []string{"bad"}, fields)
+		if err == nil || !strings.Contains(err.Error(), "unknown or read-only") {
+			t.Fatalf("err = %v, want unknown or read-only", err)
+		}
+	})
+
+	t.Run("del_tag_removes_entry", func(t *testing.T) {
+		m := map[string]any{"labels": map[string]any{"env": "prod", "team": "ops"}}
+		if err := applyMutations(m, nil, []string{"labels.env"}, fields); err != nil {
+			t.Fatal(err)
+		}
+		tags := getDotPathMap(m, "labels")
+		if _, found := tags["env"]; found {
+			t.Fatalf("labels.env should be deleted, got %v", tags)
+		}
+		if tags["team"] != "ops" {
+			t.Fatalf("labels.team should be preserved, got %v", tags)
+		}
+	})
+
+	t.Run("del_tag_no_subkey_errors", func(t *testing.T) {
+		err := applyMutations(map[string]any{}, nil, []string{"labels"}, fields)
+		if err == nil || !strings.Contains(err.Error(), "require a key") {
+			t.Fatalf("err = %v, want require a key", err)
+		}
+	})
+
+	t.Run("del_set_field_removes_member", func(t *testing.T) {
+		m := map[string]any{"modules": []any{"CD", "CE"}}
+		if err := applyMutations(m, nil, []string{"modules.CD"}, fields); err != nil {
+			t.Fatal(err)
+		}
+		s := getDotPathSlice(m, "modules")
+		if sliceContains(s, "CD") || !sliceContains(s, "CE") {
+			t.Fatalf("modules should be [CE], got %v", s)
+		}
+	})
+
+	t.Run("del_set_field_no_member_errors", func(t *testing.T) {
+		err := applyMutations(map[string]any{}, nil, []string{"modules"}, fields)
+		if err == nil || !strings.Contains(err.Error(), "require a member") {
+			t.Fatalf("err = %v, want require a member", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestRunGetThenUpdate — GetPath override, UpdateBodyPick miss, ItemExpr fallback, GET error
+// ---------------------------------------------------------------------------
+
+func TestRunGetThenUpdate(t *testing.T) {
+	getResp := `{"data":{"name":"old"},"name":"old"}`
+
+	t.Run("get_path_override", func(t *testing.T) {
+		srv, caps := sequenceServer(t, []string{getResp, `{}`})
+		ctx := testCtx(srv.URL, nil)
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+
+		ep := &spec.EndpointSpec{
+			Path:           "/widgets/w1",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPut,
+			UpdateBodyPick: "it.data",
+			GetPath:        "/widgets/get/w1",
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if (*caps)[0].path != "/widgets/get/w1" {
+			t.Fatalf("GET path = %q, want /widgets/get/w1", (*caps)[0].path)
+		}
+	})
+
+	t.Run("update_body_pick_miss_errors", func(t *testing.T) {
+		srv, _ := sequenceServer(t, []string{`{}`, `{}`})
+		ctx := testCtx(srv.URL, nil)
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+
+		ep := &spec.EndpointSpec{
+			Path:           "/widgets/w1",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPut,
+			UpdateBodyPick: "it.nonexistent.deep.path",
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err == nil || !strings.Contains(err.Error(), "did not resolve") {
+			t.Fatalf("err = %v, want did not resolve", err)
+		}
+	})
+
+	t.Run("item_expr_fallback", func(t *testing.T) {
+		srv, caps := sequenceServer(t, []string{getResp, `{}`})
+		ctx := testCtx(srv.URL, nil)
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+
+		// No UpdateBodyPick; use ItemExpr as fallback.
+		ep := &spec.EndpointSpec{
+			Path:           "/widgets/w1",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPut,
+			ItemExpr:       "it.data",
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		putBody := bodyMap(t, (*caps)[1].body)
+		if putBody["name"] != "old" {
+			t.Fatalf("PUT body name = %v, want old (from it.data)", putBody["name"])
+		}
+	})
+
+	t.Run("get_failure_errors", func(t *testing.T) {
+		// Server returns HTTP 404 — client surfaces an error.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"error":"not found"}`)
+		}))
+		t.Cleanup(srv.Close)
+		ctx := testCtx(srv.URL, nil)
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+
+		ep := &spec.EndpointSpec{
+			Path:           "/widgets/w1",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPut,
+			UpdateBodyPick: "it",
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err == nil || !strings.Contains(err.Error(), "GET failed") {
+			t.Fatalf("err = %v, want GET failed", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestRunGetThenPutKV — GetPath override, ItemExpr unwrap, GET failure
+// ---------------------------------------------------------------------------
+
+func TestRunGetThenPutKV(t *testing.T) {
+	t.Run("get_path_override", func(t *testing.T) {
+		kvResp := `[{"key":"a","value":"1"}]`
+		srv, caps := sequenceServer(t, []string{kvResp, `{}`})
+		ctx := testCtx(srv.URL, nil)
+		ctx.Resolver = testNounRegistry(t)
+
+		ep := &spec.EndpointSpec{
+			Path:           "/kv",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPutKV,
+			GetPath:        "/kv/get",
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if (*caps)[0].path != "/kv/get" {
+			t.Fatalf("GET path = %q, want /kv/get", (*caps)[0].path)
+		}
+	})
+
+	t.Run("item_expr_unwrap", func(t *testing.T) {
+		// KV list is nested under "data" key; ItemExpr unwraps it.
+		nestedResp := `{"data":[{"key":"env","value":"prod"}]}`
+		srv, caps := sequenceServer(t, []string{nestedResp, `{}`})
+		ctx := testCtx(srv.URL, nil)
+		ctx.Resolver = testNounRegistry(t)
+
+		ep := &spec.EndpointSpec{
+			Path:           "/kv",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPutKV,
+			ItemExpr:       "it.data",
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		putBody := bodyMap(t, (*caps)[1].body)
+		pairsRaw, _ := putBody["metadata"].([]any)
+		if len(pairsRaw) == 0 {
+			t.Fatalf("expected pairs in PUT body, got: %s", (*caps)[1].body)
+		}
+	})
+
+	t.Run("get_failure_errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{}`)
+		}))
+		t.Cleanup(srv.Close)
+		ctx := testCtx(srv.URL, nil)
+		ctx.Resolver = testNounRegistry(t)
+
+		ep := &spec.EndpointSpec{
+			Path:           "/kv",
+			Method:         "PUT",
+			UpdateStrategy: spec.UpdateStrategyGetThenPutKV,
+		}
+		_, _, err := callEndpointFull(ctx, ep, nil)
+		if err == nil || !strings.Contains(err.Error(), "GET failed") {
+			t.Fatalf("err = %v, want GET failed", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestFirstNonEmpty / TestFirstNonEmptyMap
+// ---------------------------------------------------------------------------
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "b", "c"); got != "b" {
+		t.Fatalf("got %q, want b", got)
+	}
+	if got := firstNonEmpty("", ""); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	if got := firstNonEmpty("a", "b"); got != "a" {
+		t.Fatalf("got %q, want a", got)
+	}
+}
+
+func TestFirstNonEmptyMap(t *testing.T) {
+	m1 := map[string]string{"a": "1"}
+	m2 := map[string]string{"b": "2"}
+	if got := firstNonEmptyMap(nil, m1, m2); got["a"] != "1" {
+		t.Fatalf("expected m1, got %v", got)
+	}
+	if got := firstNonEmptyMap(nil, nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+	if got := firstNonEmptyMap(m2, m1); got["b"] != "2" {
+		t.Fatalf("expected m2, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestResolveContentType
+// ---------------------------------------------------------------------------
+
+func TestResolveContentType(t *testing.T) {
+	tests := []struct {
+		method      string
+		epContentType string
+		want        string
+	}{
+		{"POST", "", "application/json"},
+		{"PUT", "", "application/json"},
+		{"PATCH", "", "application/merge-patch+json"},
+		{"GET", "", ""},
+		{"DELETE", "", ""},
+		{"POST", "text/xml", "text/xml"},
+	}
+	for _, tc := range tests {
+		ep := &spec.EndpointSpec{ContentType: tc.epContentType}
+		if got := resolveContentType(ep, tc.method); got != tc.want {
+			t.Fatalf("resolveContentType(%s, %q) = %q, want %q", tc.method, tc.epContentType, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestSeedEnvelopeScope
+// ---------------------------------------------------------------------------
+
+func TestSeedEnvelopeScope(t *testing.T) {
+	t.Run("nil_auth_no_panic", func(t *testing.T) {
+		env := map[string]any{}
+		ctx := testCtx("http://unused", nil)
+		ctx.Auth = nil
+		seedEnvelopeScope(env, ctx) // must not panic
+		if len(env) != 0 {
+			t.Fatalf("env should be unchanged, got %v", env)
+		}
+	})
+
+	t.Run("seeds_missing_org_and_project", func(t *testing.T) {
+		env := map[string]any{}
+		ctx := testCtx("http://unused", nil)
+		seedEnvelopeScope(env, ctx)
+		if env["orgIdentifier"] != "org" {
+			t.Fatalf("orgIdentifier = %v, want org", env["orgIdentifier"])
+		}
+		if env["projectIdentifier"] != "proj" {
+			t.Fatalf("projectIdentifier = %v, want proj", env["projectIdentifier"])
+		}
+	})
+
+	t.Run("does_not_overwrite_existing", func(t *testing.T) {
+		env := map[string]any{"orgIdentifier": "custom-org"}
+		ctx := testCtx("http://unused", nil)
+		seedEnvelopeScope(env, ctx)
+		if env["orgIdentifier"] != "custom-org" {
+			t.Fatalf("orgIdentifier should not be overwritten, got %v", env["orgIdentifier"])
+		}
+		if env["projectIdentifier"] != "proj" {
+			t.Fatalf("projectIdentifier = %v, want proj", env["projectIdentifier"])
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildYamlEnvelope — add already-wrapped YAML case
+// ---------------------------------------------------------------------------
+
+func TestBuildYamlEnvelopeWrapped(t *testing.T) {
+	ctx := testCtx("http://unused", nil)
+	// File already has the wrapper key — inner fields should be lifted, yaml field set.
+	raw := "service:\n  identifier: s1\n  name: My Service\n"
+	env, err := buildYamlEnvelope(ctx, "service", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["identifier"] != "s1" {
+		t.Fatalf("identifier = %v, want s1", env["identifier"])
+	}
+	if _, ok := env["yaml"].(string); !ok {
+		t.Fatalf("yaml field missing or not string: %v", env["yaml"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestUnwrapIfAlreadyWrapped — non-map input passthrough
+// ---------------------------------------------------------------------------
+
+func TestUnwrapIfAlreadyWrappedNonMap(t *testing.T) {
+	got := unwrapIfAlreadyWrapped("raw string", "key")
+	if got != "raw string" {
+		t.Fatalf("got %v, want raw string", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGetDotPathMap
+// ---------------------------------------------------------------------------
+
+func TestGetDotPathMap(t *testing.T) {
+	m := map[string]any{
+		"flat": map[string]any{"x": 1},
+		"str":  "not-a-map",
+		"nested": map[string]any{
+			"inner": map[string]any{"y": 2},
+		},
+	}
+
+	tests := []struct {
+		path    string
+		wantNil bool
+		wantKey string
+	}{
+		{"flat", false, "x"},
+		{"missing", true, ""},
+		{"str", true, ""},            // value is not a map
+		{"nested.inner", false, "y"},
+		{"nested.missing", true, ""},
+		{"str.x", true, ""},          // intermediate not a map
+	}
+	for _, tc := range tests {
+		got := getDotPathMap(m, tc.path)
+		if tc.wantNil {
+			if got != nil {
+				t.Fatalf("getDotPathMap(%q) = %v, want nil", tc.path, got)
+			}
+		} else {
+			if got == nil {
+				t.Fatalf("getDotPathMap(%q) = nil, want non-nil", tc.path)
+			}
+			if _, ok := got[tc.wantKey]; !ok {
+				t.Fatalf("getDotPathMap(%q) missing key %q: %v", tc.path, tc.wantKey, got)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGetDotPathSlice
+// ---------------------------------------------------------------------------
+
+func TestGetDotPathSlice(t *testing.T) {
+	m := map[string]any{
+		"list":  []any{"a", "b"},
+		"strs":  []string{"c", "d"},
+		"str":   "not-a-slice",
+		"nested": map[string]any{
+			"items": []any{"e"},
+		},
+	}
+
+	tests := []struct {
+		path     string
+		wantNil  bool
+		wantLen  int
+	}{
+		{"list", false, 2},
+		{"strs", false, 2},       // []string converted to []any
+		{"missing", true, 0},
+		{"str", true, 0},         // not a slice
+		{"nested.items", false, 1},
+		{"nested.missing", true, 0},
+	}
+	for _, tc := range tests {
+		got := getDotPathSlice(m, tc.path)
+		if tc.wantNil {
+			if got != nil {
+				t.Fatalf("getDotPathSlice(%q) = %v, want nil", tc.path, got)
+			}
+		} else {
+			if len(got) != tc.wantLen {
+				t.Fatalf("getDotPathSlice(%q) len = %d, want %d: %v", tc.path, len(got), tc.wantLen, got)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestToInt64
+// ---------------------------------------------------------------------------
+
+func TestToInt64(t *testing.T) {
+	tests := []struct {
+		in      any
+		want    int64
+		wantErr bool
+	}{
+		{int64(5), 5, false},
+		{float64(3.7), 3, false},
+		{int(7), 7, false},
+		{"x", 0, true},
+	}
+	for _, tc := range tests {
+		got, err := toInt64(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("toInt64(%v) expected error, got nil", tc.in)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("toInt64(%v) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("toInt64(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestSliceContainsAndRemove
+// ---------------------------------------------------------------------------
+
+func TestSliceContainsAndRemove(t *testing.T) {
+	s := []any{"a", "b", "c"}
+
+	if !sliceContains(s, "b") {
+		t.Fatal("sliceContains should find b")
+	}
+	if sliceContains(s, "z") {
+		t.Fatal("sliceContains should not find z")
+	}
+	if sliceContains(nil, "a") {
+		t.Fatal("sliceContains on nil should return false")
+	}
+
+	got := sliceRemove(s, "b")
+	if sliceContains(got, "b") {
+		t.Fatal("sliceRemove should remove b")
+	}
+	if !sliceContains(got, "a") || !sliceContains(got, "c") {
+		t.Fatalf("sliceRemove should keep a and c, got %v", got)
+	}
+
+	// Noop when element absent.
+	got2 := sliceRemove(s, "z")
+	if len(got2) != len(s) {
+		t.Fatalf("sliceRemove of absent element changed length: %v", got2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRunEndpoint
+// ---------------------------------------------------------------------------
+
+func readOut(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readOut: %v", err)
+	}
+	return string(b)
+}
+
+func outFile(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "out")
+}
+
+func TestRunEndpoint(t *testing.T) {
+	t.Run("verb_list_guard", func(t *testing.T) {
+		ctx := testCtx("http://unused", nil)
+		ctx.VerbHandler = VerbList
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET"})
+		if err == nil || !strings.Contains(err.Error(), "RunListEndpoint") {
+			t.Fatalf("err = %v, want RunListEndpoint mention", err)
+		}
+	})
+
+	t.Run("list_fields_get", func(t *testing.T) {
+		ctx := testCtx("http://unused", map[string]any{"list-fields": true})
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "name") {
+			t.Fatalf("field table missing 'name': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("list_fields_update", func(t *testing.T) {
+		ctx := testCtx("http://unused", map[string]any{"list-fields": true})
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+		ctx.VerbHandler = VerbUpdate
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "PUT"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "name") {
+			t.Fatalf("mutable field table missing 'name': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("nil_result_text_header", func(t *testing.T) {
+		// Server returns empty body → result == nil; TextHeader should be printed.
+		srv, _ := captureServer(t, "")
+		ctx := testCtx(srv.URL, nil)
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "DELETE", TextHeader: "done\n"}
+		_, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "done") {
+			t.Fatalf("output missing 'done': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("field_extract_raw", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"yaml":"service:\n  name: foo\n"}`)
+		ctx := testCtx(srv.URL, nil)
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", FieldExtract: "yaml"}
+		_, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "service:") {
+			t.Fatalf("raw YAML not written: %s", readOut(t, out))
+		}
+	})
+
+	t.Run("field_extract_json", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"yaml":"service:\n  name: foo\n"}`)
+		ctx := testCtx(srv.URL, nil)
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ctx.FormatFlags.Format = "json"
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", FieldExtract: "yaml"}
+		_, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := readOut(t, out)
+		var parsed any
+		if jsonErr := json.Unmarshal([]byte(body), &parsed); jsonErr != nil {
+			t.Fatalf("output is not valid JSON: %s", body)
+		}
+	})
+
+	t.Run("verb_delete_with_text", func(t *testing.T) {
+		srv, _ := captureServer(t, `{}`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.VerbHandler = VerbDelete
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "DELETE", TextHeader: "deleted\n"}
+		result, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != nil {
+			t.Fatalf("result = %v, want nil", result)
+		}
+		if !strings.Contains(readOut(t, out), "deleted") {
+			t.Fatalf("output missing 'deleted': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("verb_delete_no_text", func(t *testing.T) {
+		srv, _ := captureServer(t, `{}`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.VerbHandler = VerbDelete
+		ep := &spec.EndpointSpec{Path: "/x", Method: "DELETE"}
+		result, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != nil {
+			t.Fatalf("result = %v, want nil", result)
+		}
+	})
+
+	t.Run("verb_get_fields_flag", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"name":"widget-1"}`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.VerbHandler = VerbGet
+		ctx.Noun = "widget"
+		ctx.Resolver = testNounRegistry(t)
+		ctx.FormatFlags.Fields = "name"
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET"}
+		_, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "widget-1") {
+			t.Fatalf("fields output missing 'widget-1': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("format_default_json", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"name":"foo"}`)
+		ctx := testCtx(srv.URL, nil)
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET"}
+		_, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := readOut(t, out)
+		m := bodyMap(t, []byte(body))
+		if m["name"] != "foo" {
+			t.Fatalf("json output name = %v, want foo", m["name"])
+		}
+	})
+
+	t.Run("format_yaml_raw", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"name":"foo"}`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.FormatFlags.Format = "yaml"
+		ctx.FormatFlags.Raw = true
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		// YamlPickExpr required even with Raw=true (checked before the Raw branch).
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", YamlPickExpr: "it"}
+		_, err := RunEndpoint(ctx, ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "name: foo") {
+			t.Fatalf("yaml output missing 'name: foo': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("call_endpoint_error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		srv.Close() // closed immediately — TCP dial will fail
+		ctx := testCtx(srv.URL, nil)
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET"})
+		if err == nil {
+			t.Fatal("expected error from closed server, got nil")
+		}
+	})
+
+	t.Run("nil_result_no_textfmt", func(t *testing.T) {
+		srv, _ := captureServer(t, "")
+		ctx := testCtx(srv.URL, nil)
+		// No TextHeader/Footer/TextFormatter → result==nil, textFmt==nil → return nil, nil
+		result, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "DELETE"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Fatalf("result = %v, want nil", result)
+		}
+	})
+
+	t.Run("field_extract_not_a_map", func(t *testing.T) {
+		srv, _ := captureServer(t, `[1,2,3]`)
+		ctx := testCtx(srv.URL, nil)
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET", FieldExtract: "x"})
+		if err == nil || !strings.Contains(err.Error(), "not a JSON object") {
+			t.Fatalf("err = %v, want 'not a JSON object'", err)
+		}
+	})
+
+	t.Run("field_extract_field_missing", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"other":"v"}`)
+		ctx := testCtx(srv.URL, nil)
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET", FieldExtract: "missing"})
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("err = %v, want 'not found'", err)
+		}
+	})
+
+	t.Run("field_extract_field_not_string", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"count":42}`)
+		ctx := testCtx(srv.URL, nil)
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET", FieldExtract: "count"})
+		if err == nil || !strings.Contains(err.Error(), "not a string") {
+			t.Fatalf("err = %v, want 'not a string'", err)
+		}
+	})
+
+	t.Run("format_unsupported", func(t *testing.T) {
+		srv, _ := captureServer(t, `{"name":"foo"}`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.FormatFlags.Format = "csv"
+		_, err := RunEndpoint(ctx, &spec.EndpointSpec{Path: "/x", Method: "GET"})
+		if err == nil || !strings.Contains(err.Error(), "not supported") {
+			t.Fatalf("err = %v, want 'not supported'", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestRunListEndpoint
+// ---------------------------------------------------------------------------
+
+func TestRunListEndpoint(t *testing.T) {
+	paging := &spec.PagingSpec{PagingStrategy: spec.PagingStrategyFlatList, Countable: true}
+
+	t.Run("no_paging_json", func(t *testing.T) {
+		srv, _ := captureServer(t, `[{"name":"a"}]`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.FormatFlags.Format = "json"
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it"}
+		if err := RunListEndpoint(ctx, ep); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "name") {
+			t.Fatalf("output missing 'name': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("no_paging_call_error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		srv.Close()
+		ctx := testCtx(srv.URL, nil)
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it"}
+		if err := RunListEndpoint(ctx, ep); err == nil {
+			t.Fatal("expected error from closed server")
+		}
+	})
+
+	t.Run("paged_items_json", func(t *testing.T) {
+		srv, _ := captureServer(t, `[{"name":"a"},{"name":"b"}]`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.FormatFlags.Format = "json"
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it", Paging: paging}
+		if err := RunListEndpoint(ctx, ep); err != nil {
+			t.Fatal(err)
+		}
+		body := readOut(t, out)
+		if !strings.Contains(body, "name") {
+			t.Fatalf("output missing items: %s", body)
+		}
+	})
+
+	t.Run("paged_items_error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		srv.Close()
+		ctx := testCtx(srv.URL, nil)
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it", Paging: paging}
+		if err := RunListEndpoint(ctx, ep); err == nil {
+			t.Fatal("expected error from closed server")
+		}
+	})
+
+	t.Run("paged_count", func(t *testing.T) {
+		srv, _ := captureServer(t, `[{"name":"a"},{"name":"b"}]`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.PagingFlags.Count = true
+		out := outFile(t)
+		ctx.FormatFlags.OutFile = out
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it", Paging: paging}
+		if err := RunListEndpoint(ctx, ep); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(readOut(t, out), "2") {
+			t.Fatalf("count output missing '2': %s", readOut(t, out))
+		}
+	})
+
+	t.Run("paged_count_error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		srv.Close()
+		ctx := testCtx(srv.URL, nil)
+		ctx.PagingFlags.Count = true
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it", Paging: paging}
+		if err := RunListEndpoint(ctx, ep); err == nil {
+			t.Fatal("expected error from closed server")
+		}
+	})
+
+	t.Run("format_unsupported", func(t *testing.T) {
+		srv, _ := captureServer(t, `[{"name":"a"}]`)
+		ctx := testCtx(srv.URL, nil)
+		ctx.FormatFlags.Format = "bad"
+		ep := &spec.EndpointSpec{Path: "/x", Method: "GET", ItemsExpr: "it"}
+		if err := RunListEndpoint(ctx, ep); err == nil || !strings.Contains(err.Error(), "unknown format") {
+			t.Fatalf("err = %v, want 'unknown format'", err)
 		}
 	})
 }

--- a/pkg/registry/fields_test.go
+++ b/pkg/registry/fields_test.go
@@ -1,0 +1,449 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/spec"
+)
+
+// ---------------------------------------------------------------------------
+// splitFieldIDs
+// ---------------------------------------------------------------------------
+
+func TestSplitFieldIDs(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"name,status", []string{"name", "status"}},
+		{" name , status ", []string{"name", "status"}},
+		{"name", []string{"name"}},
+		{"", []string{}},
+		{",,,", []string{}},
+	}
+	for _, tc := range tests {
+		got := splitFieldIDs(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("splitFieldIDs(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("splitFieldIDs(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// labelFromID / fieldLabel
+// ---------------------------------------------------------------------------
+
+func TestLabelFromID(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"status", "Status"},
+		{"pipeline_name", "Pipeline Name"},
+		{"created_by_user", "Created By User"},
+		{"id", "Id"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := labelFromID(tc.in); got != tc.want {
+			t.Errorf("labelFromID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFieldLabel_UsesExplicitLabel(t *testing.T) {
+	f := spec.FieldDef{ID: "my_id", Label: "Custom Label", Expr: "it.id"}
+	if got := fieldLabel(f); got != "Custom Label" {
+		t.Errorf("fieldLabel with explicit label = %q, want %q", got, "Custom Label")
+	}
+}
+
+func TestFieldLabel_DerivedFromID(t *testing.T) {
+	f := spec.FieldDef{ID: "pipeline_name", Expr: "it.name"}
+	if got := fieldLabel(f); got != "Pipeline Name" {
+		t.Errorf("fieldLabel from ID = %q, want %q", got, "Pipeline Name")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveNounDef
+// ---------------------------------------------------------------------------
+
+type testResolver struct {
+	nouns map[string]*spec.NounDef
+}
+
+func (tr *testResolver) GetSpec(verb, noun string) *spec.CommandSpec         { return nil }
+func (tr *testResolver) GetNoun(noun string) *spec.NounDef                   { return tr.nouns[noun] }
+func (tr *testResolver) ResolveNounAlias(alias string) string                { return "" }
+func (tr *testResolver) GetVerbInfos() []spec.VerbInfo                       { return nil }
+func (tr *testResolver) GetModuleMetas() []spec.ModuleMeta                   { return nil }
+func (tr *testResolver) GetAllSpecs() []*spec.CommandSpec                    { return nil }
+func (tr *testResolver) GetSpecsForModule(module string) []*spec.CommandSpec { return nil }
+func (tr *testResolver) ResolveTextFormatter(id string) cmdctx.TextFormatterFn {
+	return nil
+}
+func (tr *testResolver) ResolveBodyFn(id string) cmdctx.CreateBodyFn         { return nil }
+func (tr *testResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn { return nil }
+func (tr *testResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)    { return nil, nil }
+func (tr *testResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn { return nil }
+func (tr *testResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn {
+	return nil
+}
+func (tr *testResolver) RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error) {
+	return nil, nil
+}
+func (tr *testResolver) FormatList(ctx *cmdctx.Ctx, rows []any, fields []spec.FieldDef, columnIDs []string) error {
+	return nil
+}
+func (tr *testResolver) FetchItems(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, pf cmdctx.PagingFlags) ([]any, error) {
+	return nil, nil
+}
+func (tr *testResolver) ResolveCommandFields(cs *spec.CommandSpec) []spec.FieldDef { return nil }
+
+func newTestResolver(nouns ...*spec.NounDef) *testResolver {
+	m := make(map[string]*spec.NounDef)
+	for _, n := range nouns {
+		m[n.Noun] = n
+	}
+	return &testResolver{nouns: m}
+}
+
+func TestResolveNounDef_NilResolver(t *testing.T) {
+	ctx := &cmdctx.Ctx{Noun: "pipeline"}
+	if got := resolveNounDef(ctx); got != nil {
+		t.Fatalf("expected nil from nil resolver, got %v", got)
+	}
+}
+
+func TestResolveNounDef_UsesFieldsNoun(t *testing.T) {
+	nd := &spec.NounDef{Noun: "stage", Fields: []spec.FieldDef{{ID: "id", Expr: "it.id"}}}
+	ctx := &cmdctx.Ctx{
+		Noun:       "pipeline",
+		FieldsNoun: "stage",
+		Resolver:   newTestResolver(nd),
+	}
+	got := resolveNounDef(ctx)
+	if got == nil || got.Noun != "stage" {
+		t.Fatalf("resolveNounDef with FieldsNoun = %v, want stage", got)
+	}
+}
+
+func TestResolveNounDef_UsesNounWhenNoFieldsNoun(t *testing.T) {
+	nd := &spec.NounDef{Noun: "pipeline", Fields: []spec.FieldDef{{ID: "id", Expr: "it.id"}}}
+	ctx := &cmdctx.Ctx{Noun: "pipeline", Resolver: newTestResolver(nd)}
+	got := resolveNounDef(ctx)
+	if got == nil || got.Noun != "pipeline" {
+		t.Fatalf("resolveNounDef = %v, want pipeline", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveFieldsForCommand
+// ---------------------------------------------------------------------------
+
+func TestResolveFieldsForCommand_NilEndpoint(t *testing.T) {
+	ctx := &cmdctx.Ctx{Noun: "pipeline", Resolver: newTestResolver()}
+	if got := resolveFieldsForCommand(ctx, nil); got != nil {
+		t.Fatalf("expected nil for nil endpoint, got %v", got)
+	}
+}
+
+func TestResolveFieldsForCommand_NoFields(t *testing.T) {
+	ctx := &cmdctx.Ctx{Noun: "pipeline", Resolver: newTestResolver()}
+	ep := &spec.EndpointSpec{NoFields: true}
+	if got := resolveFieldsForCommand(ctx, ep); got != nil {
+		t.Fatalf("expected nil for NoFields=true, got %v", got)
+	}
+}
+
+func TestResolveFieldsForCommand_NilResolver(t *testing.T) {
+	ctx := &cmdctx.Ctx{Noun: "pipeline"}
+	ep := &spec.EndpointSpec{}
+	if got := resolveFieldsForCommand(ctx, ep); got != nil {
+		t.Fatalf("expected nil for nil resolver, got %v", got)
+	}
+}
+
+func TestResolveFieldsForCommand_BaseFields(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Expr: "it.name"},
+		{ID: "status", Expr: "it.status"},
+	}
+	nd := &spec.NounDef{Noun: "pipeline", Fields: fields}
+	ctx := &cmdctx.Ctx{Noun: "pipeline", Resolver: newTestResolver(nd)}
+	ep := &spec.EndpointSpec{}
+	got := resolveFieldsForCommand(ctx, ep)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(got))
+	}
+}
+
+func TestResolveFieldsForCommand_FieldsSubset(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Expr: "it.name"},
+		{ID: "status", Expr: "it.status"},
+		{ID: "id", Expr: "it.id"},
+	}
+	nd := &spec.NounDef{Noun: "pipeline", Fields: fields}
+	ctx := &cmdctx.Ctx{Noun: "pipeline", Resolver: newTestResolver(nd)}
+	ep := &spec.EndpointSpec{FieldsSubset: []string{"name", "id"}}
+	got := resolveFieldsForCommand(ctx, ep)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fields after subset, got %d", len(got))
+	}
+}
+
+func TestResolveFieldsForCommand_FieldsExtra(t *testing.T) {
+	fields := []spec.FieldDef{{ID: "name", Expr: "it.name"}}
+	nd := &spec.NounDef{Noun: "pipeline", Fields: fields}
+	ctx := &cmdctx.Ctx{Noun: "pipeline", Resolver: newTestResolver(nd)}
+	extra := spec.FieldDef{ID: "extra_col", Expr: "it.extra"}
+	ep := &spec.EndpointSpec{FieldsExtra: []spec.FieldDef{extra}}
+	got := resolveFieldsForCommand(ctx, ep)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fields (base+extra), got %d", len(got))
+	}
+	if got[1].ID != "extra_col" {
+		t.Fatalf("expected extra_col as second field, got %q", got[1].ID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PrintFieldTable
+// ---------------------------------------------------------------------------
+
+func TestPrintFieldTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := PrintFieldTable(&buf, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No fields") {
+		t.Fatalf("expected 'No fields' message, got: %q", buf.String())
+	}
+}
+
+func TestPrintFieldTable_WithFields(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Expr: "it.name"},
+		{ID: "status", Label: "Status Label", Expr: "it.status"},
+	}
+	var buf bytes.Buffer
+	if err := PrintFieldTable(&buf, fields); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "name") {
+		t.Errorf("expected 'name' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "Status Label") {
+		t.Errorf("expected 'Status Label' in output, got: %q", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveCommandFields (Registry method)
+// ---------------------------------------------------------------------------
+
+func TestResolveCommandFields_NilEndpoint(t *testing.T) {
+	r := New()
+	cs := &spec.CommandSpec{Command: "list pipeline", Verb: VerbList, Noun: "pipeline"}
+	if got := r.ResolveCommandFields(cs); got != nil {
+		t.Fatalf("expected nil for nil endpoint, got %v", got)
+	}
+}
+
+func TestResolveCommandFields_NounNotRegistered(t *testing.T) {
+	r := New()
+	cs := &spec.CommandSpec{Noun: "pipeline", Endpoint: &spec.EndpointSpec{}}
+	if got := r.ResolveCommandFields(cs); got != nil {
+		t.Fatalf("expected nil for unregistered noun, got %v", got)
+	}
+}
+
+func TestResolveCommandFields_HappyPath(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{
+		Noun:   "pipeline",
+		Fields: []spec.FieldDef{{ID: "name", Expr: "it.name"}, {ID: "id", Expr: "it.id"}},
+	})
+	cs := &spec.CommandSpec{Noun: "pipeline", Endpoint: &spec.EndpointSpec{}}
+	got := r.ResolveCommandFields(cs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fields, got %d: %v", len(got), got)
+	}
+}
+
+func TestResolveCommandFields_WithSubsetAndExtra(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{
+		Noun: "pipeline",
+		Fields: []spec.FieldDef{
+			{ID: "name", Expr: "it.name"},
+			{ID: "status", Expr: "it.status"},
+		},
+	})
+	cs := &spec.CommandSpec{
+		Noun: "pipeline",
+		Endpoint: &spec.EndpointSpec{
+			FieldsSubset: []string{"name"},
+			FieldsExtra:  []spec.FieldDef{{ID: "extra", Expr: "it.extra"}},
+		},
+	}
+	got := r.ResolveCommandFields(cs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 (1 subset + 1 extra), got %d", len(got))
+	}
+}
+
+func TestResolveCommandFields_FieldsNounOverride(t *testing.T) {
+	r := New()
+	r.RegisterNoun(spec.NounDef{Noun: "pipeline"})
+	r.RegisterNoun(spec.NounDef{
+		Noun:   "stage",
+		Fields: []spec.FieldDef{{ID: "stage_id", Expr: "it.id"}},
+	})
+	cs := &spec.CommandSpec{Noun: "pipeline", FieldsNoun: "stage", Endpoint: &spec.EndpointSpec{}}
+	got := r.ResolveCommandFields(cs)
+	if len(got) != 1 || got[0].ID != "stage_id" {
+		t.Fatalf("expected stage field via FieldsNoun, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MutableFields
+// ---------------------------------------------------------------------------
+
+func TestMutableFields_NilNoun(t *testing.T) {
+	if got := MutableFields(nil); got != nil {
+		t.Fatalf("expected nil for nil noun, got %v", got)
+	}
+}
+
+func TestMutableFields_FiltersNonMutable(t *testing.T) {
+	nd := &spec.NounDef{Fields: []spec.FieldDef{
+		{ID: "name", Expr: "it.name", MutablePath: "name"},
+		{ID: "status", Expr: "it.status"}, // not mutable
+	}}
+	got := MutableFields(nd)
+	if len(got) != 1 || got[0].ID != "name" {
+		t.Fatalf("MutableFields = %v, want only 'name'", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PrintMutableFieldTable
+// ---------------------------------------------------------------------------
+
+func TestPrintMutableFieldTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := PrintMutableFieldTable(&buf, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No mutable") {
+		t.Fatalf("expected 'No mutable' message, got: %q", buf.String())
+	}
+}
+
+func TestPrintMutableFieldTable_WithFields(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Expr: "it.name", MutablePath: "name"},
+		{ID: "tags", Expr: "it.tags", MutablePath: "tags", FieldType: "list"},
+	}
+	var buf bytes.Buffer
+	if err := PrintMutableFieldTable(&buf, fields); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "name") {
+		t.Errorf("expected 'name' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "list") {
+		t.Errorf("expected 'list' field type in output, got: %q", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildTspec
+// ---------------------------------------------------------------------------
+
+func TestBuildTspec_EmptyFields(t *testing.T) {
+	if got := buildTspec(nil, nil); got != nil {
+		t.Fatalf("buildTspec(nil, nil) = %v, want nil", got)
+	}
+}
+
+func TestBuildTspec_AllFieldsWhenNoColumnIDs(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Expr: "it.name"},
+		{ID: "status", Expr: "it.status"},
+	}
+	got := buildTspec(nil, fields)
+	if got == nil || len(got.Columns) != 2 {
+		t.Fatalf("buildTspec(nil, fields) = %v, want 2 columns", got)
+	}
+}
+
+func TestBuildTspec_SubsetByColumnIDs(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Expr: "it.name"},
+		{ID: "status", Expr: "it.status"},
+		{ID: "id", Expr: "it.id"},
+	}
+	got := buildTspec([]string{"name", "id"}, fields)
+	if got == nil || len(got.Columns) != 2 {
+		t.Fatalf("buildTspec with columnIDs = %v, want 2 columns", got)
+	}
+	if got.Columns[0].Header != "Name" {
+		t.Errorf("first column header = %q, want %q", got.Columns[0].Header, "Name")
+	}
+}
+
+func TestBuildTspec_UnknownColumnIDSkipped(t *testing.T) {
+	fields := []spec.FieldDef{{ID: "name", Expr: "it.name"}}
+	got := buildTspec([]string{"name", "nonexistent"}, fields)
+	if got == nil || len(got.Columns) != 1 {
+		t.Fatalf("buildTspec: non-existent column ID should be skipped, got %v", got)
+	}
+}
+
+func TestBuildTspec_AllColumnIDsUnknown(t *testing.T) {
+	fields := []spec.FieldDef{{ID: "name", Expr: "it.name"}}
+	got := buildTspec([]string{"nonexistent"}, fields)
+	if got != nil {
+		t.Fatalf("buildTspec: all unknown column IDs should return nil, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FieldsToTableColumns
+// ---------------------------------------------------------------------------
+
+func TestFieldsToTableColumns(t *testing.T) {
+	fields := []spec.FieldDef{
+		{ID: "name", Label: "Name", Expr: "it.name", Align: "left", FieldType: "scalar", WidthMax: 30},
+		{ID: "status", Expr: "it.status"},
+	}
+	cols := FieldsToTableColumns(fields)
+	if len(cols) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(cols))
+	}
+	if cols[0].Header != "Name" || cols[0].Expr != "it.name" || cols[0].Align != "left" || cols[0].WidthMax != 30 {
+		t.Errorf("first column = %v, incorrect fields", cols[0])
+	}
+	if cols[1].Header != "Status" {
+		t.Errorf("second column header = %q, want %q", cols[1].Header, "Status")
+	}
+}

--- a/pkg/registry/qualify_test.go
+++ b/pkg/registry/qualify_test.go
@@ -1,0 +1,86 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/spec"
+)
+
+func noopWorkflow(*cmdctx.Ctx) error { return nil }
+
+func TestQualify_ShortIDNamespaced(t *testing.T) {
+	r := New()
+	r.Module("core").RegisterWorkflow("login", noopWorkflow)
+	if _, ok := r.workflows["core:login"]; !ok {
+		t.Fatal(`expected workflow registered as "core:login"`)
+	}
+}
+
+func TestQualify_CrossModulePrefixRejected(t *testing.T) {
+	r := New()
+	r.Module("gitops").RegisterWorkflow("pipeline:foo", noopWorkflow)
+	if _, ok := r.workflows["pipeline:foo"]; ok {
+		t.Fatal("cross-module workflow must not be registered")
+	}
+	if len(r.initErrs) == 0 {
+		t.Fatal("expected init error for cross-module prefix")
+	}
+	if !strings.Contains(r.initErrs[0], `has prefix "pipeline" but module is "gitops"`) {
+		t.Fatalf("init error %q missing expected substring", r.initErrs[0])
+	}
+}
+
+func TestQualify_CorePrefixRegistrationRejected(t *testing.T) {
+	r := New()
+	r.Module("core").RegisterWorkflow("core:login", noopWorkflow)
+	if _, ok := r.workflows["core:login"]; ok {
+		t.Fatal("module must not register with reserved core: prefix")
+	}
+	if len(r.initErrs) == 0 {
+		t.Fatal("expected init error for core: registration")
+	}
+	if !strings.Contains(r.initErrs[0], `cannot register "core:login" with reserved prefix "core"`) {
+		t.Fatalf("init error %q missing expected substring", r.initErrs[0])
+	}
+}
+
+func TestQualify_CorePrefixSpecPassthrough(t *testing.T) {
+	r := New()
+	r.RegisterWorkflow("core:shared", noopWorkflow)
+	cs := &spec.CommandSpec{
+		Command:     "execute shared",
+		Verb:        VerbExecute,
+		Noun:        "shared",
+		Module:      "pipeline",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  "core:shared",
+	}
+	if err := r.Module("pipeline").Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if cs.WorkflowID != "core:shared" {
+		t.Fatalf("WorkflowID = %q, want %q", cs.WorkflowID, "core:shared")
+	}
+	if err := r.CheckFunctions(); err != nil {
+		t.Fatalf("CheckFunctions() = %v, want nil", err)
+	}
+}
+
+func TestQualify_MultipleColonsRejected(t *testing.T) {
+	r := New()
+	r.Module("gitops").RegisterWorkflow("gitops:foo:bar", noopWorkflow)
+	if _, ok := r.workflows["gitops:foo:bar"]; ok {
+		t.Fatal("workflow with multiple colons must not be registered")
+	}
+	if len(r.initErrs) == 0 {
+		t.Fatal("expected init error for multiple colons")
+	}
+	if !strings.Contains(r.initErrs[0], "cannot contain more than one colon") {
+		t.Fatalf("init error %q missing expected substring", r.initErrs[0])
+	}
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,1091 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/harness/cli/pkg/auth"
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/hbase"
+	"github.com/harness/cli/pkg/spec"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func wfSpec(verb, noun, module string) *spec.CommandSpec {
+	return &spec.CommandSpec{
+		Command:     verb + " " + noun,
+		Verb:        verb,
+		Noun:        noun,
+		Module:      module,
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  "test:noop",
+	}
+}
+
+func registryWithNoop(t *testing.T) *Registry {
+	t.Helper()
+	r := New()
+	r.RegisterWorkflow("test:noop", func(*cmdctx.Ctx) error { return nil })
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// New
+// ---------------------------------------------------------------------------
+
+// TestNew_StrictYAML: env off → false, env on → true.
+func TestNew_StrictYAML(t *testing.T) {
+	tests := []struct {
+		envVal string
+		want   bool
+	}{
+		{"0", false},
+		{"1", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.envVal, func(t *testing.T) {
+			t.Setenv(hbase.EnvCheckSpecs, tc.envVal)
+			r := New()
+			if r.StrictYAML != tc.want {
+				t.Errorf("StrictYAML = %v, want %v", r.StrictYAML, tc.want)
+			}
+		})
+	}
+}
+
+func TestNew_MapsInitialised(t *testing.T) {
+	r := New()
+	if r.specs == nil || r.nouns == nil || r.workflows == nil {
+		t.Fatal("New() must initialise internal maps")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SetModuleMeta / GetModuleMetas / externalBinaryFor
+// ---------------------------------------------------------------------------
+
+func TestSetModuleMeta_AppendsAndSorts(t *testing.T) {
+	r := New()
+	r.SetModuleMeta(spec.ModuleMeta{Name: "pipeline"})
+	r.SetModuleMeta(spec.ModuleMeta{Name: "core"})
+	metas := r.GetModuleMetas()
+	if len(metas) != 2 {
+		t.Fatalf("GetModuleMetas() len = %d, want 2", len(metas))
+	}
+	if metas[0].Name != "core" {
+		t.Errorf("first module = %q, want %q after SortModules", metas[0].Name, "core")
+	}
+}
+
+func TestGetModuleMetas_ReturnsCopy(t *testing.T) {
+	r := New()
+	r.SetModuleMeta(spec.ModuleMeta{Name: "pipeline"})
+	a := r.GetModuleMetas()
+	a[0].Name = "mutated"
+	if b := r.GetModuleMetas(); b[0].Name == "mutated" {
+		t.Fatal("GetModuleMetas() must return a copy, not a reference to the internal slice")
+	}
+}
+
+// TestExternalBinaryFor: three branches differ only in IsMainBinary + whether the module
+// is known — pure table.
+func TestExternalBinaryFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		isMainBinary bool
+		moduleName   string // non-empty → SetModuleMeta with ExternalBinary "harness-har"
+		lookup       string
+		want         string
+	}{
+		{name: "not_main_binary", isMainBinary: false, moduleName: "har", lookup: "har", want: ""},
+		{name: "main_binary_known_module", isMainBinary: true, moduleName: "har", lookup: "har", want: "harness-har"},
+		{name: "main_binary_unknown_module", isMainBinary: true, moduleName: "", lookup: "unknown", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			r.IsMainBinary = tc.isMainBinary
+			if tc.moduleName != "" {
+				r.SetModuleMeta(spec.ModuleMeta{Name: tc.moduleName, ExternalBinary: "harness-har"})
+			}
+			if got := r.externalBinaryFor(tc.lookup); got != tc.want {
+				t.Errorf("externalBinaryFor(%q) = %q, want %q", tc.lookup, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RegisterNoun
+// ---------------------------------------------------------------------------
+
+func TestRegisterNoun_HappyPath(t *testing.T) {
+	r := New()
+	nd := spec.NounDef{Noun: "pipeline", NounAliases: []string{"pipelines"}}
+	if err := r.RegisterNoun(nd); err != nil {
+		t.Fatalf("RegisterNoun: %v", err)
+	}
+	if got := r.GetNoun("pipeline"); got == nil || got.Noun != "pipeline" {
+		t.Fatal("GetNoun returned nil after successful RegisterNoun")
+	}
+}
+
+func TestRegisterNoun_AliasesRegistered(t *testing.T) {
+	r := New()
+	nd := spec.NounDef{Noun: "pipeline", NounAliases: []string{"pipelines", "pl"}}
+	if err := r.RegisterNoun(nd); err != nil {
+		t.Fatalf("RegisterNoun: %v", err)
+	}
+	for _, alias := range []string{"pipelines", "pl"} {
+		if got := r.ResolveNounAlias(alias); got != "pipeline" {
+			t.Errorf("ResolveNounAlias(%q) = %q, want %q", alias, got, "pipeline")
+		}
+	}
+}
+
+// TestRegisterNoun_Errors: four error branches share the same call shape (setup + RegisterNoun
+// → err containing wantSubstring).
+func TestRegisterNoun_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(*Registry)
+		nd      spec.NounDef
+		wantErr string
+	}{
+		{
+			name:    "duplicate_noun",
+			setup:   func(r *Registry) { r.RegisterNoun(spec.NounDef{Noun: "pipeline"}) },
+			nd:      spec.NounDef{Noun: "pipeline"},
+			wantErr: `duplicate noun "pipeline"`,
+		},
+		{
+			name:    "alias_conflicts_with_noun",
+			setup:   func(r *Registry) { r.RegisterNoun(spec.NounDef{Noun: "pr"}) },
+			nd:      spec.NounDef{Noun: "pullrequest", NounAliases: []string{"pr"}},
+			wantErr: "conflicts with existing noun",
+		},
+		{
+			name:    "alias_conflicts_with_alias",
+			setup:   func(r *Registry) { r.RegisterNoun(spec.NounDef{Noun: "pr", NounAliases: []string{"prs"}}) },
+			nd:      spec.NounDef{Noun: "pullrequest", NounAliases: []string{"prs"}},
+			wantErr: "already claimed by noun",
+		},
+		{
+			name:    "invalid_field_missing_expr",
+			setup:   func(*Registry) {},
+			nd:      spec.NounDef{Noun: "bad", Fields: []spec.FieldDef{{ID: "name", Expr: ""}}},
+			wantErr: "expr is required",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			tc.setup(r)
+			err := r.RegisterNoun(tc.nd)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("RegisterNoun err = %v, want to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetNoun / ResolveNounAlias
+// ---------------------------------------------------------------------------
+
+func TestGetNoun_NotFound(t *testing.T) {
+	r := New()
+	if got := r.GetNoun("nonexistent"); got != nil {
+		t.Fatalf("GetNoun unknown = %v, want nil", got)
+	}
+}
+
+func TestResolveNounAlias_NotFound(t *testing.T) {
+	r := New()
+	if got := r.ResolveNounAlias("nothing"); got != "" {
+		t.Errorf("ResolveNounAlias unknown = %q, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Register — side-effect tests stay separate; error tests are grouped
+// ---------------------------------------------------------------------------
+
+func TestRegister_HappyPath(t *testing.T) {
+	r := registryWithNoop(t)
+	if err := r.Register(wfSpec(VerbCreate, "pipeline", "pipeline")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+}
+
+// TestRegister_Errors: four error paths share the same assertion shape (err containing
+// wantSubstring). Setups differ, so t.Run with a setup func.
+func TestRegister_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(*Registry)
+		cs      func() *spec.CommandSpec
+		wantErr string
+	}{
+		{
+			name:  "unknown_verb",
+			setup: func(*Registry) {},
+			cs: func() *spec.CommandSpec {
+				return &spec.CommandSpec{Command: "frobnicate pipeline", Verb: "frobnicate", Noun: "pipeline", Module: "pipeline"}
+			},
+			wantErr: "not in the allowed verb set",
+		},
+		{
+			name:  "external_flag_rejected",
+			setup: func(*Registry) {},
+			cs: func() *spec.CommandSpec {
+				return &spec.CommandSpec{Command: "create pipeline", Verb: VerbCreate, Noun: "pipeline", Module: "pipeline", External: true}
+			},
+			wantErr: "External must not be set before registration",
+		},
+		{
+			name: "duplicate_leaf_verb",
+			setup: func(r *Registry) {
+				r.RegisterWorkflow("test:noop", func(*cmdctx.Ctx) error { return nil })
+				r.Register(&spec.CommandSpec{Command: "version", Verb: VerbVersion, Module: "core", HandlerType: spec.HandlerWorkflow, WorkflowID: "test:noop"})
+			},
+			cs: func() *spec.CommandSpec {
+				return &spec.CommandSpec{Command: "version", Verb: VerbVersion, Module: "core", HandlerType: spec.HandlerWorkflow, WorkflowID: "test:noop"}
+			},
+			wantErr: "duplicate leaf verb",
+		},
+		{
+			name: "duplicate_noun_verb",
+			setup: func(r *Registry) {
+				r.RegisterWorkflow("test:noop", func(*cmdctx.Ctx) error { return nil })
+				r.Register(wfSpec(VerbCreate, "pipeline", "pipeline"))
+			},
+			cs:      func() *spec.CommandSpec { return wfSpec(VerbCreate, "pipeline", "pipeline") },
+			wantErr: "duplicate command",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			tc.setup(r)
+			if err := r.Register(tc.cs()); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Register() err = %v, want to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegister_DevOnlySkippedInProd(t *testing.T) {
+	if hbase.IsDev() {
+		t.Skip("skip in dev build where DevOnly commands are allowed")
+	}
+	r := registryWithNoop(t)
+	cs := wfSpec(VerbCreate, "pipeline", "pipeline")
+	cs.DevOnly = true
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("DevOnly Register in prod should return nil, got %v", err)
+	}
+	if r.GetSpec(VerbCreate, "pipeline") != nil {
+		t.Fatal("DevOnly command must not appear in registry in a prod build")
+	}
+}
+
+func TestRegister_VerbHandlerDefaultsToVerb(t *testing.T) {
+	r := registryWithNoop(t)
+	cs := wfSpec(VerbCreate, "pipeline", "pipeline")
+	cs.VerbHandler = ""
+	r.Register(cs)
+	if cs.VerbHandler != VerbCreate {
+		t.Errorf("VerbHandler = %q, want %q", cs.VerbHandler, VerbCreate)
+	}
+}
+
+func TestRegister_IsMainBinarySetsExternal(t *testing.T) {
+	r := registryWithNoop(t)
+	r.IsMainBinary = true
+	r.SetModuleMeta(spec.ModuleMeta{Name: "har", ExternalBinary: "harness-har"})
+	cs := wfSpec(VerbList, "artifact", "har")
+	if err := r.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if !cs.External {
+		t.Fatal("Register must set External=true when IsMainBinary and module has ExternalBinary")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetSpec / GetAllSpecs / GetSpecsForModule
+// ---------------------------------------------------------------------------
+
+func TestGetSpec_Found(t *testing.T) {
+	r := registryWithNoop(t)
+	r.Register(wfSpec(VerbCreate, "pipeline", "pipeline"))
+	got := r.GetSpec(VerbCreate, "pipeline")
+	if got == nil || got.Noun != "pipeline" {
+		t.Errorf("GetSpec(VerbCreate, pipeline) = %v, want non-nil spec with noun=pipeline", got)
+	}
+}
+
+func TestGetSpec_NotFound(t *testing.T) {
+	if got := New().GetSpec(VerbCreate, "nonexistent"); got != nil {
+		t.Fatalf("GetSpec unknown = %v, want nil", got)
+	}
+}
+
+func TestGetSpec_NounVariant(t *testing.T) {
+	r := registryWithNoop(t)
+	cs := wfSpec(VerbList, "pr", "code")
+	cs.NounVariant = "mine"
+	cs.Command = "list pr:mine"
+	r.Register(cs)
+	if got := r.GetSpec(VerbList, "pr:mine"); got == nil {
+		t.Fatal("GetSpec(VerbList, \"pr:mine\") returned nil")
+	}
+}
+
+func TestGetAllSpecs(t *testing.T) {
+	r := registryWithNoop(t)
+	r.Register(wfSpec(VerbCreate, "pipeline", "pipeline"))
+	r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+	if got := r.GetAllSpecs(); len(got) != 2 {
+		t.Errorf("GetAllSpecs() len = %d, want 2", len(got))
+	}
+}
+
+func TestGetSpecsForModule(t *testing.T) {
+	r := registryWithNoop(t)
+	r.Register(wfSpec(VerbCreate, "pipeline", "pipeline"))
+	r.Register(wfSpec(VerbCreate, "artifact", "har"))
+	got := r.GetSpecsForModule("pipeline")
+	if len(got) != 1 || got[0].Noun != "pipeline" {
+		t.Errorf("GetSpecsForModule(\"pipeline\") = %v, want single pipeline spec", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetVerbInfos
+// ---------------------------------------------------------------------------
+
+func TestGetVerbInfos_OnlyRegisteredVerbs(t *testing.T) {
+	r := registryWithNoop(t)
+	r.Register(wfSpec(VerbCreate, "pipeline", "pipeline"))
+	for _, vi := range r.GetVerbInfos() {
+		if vi.Verb == VerbCreate {
+			return
+		}
+	}
+	t.Fatal("GetVerbInfos() did not include VerbCreate")
+}
+
+func TestGetVerbInfos_EmptyVerbsExcluded(t *testing.T) {
+	r := New()
+	for _, vi := range r.GetVerbInfos() {
+		if len(r.specs[vi.Verb]) == 0 {
+			t.Errorf("GetVerbInfos includes verb %q with no registered specs", vi.Verb)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolve* helpers — five nil-return tests grouped; FetchFn variants stay separate
+// ---------------------------------------------------------------------------
+
+// TestResolveMapFns_NotFound: five resolver methods all return a nil func value for
+// unregistered keys. Use a bool-returning closure to avoid the interface-nil pitfall.
+func TestResolveMapFns_NotFound(t *testing.T) {
+	tests := []struct {
+		name  string
+		isNil func(*Registry) bool
+	}{
+		{"text_formatter", func(r *Registry) bool { return r.ResolveTextFormatter("missing") == nil }},
+		{"body_fn", func(r *Registry) bool { return r.ResolveBodyFn("missing") == nil }},
+		{"query_params_fn", func(r *Registry) bool { return r.ResolveQueryParamsFn("missing") == nil }},
+		{"flag_resolve_fn", func(r *Registry) bool { return r.ResolveFlagResolveFn("missing") == nil }},
+		{"endpoint_validator", func(r *Registry) bool { return r.ResolveEndpointValidator("missing") == nil }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.isNil(New()) {
+				t.Errorf("Resolve %s(missing) should return nil for unregistered key", tc.name)
+			}
+		})
+	}
+}
+
+func TestResolveFetchFn_NotFound(t *testing.T) {
+	if _, err := New().ResolveFetchFn("missing"); err == nil {
+		t.Fatal("expected error for unregistered fetch fn")
+	}
+}
+
+func TestResolveFetchFn_Found(t *testing.T) {
+	r := New()
+	r.RegisterFetchFn("test:fetch", func(*cmdctx.Ctx, *spec.EndpointSpec, int, int, any) (*cmdctx.PageResult, error) {
+		return nil, nil
+	})
+	fn, err := r.ResolveFetchFn("test:fetch")
+	if err != nil || fn == nil {
+		t.Fatalf("ResolveFetchFn: err=%v fn=%v", err, fn)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Register* panic on duplicate — all 9 grouped by shared structure
+// ---------------------------------------------------------------------------
+
+// TestRegisterFns_PanicOnDuplicate: every Register* method panics when the same key is
+// registered twice. The `register` func is called once to seed, once to trigger the panic.
+func TestRegisterFns_PanicOnDuplicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		register func(*Registry)
+	}{
+		{"workflow", func(r *Registry) {
+			r.RegisterWorkflow("core:wf", func(*cmdctx.Ctx) error { return nil })
+		}},
+		{"body_fn", func(r *Registry) {
+			r.RegisterBodyFn("core:b", func(*cmdctx.Ctx) (any, error) { return nil, nil })
+		}},
+		{"query_params_fn", func(r *Registry) {
+			r.RegisterQueryParamsFn("core:q", func(*cmdctx.Ctx) (map[string]string, error) { return nil, nil })
+		}},
+		{"follow_fn", func(r *Registry) {
+			r.RegisterFollowFn("core:f", func(*cmdctx.Ctx, any) error { return nil })
+		}},
+		{"fetch_fn", func(r *Registry) {
+			r.RegisterFetchFn("core:fetch", func(*cmdctx.Ctx, *spec.EndpointSpec, int, int, any) (*cmdctx.PageResult, error) {
+				return nil, nil
+			})
+		}},
+		{"flag_completion_fn", func(r *Registry) {
+			r.RegisterFlagCompletionFn("core:comp", func(*cmdctx.Ctx, []string, *pflag.FlagSet) ([]string, error) { return nil, nil })
+		}},
+		{"flag_resolve_fn", func(r *Registry) {
+			r.RegisterFlagResolveFn("core:rv", func(*cmdctx.Ctx, string) (string, error) { return "", nil })
+		}},
+		{"text_formatter", func(r *Registry) {
+			r.RegisterTextFormatter("core:tf", func(io.Writer, cmdctx.DataAccessor) error { return nil })
+		}},
+		{"endpoint_validator_fn", func(r *Registry) {
+			r.RegisterEndpointValidatorFn("core:ev", func(*cmdctx.Ctx, cmdctx.EndpointRequest) error { return nil })
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			tc.register(r) // first registration succeeds
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("expected panic on duplicate %s registration, got none", tc.name)
+				}
+			}()
+			tc.register(r) // duplicate — must panic
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unknownNounError
+// ---------------------------------------------------------------------------
+
+func TestUnknownNounError(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*Registry)
+		verb, noun  string
+		wantContain string // empty → assert "Did you mean:" is absent
+	}{
+		{
+			name: "noun_registered_wrong_verb",
+			setup: func(r *Registry) {
+				r.RegisterNoun(spec.NounDef{Noun: "pipeline"})
+				r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+			},
+			verb: VerbCreate, noun: "pipeline",
+			wantContain: `"pipeline" is not supported for "create"`,
+		},
+		{
+			name: "completely_unknown_noun",
+			setup: func(r *Registry) {
+				r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+			},
+			verb: VerbList, noun: "xyz",
+			wantContain: `"xyz" is not a valid noun for "list"`,
+		},
+		{
+			name: "suggests_close_match",
+			setup: func(r *Registry) {
+				r.RegisterNoun(spec.NounDef{Noun: "pipeline"})
+				r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+			},
+			verb: VerbList, noun: "pipelyne",
+			wantContain: "Did you mean:",
+		},
+		{
+			name: "no_suggestion_for_unrelated_input",
+			setup: func(r *Registry) {
+				r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+			},
+			verb: VerbList, noun: "zzzzzzz",
+			wantContain: "", // assert "Did you mean:" is absent
+		},
+		{
+			name: "alias_resolved_before_lookup",
+			setup: func(r *Registry) {
+				r.RegisterNoun(spec.NounDef{Noun: "pipeline", NounAliases: []string{"pipelines"}})
+				r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+			},
+			verb: VerbCreate, noun: "pipelines",
+			wantContain: "not supported for",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := registryWithNoop(t)
+			tc.setup(r)
+			err := r.unknownNounError(tc.verb, tc.noun)
+			if tc.wantContain == "" {
+				if strings.Contains(err.Error(), "Did you mean:") {
+					t.Errorf("expected no suggestion, got: %v", err)
+				}
+			} else if !strings.Contains(err.Error(), tc.wantContain) {
+				t.Errorf("err = %q, want to contain %q", err.Error(), tc.wantContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildUseString — pure table: zero setup variation, all inputs → output checks
+// ---------------------------------------------------------------------------
+
+func TestBuildUseString(t *testing.T) {
+	tests := []struct {
+		name        string
+		cs          *spec.CommandSpec
+		vs          VerbSpec
+		wantEqual   string
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:      "leaf_verb_no_noun",
+			cs:        &spec.CommandSpec{Verb: VerbVersion},
+			vs:        verbRegistry[VerbVersion],
+			wantEqual: VerbVersion,
+		},
+		{
+			name:      "verb_with_noun_no_id_requirement",
+			cs:        &spec.CommandSpec{Verb: VerbDescribe, Noun: "pipeline"},
+			vs:        verbRegistry[VerbDescribe],
+			wantEqual: "pipeline",
+		},
+		{
+			name:        "requires_id_default_label",
+			cs:          &spec.CommandSpec{Verb: VerbGet, Noun: "pipeline"},
+			vs:          verbRegistry[VerbGet],
+			wantContain: "<id>",
+		},
+		{
+			name:        "requires_id_custom_label",
+			cs:          &spec.CommandSpec{Verb: VerbGet, Noun: "pipeline", IdLabel: "<pipeline-id>"},
+			vs:          verbRegistry[VerbGet],
+			wantContain: "<pipeline-id>",
+		},
+		{
+			name:       "requires_id_suppressed_by_no_id",
+			cs:         &spec.CommandSpec{Verb: VerbGet, Noun: "pipeline", NoId: true},
+			vs:         verbRegistry[VerbGet],
+			wantAbsent: "<id>",
+		},
+		{
+			name:        "allows_id_optional_bracket",
+			cs:          &spec.CommandSpec{Verb: VerbCreate, Noun: "pipeline"},
+			vs:          verbRegistry[VerbCreate],
+			wantContain: "[id]",
+		},
+		{
+			name:        "allows_parentid_optional",
+			cs:          &spec.CommandSpec{Verb: VerbList, Noun: "stage"},
+			vs:          verbRegistry[VerbList],
+			wantContain: "[parentid]",
+		},
+		{
+			name:        "allows_parentid_required",
+			cs:          &spec.CommandSpec{Verb: VerbList, Noun: "stage", RequiresParentId: true},
+			vs:          verbRegistry[VerbList],
+			wantContain: "<parentid>",
+		},
+		{
+			name:        "allows_parentid_custom_label",
+			cs:          &spec.CommandSpec{Verb: VerbList, Noun: "stage", ParentIdLabel: "pipeline-id"},
+			vs:          verbRegistry[VerbList],
+			wantContain: "pipeline-id",
+		},
+		{
+			name:        "requires_id_with_args_label",
+			cs:          &spec.CommandSpec{Verb: VerbGet, Noun: "pipeline", HasArgs: true, ArgsLabel: "<file>"},
+			vs:          verbRegistry[VerbGet],
+			wantContain: "<file>",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildUseString(tc.cs, tc.vs)
+			if tc.wantEqual != "" && got != tc.wantEqual {
+				t.Errorf("buildUseString = %q, want %q", got, tc.wantEqual)
+			}
+			if tc.wantContain != "" && !strings.Contains(got, tc.wantContain) {
+				t.Errorf("buildUseString = %q, want to contain %q", got, tc.wantContain)
+			}
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Errorf("buildUseString = %q, should not contain %q", got, tc.wantAbsent)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildPagingFlags — pure table: same helper setup, differ in flags + paging spec
+// ---------------------------------------------------------------------------
+
+func makePagingFlagSet(t *testing.T) *pflag.FlagSet {
+	t.Helper()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Int("offset", 0, "")
+	fs.Int("limit", 0, "")
+	fs.Bool("all", false, "")
+	fs.Bool("count", false, "")
+	return fs
+}
+
+var countablePaging = &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageIndex, Countable: true}
+var notCountablePaging = &spec.PagingSpec{PagingStrategy: spec.PagingStrategyPageHeader}
+
+func TestBuildPagingFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		setFlags   func(*pflag.FlagSet)
+		paging     *spec.PagingSpec
+		wantErr    string
+		wantOffset int
+		wantLimit  int
+	}{
+		{
+			name:       "happy_path",
+			setFlags:   func(fs *pflag.FlagSet) { fs.Set("offset", "5"); fs.Set("limit", "10") },
+			paging:     countablePaging,
+			wantOffset: 5, wantLimit: 10,
+		},
+		{
+			name:     "negative_offset",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("offset", "-1") },
+			paging:   countablePaging,
+			wantErr:  "--offset must be non-negative",
+		},
+		{
+			name:     "negative_limit",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("limit", "-1") },
+			paging:   countablePaging,
+			wantErr:  "--limit must be non-negative",
+		},
+		{
+			name:     "all_on_non_countable",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("all", "true") },
+			paging:   notCountablePaging,
+			wantErr:  "--all is not supported",
+		},
+		{
+			name:     "count_on_non_countable",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("count", "true") },
+			paging:   notCountablePaging,
+			wantErr:  "--count is not supported",
+		},
+		{
+			name:     "all_incompatible_with_offset",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("all", "true"); fs.Set("offset", "5") },
+			paging:   countablePaging,
+			wantErr:  "--all is incompatible",
+		},
+		{
+			name:     "all_incompatible_with_limit",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("all", "true"); fs.Set("limit", "5") },
+			paging:   countablePaging,
+			wantErr:  "--all is incompatible",
+		},
+		{
+			name:     "count_incompatible_with_offset",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("count", "true"); fs.Set("offset", "5") },
+			paging:   countablePaging,
+			wantErr:  "--count is incompatible",
+		},
+		{
+			name:     "count_incompatible_with_all",
+			setFlags: func(fs *pflag.FlagSet) { fs.Set("count", "true"); fs.Set("all", "true") },
+			paging:   countablePaging,
+			wantErr:  "--count is incompatible",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := makePagingFlagSet(t)
+			tc.setFlags(fs)
+			pf, err := buildPagingFlags(fs, tc.paging)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("buildPagingFlags err = %v, want to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildPagingFlags unexpected error: %v", err)
+			}
+			if pf.Offset != tc.wantOffset || pf.Limit != tc.wantLimit {
+				t.Errorf("pf = %+v, want Offset=%d Limit=%d", pf, tc.wantOffset, tc.wantLimit)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildFlagValues — t.Run: setups differ (different CommandSpec + FlagSet per case)
+// ---------------------------------------------------------------------------
+
+func makeFlagSetForSpec(cs *spec.CommandSpec) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	for _, f := range cs.Flags {
+		if f.IsBool {
+			fs.Bool(f.Name, false, "")
+		} else if f.IsMulti {
+			fs.StringArray(f.Name, nil, "")
+		} else {
+			fs.String(f.Name, f.Default, "")
+		}
+	}
+	return fs
+}
+
+func TestBuildFlagValues(t *testing.T) {
+	t.Run("string_flag", func(t *testing.T) {
+		cs := &spec.CommandSpec{Flags: []spec.Flag{{Name: "env", Default: "dev"}}}
+		fs := makeFlagSetForSpec(cs)
+		fs.Set("env", "prod")
+		if got := buildFlagValues(fs, cs)["env"]; got != "prod" {
+			t.Errorf("fv[env] = %v, want prod", got)
+		}
+	})
+	t.Run("bool_flag", func(t *testing.T) {
+		cs := &spec.CommandSpec{Flags: []spec.Flag{{Name: "verbose", IsBool: true}}}
+		fs := makeFlagSetForSpec(cs)
+		fs.Set("verbose", "true")
+		if got := buildFlagValues(fs, cs)["verbose"]; got != true {
+			t.Errorf("fv[verbose] = %v, want true", got)
+		}
+	})
+	t.Run("multi_flag", func(t *testing.T) {
+		cs := &spec.CommandSpec{Flags: []spec.Flag{{Name: "tags", IsMulti: true}}}
+		fs := makeFlagSetForSpec(cs)
+		fs.Set("tags", "a")
+		tags, ok := buildFlagValues(fs, cs)["tags"].([]string)
+		if !ok || len(tags) == 0 {
+			t.Errorf("fv[tags] = %v, want non-empty []string", buildFlagValues(fs, cs)["tags"])
+		}
+	})
+	t.Run("builtin_page_flag_0indexed", func(t *testing.T) {
+		cs := &spec.CommandSpec{BuiltinFlags: spec.BuiltinFlags{Page: true}}
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.Int("page", 1, "")
+		fs.Set("page", "3")
+		if got := buildFlagValues(fs, cs)["page"]; got != 2 {
+			t.Errorf("fv[page] = %v, want 2 (0-indexed from page=3)", got)
+		}
+	})
+	t.Run("format_flag", func(t *testing.T) {
+		cs := &spec.CommandSpec{}
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("format", "", "")
+		fs.Set("format", "json")
+		if got := buildFlagValues(fs, cs)["format"]; got != "json" {
+			t.Errorf("fv[format] = %v, want json", got)
+		}
+	})
+	t.Run("file_flag", func(t *testing.T) {
+		cs := &spec.CommandSpec{}
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("file", "", "")
+		fs.Set("file", "/tmp/spec.yaml")
+		if got := buildFlagValues(fs, cs)["file"]; got != "/tmp/spec.yaml" {
+			t.Errorf("fv[file] = %v, want /tmp/spec.yaml", got)
+		}
+	})
+	t.Run("no_auth_injects_profile_org_project", func(t *testing.T) {
+		cs := &spec.CommandSpec{NoAuth: true}
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("profile", "", "")
+		fs.String("org", "", "")
+		fs.String("project", "", "")
+		fs.Set("profile", "prod")
+		if got := buildFlagValues(fs, cs)["profile"]; got != "prod" {
+			t.Errorf("fv[profile] = %v, want prod", got)
+		}
+	})
+	t.Run("no_auth_does_not_override_explicit_flag", func(t *testing.T) {
+		cs := &spec.CommandSpec{NoAuth: true, Flags: []spec.Flag{{Name: "org"}}}
+		fs := makeFlagSetForSpec(cs)
+		fs.String("project", "", "")
+		fs.Set("org", "from-explicit")
+		if got := buildFlagValues(fs, cs)["org"]; got != "from-explicit" {
+			t.Errorf("fv[org] = %v, want from-explicit", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// authTelemetryFields — pure table: same call, differ only in input + expected fields
+// ---------------------------------------------------------------------------
+
+func TestAuthTelemetryFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          *auth.ResolvedAuth
+		wantAccountID  string
+		wantTokenKind  string
+		wantAuthSource string
+	}{
+		{
+			name:  "nil_input_returns_empty_strings",
+			input: nil,
+		},
+		{
+			name: "env_source",
+			input: &auth.ResolvedAuth{
+				AccountID: "acc123",
+				Email:     "user@example.com",
+				TokenKind: auth.TokenKindPAT,
+				Source:    auth.SourceEnv,
+			},
+			wantAccountID:  "acc123",
+			wantTokenKind:  "pat",
+			wantAuthSource: "env",
+		},
+		{
+			name:           "profile_source",
+			input:          &auth.ResolvedAuth{Source: "profile:default", TokenKind: auth.TokenKindSAT},
+			wantTokenKind:  "sat",
+			wantAuthSource: "profile",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID, _, tokenKind, authSource := authTelemetryFields(tc.input)
+			if accountID != tc.wantAccountID {
+				t.Errorf("accountID = %q, want %q", accountID, tc.wantAccountID)
+			}
+			if tokenKind != tc.wantTokenKind {
+				t.Errorf("tokenKind = %q, want %q", tokenKind, tc.wantTokenKind)
+			}
+			if authSource != tc.wantAuthSource {
+				t.Errorf("authSource = %q, want %q", authSource, tc.wantAuthSource)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// telemetryAuth
+// ---------------------------------------------------------------------------
+
+// AuthAlreadySet checks pointer identity — stays separate from the nil-check cases.
+func TestTelemetryAuth_AuthAlreadySet(t *testing.T) {
+	a := &auth.ResolvedAuth{AccountID: "acc"}
+	if got := telemetryAuth(&spec.CommandSpec{}, &cmdctx.Ctx{Auth: a}); got != a {
+		t.Fatal("telemetryAuth should return ctx.Auth unchanged when it is already set")
+	}
+}
+
+func TestTelemetryAuth(t *testing.T) {
+	t.Run("no_auth_false_nil_auth_returns_nil", func(t *testing.T) {
+		got := telemetryAuth(&spec.CommandSpec{NoAuth: false}, &cmdctx.Ctx{Auth: nil})
+		if got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// misconfiguredCmd
+// ---------------------------------------------------------------------------
+
+func TestMisconfiguredCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		module  string
+		wantErr string
+	}{
+		{name: "known_module_prefix_in_error", module: "pipeline", wantErr: "misconfigured command"},
+		{name: "empty_module_falls_back_to_unknown", module: "", wantErr: "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "pipeline"}
+			cs := &spec.CommandSpec{Module: tc.module}
+			misconfiguredCmd(cmd, cs, "something broke")
+			if cmd.RunE == nil {
+				t.Fatal("misconfiguredCmd must set RunE")
+			}
+			err := cmd.RunE(cmd, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("RunE err = %v, want to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// moduleRegistrar — Register*, qualify error branches
+// ---------------------------------------------------------------------------
+
+func TestModuleRegistrar_RegisterWorkflow(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterWorkflow("mywf", func(*cmdctx.Ctx) error { return nil })
+	if _, ok := r.workflows["mymod:mywf"]; !ok {
+		t.Fatal("workflow not found under mymod:mywf after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterTextFormatter(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterTextFormatter("fmt", func(io.Writer, cmdctx.DataAccessor) error { return nil })
+	if r.ResolveTextFormatter("mymod:fmt") == nil {
+		t.Fatal("text formatter not found after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterBodyFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterBodyFn("body", func(*cmdctx.Ctx) (any, error) { return nil, nil })
+	if r.ResolveBodyFn("mymod:body") == nil {
+		t.Fatal("body_fn not found after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterQueryParamsFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterQueryParamsFn("qp", func(*cmdctx.Ctx) (map[string]string, error) { return nil, nil })
+	if r.ResolveQueryParamsFn("mymod:qp") == nil {
+		t.Fatal("query_params_fn not found after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterFollowFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterFollowFn("follow", func(*cmdctx.Ctx, any) error { return nil })
+	if _, ok := r.followFns["mymod:follow"]; !ok {
+		t.Fatal("follow_fn not found after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterFetchFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterFetchFn("fetch", func(*cmdctx.Ctx, *spec.EndpointSpec, int, int, any) (*cmdctx.PageResult, error) {
+		return nil, nil
+	})
+	if fn, err := r.ResolveFetchFn("mymod:fetch"); err != nil || fn == nil {
+		t.Fatalf("fetch_fn not found: err=%v fn=%v", err, fn)
+	}
+}
+
+func TestModuleRegistrar_RegisterFlagCompletionFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterFlagCompletionFn("comp", func(*cmdctx.Ctx, []string, *pflag.FlagSet) ([]string, error) { return nil, nil })
+	if _, ok := r.flagCompletionFns["mymod:comp"]; !ok {
+		t.Fatal("flag_completion_fn not found after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterFlagResolveFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterFlagResolveFn("rv", func(*cmdctx.Ctx, string) (string, error) { return "", nil })
+	if r.ResolveFlagResolveFn("mymod:rv") == nil {
+		t.Fatal("flag_resolve_fn not found after registration")
+	}
+}
+
+func TestModuleRegistrar_RegisterEndpointValidatorFn(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterEndpointValidatorFn("ev", func(*cmdctx.Ctx, cmdctx.EndpointRequest) error { return nil })
+	if r.ResolveEndpointValidator("mymod:ev") == nil {
+		t.Fatal("endpoint_validator_fn not found after registration")
+	}
+}
+
+func TestModuleRegistrar_QualifyErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		shortID string
+	}{
+		{
+			name:    "reserved core prefix rejected on register",
+			shortID: "core:wf",
+		},
+		{
+			name:    "wrong module prefix rejected",
+			shortID: "other:wf",
+		},
+		{
+			name:    "double colon rejected",
+			shortID: "mymod:x:y",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			m := r.Module("mymod")
+			m.RegisterWorkflow(tc.shortID, func(*cmdctx.Ctx) error { return nil })
+			if len(r.initErrs) == 0 {
+				t.Fatalf("expected initErr for shortID %q, got none", tc.shortID)
+			}
+		})
+	}
+}
+
+func TestModuleRegistrar_Register_QualifiesWorkflowID(t *testing.T) {
+	r := New()
+	m := r.Module("mymod")
+	m.RegisterWorkflow("mywf", func(*cmdctx.Ctx) error { return nil })
+	cs := &spec.CommandSpec{
+		Command:     "execute thing",
+		Verb:        VerbExecute,
+		Noun:        "thing",
+		HandlerType: spec.HandlerWorkflow,
+		WorkflowID:  "mywf", // short ID — should be qualified to mymod:mywf
+	}
+	if err := m.Register(cs); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if cs.WorkflowID != "mymod:mywf" {
+		t.Errorf("WorkflowID = %q, want %q", cs.WorkflowID, "mymod:mywf")
+	}
+	if cs.Module != "mymod" {
+		t.Errorf("Module = %q, want %q", cs.Module, "mymod")
+	}
+}

--- a/pkg/registry/scope_test.go
+++ b/pkg/registry/scope_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import "testing"
+
+func TestParseScopePrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		isList    bool
+		wantID    string
+		wantLevel string
+	}{
+		{
+			name:      "account dot prefix",
+			raw:       "account.foo",
+			wantID:    "foo",
+			wantLevel: "account",
+		},
+		{
+			name:      "org dot prefix",
+			raw:       "org.bar",
+			wantLevel: "org",
+			wantID:    "bar",
+		},
+		{
+			name:      "list bare account",
+			raw:       "account",
+			isList:    true,
+			wantID:    "",
+			wantLevel: "account",
+		},
+		{
+			name:      "non-list bare account",
+			raw:       "account",
+			wantID:    "account",
+			wantLevel: "project",
+		},
+		{
+			name:      "list bare org",
+			raw:       "org",
+			isList:    true,
+			wantID:    "",
+			wantLevel: "org",
+		},
+		{
+			name:      "non-list bare org treated as literal id",
+			raw:       "org",
+			wantID:    "org",
+			wantLevel: "project",
+		},
+		{
+			name:      "plain id has project level",
+			raw:       "my-resource",
+			wantID:    "my-resource",
+			wantLevel: "project",
+		},
+		{
+			name:      "empty string has project level",
+			raw:       "",
+			wantID:    "",
+			wantLevel: "project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotLevel := parseScopePrefix(tt.raw, tt.isList)
+			if gotID != tt.wantID || gotLevel != tt.wantLevel {
+				t.Fatalf("parseScopePrefix(%q, %v) = (%q, %q), want (%q, %q)",
+					tt.raw, tt.isList, gotID, gotLevel, tt.wantID, tt.wantLevel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds unit tests across the CLI core and module layers. Focus is on the spec-driven **registry/endpoint** execution path (HTTP dispatch, update strategies, mutations), plus targeted coverage for **login**, **gitops agent install**, and **pipeline log** handlers.
No production behavior changes — only test files
## What's covered
### `pkg/registry/`
- **`endpoint_test.go`** — `CallEndpoint`, file-body paths, YAML envelope, get-then-put / get-then-put-kv / set-fields update strategies, query/body param evaluation, mutations (`--set`/`--del`), validators, list/get dispatch. Most `endpoint.go` helpers at **90%+** coverage; `callEndpointFull` ~97%.
- **`registry_test.go`** — spec registration, noun aliases, verb wiring, `buildUseString`, paging/flag parsing, resolver lookups.
- **`fields_test.go`**, **`qualify_test.go`**, **`scope_test.go`** — field resolution and scope helpers.
- **`buildctx_workflow_test.go`**, **`checks_workflow_test.go`** — `buildCtx` validation (id parts, parent id, format flags, `--set`/`--del`), workflow spec checks.
### Modules
- **`modules/core/auth/login_test.go`** — non-interactive login, PAT validation, profile overwrite, registry URL fetch (httptest).
- **`modules/gitops/gitops_test.go`** — `gitops_agent:install` workflow (validation, GET path, full install path with mocked client).
- **`modules/pipeline/execution_log_test.go`** — pipeline log handler validation and completion helpers.