### PR TITLE
fix: use get-then-patch strategy for PATCH update commands

### DIFF
--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -451,7 +451,7 @@ commands:
     endpoint:
       method: PATCH
       path: /code/api/v1/repos/{{ctx.id}}
-      update_strategy: get-then-put
+      update_strategy: get-then-patch
       update_body_pick: it
       no_fields: true
       text_header: "\nUpdated repository {{ctx.id}}\n"
@@ -619,7 +619,7 @@ commands:
     endpoint:
       method: PATCH
       path: /code/api/v1/repos/{{ctx.idParts[0]}}/pullreq/{{ctx.idParts[1]}}
-      update_strategy: get-then-put
+      update_strategy: get-then-patch
       update_body_pick: it
       no_fields: true
       text_header: "\nUpdated PR #{{ctx.idParts[1]}}\n"

--- a/pkg/spec/governance.spec.yaml
+++ b/pkg/spec/governance.spec.yaml
@@ -140,7 +140,7 @@ commands:
       method: PATCH
       file_body: optional
       path: /pm/api/v1/policies/{{ctx.id}}
-      update_strategy: get-then-put
+      update_strategy: get-then-patch
       update_body_pick: it
       update_body_wrap: ""
       item_expr: it
@@ -227,7 +227,7 @@ commands:
       method: PATCH
       file_body: optional
       path: /pm/api/v1/policysets/{{ctx.id}}
-      update_strategy: get-then-put
+      update_strategy: get-then-patch
       update_body_pick: it
       update_body_wrap: ""
       item_expr: it


### PR DESCRIPTION
## Summary
- `update pr`, `update repository`, `update policy`, and `update policy_set` all declare `method: PATCH` but were wired to `update_strategy: get-then-put`.
- `get-then-put` only fires when `method == "PUT"` (`pkg/registry/endpoint.go`), and `get-then-patch` only fires when `method == "PATCH"`. With this mismatched pairing, neither branch matched, so these commands fell through to the generic dispatch path — whose `PATCH` case has no explicit handling and silently sends a `POST` instead.
- The API rejects that `POST` with `405 Method Not Allowed`, so all four commands were completely broken.
- Fix: set `update_strategy: get-then-patch` to match the declared `method: PATCH`, consistent with existing correct pairings (e.g. `fme.spec.yaml`).

## Verification
- `harness update pr <repo>/<pr_number> --set title=...` against a live PR: before the fix, `--debug` showed `POST .../pullreq/{id}` → `status=405`; after the fix, `GET` then `PATCH .../pullreq/{id}` → `status=200`.
- `go build ./cmd/harness/main-harness.go` and `go vet ./...` both clean.
- Confirmed no other `method: PATCH` + `update_strategy: get-then-put` mismatches remain across `pkg/spec/*.spec.yaml`.

## Test plan
- [x] Build succeeds
- [x] `go vet` clean
- [x] Manually verified `update pr` against the live API (200, not 405)
- [ ] Manually verify `update repository`, `update policy`, `update policy_set` if a reviewer has access to those resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)