### PR TITLE
 Feat : Adds three new `push artifact` commands to the `har` module.

### DIFF
--- a/modules/har/pkg/har/configure_maven.go
+++ b/modules/har/pkg/har/configure_maven.go
@@ -1,0 +1,116 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+func configureMaven(ctx *cmdctx.Ctx) error {
+	a := ctx.Auth
+	registryID := ctx.Id
+
+	registryURL := fmt.Sprintf("%s/pkg/%s/%s/maven", a.RegistryURL, a.AccountID, registryID)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home directory: %w", err)
+	}
+
+	m2Dir := filepath.Join(home, ".m2")
+	if err := os.MkdirAll(m2Dir, 0755); err != nil {
+		return fmt.Errorf("creating .m2 directory: %w", err)
+	}
+	settingsPath := filepath.Join(m2Dir, "settings.xml")
+
+	if err := writeMavenSettings(settingsPath, registryID, registryURL, a.PATToken); err != nil {
+		return fmt.Errorf("writing settings.xml: %w", err)
+	}
+
+	fmt.Printf("Configured Maven → %s (%s)\n", registryURL, settingsPath)
+	return nil
+}
+
+func writeMavenSettings(settingsPath, registryID, registryURL, authToken string) error {
+	type Server struct {
+		XMLName  xml.Name `xml:"server"`
+		ID       string   `xml:"id"`
+		Username string   `xml:"username"`
+		Password string   `xml:"password"`
+	}
+	type Mirror struct {
+		XMLName  xml.Name `xml:"mirror"`
+		ID       string   `xml:"id"`
+		Name     string   `xml:"name"`
+		URL      string   `xml:"url"`
+		MirrorOf string   `xml:"mirrorOf"`
+	}
+	type Settings struct {
+		XMLName xml.Name `xml:"settings"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Servers struct {
+			XMLName xml.Name `xml:"servers"`
+			Server  []Server `xml:"server"`
+		}
+		Mirrors struct {
+			XMLName xml.Name `xml:"mirrors"`
+			Mirror  []Mirror `xml:"mirror"`
+		}
+	}
+
+	settings := Settings{Xmlns: "http://maven.apache.org/SETTINGS/1.0.0"}
+
+	if data, err := os.ReadFile(settingsPath); err == nil && len(data) > 0 {
+		if xmlErr := xml.Unmarshal(data, &settings); xmlErr != nil {
+			settings = Settings{Xmlns: "http://maven.apache.org/SETTINGS/1.0.0"}
+		}
+	}
+
+	serverID := "harness-" + registryID
+
+	var mirrors []Mirror
+	for _, m := range settings.Mirrors.Mirror {
+		if m.ID == serverID {
+			continue
+		}
+		if strings.HasPrefix(m.ID, "harness-") && m.MirrorOf == "*" {
+			continue
+		}
+		mirrors = append(mirrors, m)
+	}
+	mirrors = append(mirrors, Mirror{
+		ID:       serverID,
+		Name:     "Harness " + registryID,
+		URL:      registryURL,
+		MirrorOf: "*",
+	})
+	settings.Mirrors.Mirror = mirrors
+
+	var servers []Server
+	for _, s := range settings.Servers.Server {
+		if s.ID == serverID || strings.HasPrefix(s.ID, "harness-") {
+			continue
+		}
+		servers = append(servers, s)
+	}
+	servers = append(servers, Server{
+		ID:       serverID,
+		Username: "harness",
+		Password: authToken,
+	})
+	settings.Servers.Server = servers
+
+	out, err := xml.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling settings.xml: %w", err)
+	}
+
+	return atomicWrite(settingsPath, []byte(xml.Header+string(out)+"\n"), 0600)
+}

--- a/modules/har/pkg/har/configure_npm.go
+++ b/modules/har/pkg/har/configure_npm.go
@@ -18,13 +18,19 @@ const configureRegistryHandlerID = "configure_registry"
 func configureRegistryHandler(ctx *cmdctx.Ctx) error {
 	client := cmdctx.GetString(ctx.FlagValues, "client")
 	if client == "" {
-		return fmt.Errorf("--client is required (supported: npm)")
+		return fmt.Errorf("--client is required (supported: npm, maven, pip, nuget)")
 	}
 	switch client {
 	case "npm":
 		return configureNpm(ctx)
+	case "maven":
+		return configureMaven(ctx)
+	case "pip":
+		return configurePip(ctx)
+	case "nuget":
+		return configureNuget(ctx)
 	default:
-		return fmt.Errorf("unsupported client %q (supported: npm)", client)
+		return fmt.Errorf("unsupported client %q (supported: npm, maven, pip, nuget)", client)
 	}
 }
 
@@ -150,5 +156,5 @@ func writeNpmrc(npmrcPath, registryURL, scope, authToken string) error {
 		content += "\n"
 	}
 
-	return os.WriteFile(npmrcPath, []byte(content), 0600)
+	return atomicWrite(npmrcPath, []byte(content), 0600)
 }

--- a/modules/har/pkg/har/configure_nuget.go
+++ b/modules/har/pkg/har/configure_nuget.go
@@ -1,0 +1,128 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+func configureNuget(ctx *cmdctx.Ctx) error {
+	a := ctx.Auth
+	registryID := ctx.Id
+
+	registryURL := fmt.Sprintf("%s/pkg/%s/%s/nuget/v3/index.json", a.RegistryURL, a.AccountID, registryID)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home directory: %w", err)
+	}
+
+	nugetDir := filepath.Join(home, ".nuget", "NuGet")
+	if err := os.MkdirAll(nugetDir, 0755); err != nil {
+		return fmt.Errorf("creating NuGet config directory: %w", err)
+	}
+	configPath := filepath.Join(nugetDir, "NuGet.Config")
+
+	if err := writeNugetConfig(configPath, registryID, registryURL, a.PATToken); err != nil {
+		return fmt.Errorf("writing NuGet.Config: %w", err)
+	}
+
+	fmt.Printf("Configured NuGet → %s (%s)\n", registryURL, configPath)
+	return nil
+}
+
+func writeNugetConfig(configPath, registryID, registryURL, authToken string) error {
+	type Add struct {
+		XMLName         xml.Name `xml:"add"`
+		Key             string   `xml:"key,attr"`
+		Value           string   `xml:"value,attr"`
+		ProtocolVersion *string  `xml:"protocolVersion,attr,omitempty"`
+	}
+	type PackageSources struct {
+		XMLName xml.Name `xml:"packageSources"`
+		Sources []Add    `xml:"add"`
+	}
+	type CredentialAdd struct {
+		XMLName xml.Name `xml:"add"`
+		Key     string   `xml:"key,attr"`
+		Value   string   `xml:"value,attr"`
+	}
+	type SourceCredential struct {
+		XMLName xml.Name
+		Adds    []CredentialAdd `xml:"add"`
+	}
+	type PackageSourceCredentials struct {
+		XMLName xml.Name           `xml:"packageSourceCredentials"`
+		Sources []SourceCredential `xml:",any"`
+	}
+	type Configuration struct {
+		XMLName                  xml.Name                  `xml:"configuration"`
+		PackageSources           PackageSources            `xml:"packageSources"`
+		PackageSourceCredentials *PackageSourceCredentials `xml:"packageSourceCredentials,omitempty"`
+	}
+
+	conf := Configuration{}
+
+	if data, err := os.ReadFile(configPath); err == nil && len(data) > 0 {
+		if xmlErr := xml.Unmarshal(data, &conf); xmlErr != nil {
+			conf = Configuration{}
+		}
+	}
+
+	sourceName := "harness-" + registryID
+	protocolVersion := "3"
+
+	sourceFound := false
+	for i, s := range conf.PackageSources.Sources {
+		if s.Key == sourceName {
+			conf.PackageSources.Sources[i].Value = registryURL
+			conf.PackageSources.Sources[i].ProtocolVersion = &protocolVersion
+			sourceFound = true
+			break
+		}
+	}
+	if !sourceFound {
+		conf.PackageSources.Sources = append(conf.PackageSources.Sources, Add{
+			Key:             sourceName,
+			Value:           registryURL,
+			ProtocolVersion: &protocolVersion,
+		})
+	}
+
+	if conf.PackageSourceCredentials == nil {
+		conf.PackageSourceCredentials = &PackageSourceCredentials{}
+	}
+	credFound := false
+	for i, src := range conf.PackageSourceCredentials.Sources {
+		if src.XMLName.Local == sourceName {
+			conf.PackageSourceCredentials.Sources[i].Adds = []CredentialAdd{
+				{Key: "Username", Value: "harness"},
+				{Key: "ClearTextPassword", Value: authToken},
+			}
+			credFound = true
+			break
+		}
+	}
+	if !credFound {
+		conf.PackageSourceCredentials.Sources = append(conf.PackageSourceCredentials.Sources, SourceCredential{
+			XMLName: xml.Name{Local: sourceName},
+			Adds: []CredentialAdd{
+				{Key: "Username", Value: "harness"},
+				{Key: "ClearTextPassword", Value: authToken},
+			},
+		})
+	}
+
+	out, err := xml.MarshalIndent(conf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling NuGet.Config: %w", err)
+	}
+
+	return atomicWrite(configPath, []byte(xml.Header+string(out)+"\n"), 0600)
+}

--- a/modules/har/pkg/har/configure_pip.go
+++ b/modules/har/pkg/har/configure_pip.go
@@ -1,0 +1,49 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+func configurePip(ctx *cmdctx.Ctx) error {
+	a := ctx.Auth
+	registryID := ctx.Id
+	global := cmdctx.GetBool(ctx.FlagValues, "global")
+
+	registryURL := fmt.Sprintf("%s/pkg/%s/%s/pypi/simple/", a.RegistryURL, a.AccountID, registryID)
+
+	var pipConfPath string
+	if global {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("getting home directory: %w", err)
+		}
+		pipConfDir := filepath.Join(home, ".config", "pip")
+		if err := os.MkdirAll(pipConfDir, 0755); err != nil {
+			return fmt.Errorf("creating pip config directory: %w", err)
+		}
+		pipConfPath = filepath.Join(pipConfDir, "pip.conf")
+	} else {
+		pipConfPath = "pip.conf"
+	}
+
+	if err := writePipConf(pipConfPath, registryURL, a.PATToken); err != nil {
+		return fmt.Errorf("writing pip.conf: %w", err)
+	}
+
+	fmt.Printf("Configured pip → %s (%s)\n", registryURL, pipConfPath)
+	return nil
+}
+
+func writePipConf(pipConfPath, registryURL, authToken string) error {
+	authedURL := strings.Replace(registryURL, "://", fmt.Sprintf("://harness:%s@", authToken), 1)
+	content := fmt.Sprintf("[global]\nindex-url = %s\n", authedURL)
+	return atomicWrite(pipConfPath, []byte(content), 0600)
+}

--- a/modules/har/pkg/har/har.go
+++ b/modules/har/pkg/har/har.go
@@ -7,6 +7,7 @@ import "github.com/harness/cli/pkg/registry"
 
 // ModuleInit registers har workflows. Commands are declared in har.spec.yaml.
 func ModuleInit(reg registry.ModuleRegistrar) {
+	reg.RegisterWorkflow("push_artifact_generic", pushGenericArtifact)
 	reg.RegisterWorkflow("push_artifact_maven", pushMavenArtifact)
 	reg.RegisterWorkflow("push_artifact_npm", pushNpmArtifact)
 	reg.RegisterWorkflow("push_artifact_python", pushPythonArtifact)

--- a/modules/har/pkg/har/har.go
+++ b/modules/har/pkg/har/har.go
@@ -8,6 +8,8 @@ import "github.com/harness/cli/pkg/registry"
 // ModuleInit registers har workflows. Commands are declared in har.spec.yaml.
 func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterWorkflow("push_artifact_generic", pushGenericArtifact)
+	reg.RegisterWorkflow("push_artifact_debian", pushDebianArtifact)
+	reg.RegisterWorkflow("push_artifact_conan", pushConanArtifact)
 	reg.RegisterWorkflow("push_artifact_maven", pushMavenArtifact)
 	reg.RegisterWorkflow("push_artifact_npm", pushNpmArtifact)
 	reg.RegisterWorkflow("push_artifact_python", pushPythonArtifact)

--- a/modules/har/pkg/har/harutil.go
+++ b/modules/har/pkg/har/harutil.go
@@ -9,16 +9,44 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
-	"net/textproto"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/harness/cli/pkg/auth"
 )
+
+// atomicWrite writes content to path via a temp file + rename, ensuring an
+// incomplete write never leaves a partial file. perm is applied before rename.
+func atomicWrite(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".harness-tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
 
 // parseRegistryAndName splits ctx.Id ("registry/name") into its two parts.
 func parseRegistryAndName(id string) (registry, name string, err error) {
@@ -73,34 +101,6 @@ func buildPkgURL(registryURL, accountID, subpath string) (string, error) {
 	q.Set("accountIdentifier", accountID)
 	base.RawQuery = q.Encode()
 	return base.String(), nil
-}
-
-// multipartFile builds a multipart/form-data body containing a single file field.
-// Returns the body as a pipe reader, the content-type header value (includes boundary),
-// and any error. The caller must close the writer after copying their data.
-//
-// Typical usage:
-//
-//	pr, contentType, pw, err := newMultipartFile("file", "app.jar")
-//	go func() { defer pw.Close(); io.Copy(pw, fileReader) }()
-//	req, _ := http.NewRequest("POST", uploadURL, pr)
-//	req.Header.Set("Content-Type", contentType)
-func newMultipartFile(fieldName, filename string) (io.Reader, string, *multipart.Writer, error) {
-	pr, pw := io.Pipe()
-	mw := multipart.NewWriter(pw)
-
-	h := make(textproto.MIMEHeader)
-	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fieldName, filename))
-	h.Set("Content-Type", "application/octet-stream")
-
-	_, err := mw.CreatePart(h)
-	if err != nil {
-		pw.Close()
-		pr.Close()
-		return nil, "", nil, fmt.Errorf("creating multipart field: %w", err)
-	}
-
-	return pr, mw.FormDataContentType(), mw, nil
 }
 
 // readFileFromTarGz reads the contents of the first file in archivePath whose path

--- a/modules/har/pkg/har/push_conan.go
+++ b/modules/har/pkg/har/push_conan.go
@@ -1,3 +1,4 @@
+
 // Copyright © 2026 Harness Inc.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -62,11 +63,7 @@ func pushConanArtifact(ctx *cmdctx.Ctx) error {
 		return fmt.Errorf("push conan artifact requires: push artifact <registry> <reference> <recipe-dir>")
 	}
 
-	registry, _, err := parseRegistryAndName(ctx.Id)
-	if err != nil {
-		return err
-	}
-
+	registry := ctx.Id
 	reference := ctx.Args[0]
 	recipeDir := ctx.Args[1]
 

--- a/modules/har/pkg/har/push_conan.go
+++ b/modules/har/pkg/har/push_conan.go
@@ -1,0 +1,360 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"crypto/md5" //nolint:gosec // Conan revision is MD5 by spec, not for security.
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+// Conan file-name constants (mirrors the conanutil package in the legacy CLI).
+const (
+	conanPlaceholder  = "_"
+	conanManifestFile = "conanmanifest.txt"
+	conanFilePy       = "conanfile.py"
+	conanInfoTxt      = "conaninfo.txt"
+	conanTarballExport  = "conan_export"
+	conanTarballSources = "conan_sources"
+	conanTarballPackage = "conan_package"
+)
+
+var (
+	conanTarballExtensions = map[string]bool{".tgz": true, ".txz": true, ".tzst": true}
+	conanNamePattern       = regexp.MustCompile(`^[a-z0-9_][a-z0-9_+.\-]{1,100}$`)
+	conanRevisionPattern   = regexp.MustCompile(`^([a-f0-9]{32}|[a-f0-9]{40})$`)
+	conanPackageIDPattern  = regexp.MustCompile(`^[a-f0-9]{40}$`)
+)
+
+type conanRef struct {
+	Name    string
+	Version string
+	User    string
+	Channel string
+}
+
+func (r conanRef) display() string {
+	if r.User == conanPlaceholder && r.Channel == conanPlaceholder {
+		return r.Name + "/" + r.Version
+	}
+	return r.Name + "/" + r.Version + "@" + r.User + "/" + r.Channel
+}
+
+// pushConanArtifact implements "push artifact:conan".
+//
+// Usage:
+//
+//	harness push artifact:conan <registry> <name/version[@user/channel]> <recipe-dir>
+//	  [--package-dir <dir> --package-id <sha>]
+//	  [--recipe-revision <md5>] [--package-revision <md5>]
+func pushConanArtifact(ctx *cmdctx.Ctx) error {
+	if len(ctx.Args) < 2 {
+		return fmt.Errorf("push conan artifact requires: push artifact <registry> <reference> <recipe-dir>")
+	}
+
+	registry, _, err := parseRegistryAndName(ctx.Id)
+	if err != nil {
+		return err
+	}
+
+	reference := ctx.Args[0]
+	recipeDir := ctx.Args[1]
+
+	ref, err := parseConanRef(reference)
+	if err != nil {
+		return fmt.Errorf("invalid Conan reference: %w", err)
+	}
+
+	recipeRevision := cmdctx.GetString(ctx.FlagValues, "recipe-revision")
+	packageDir := cmdctx.GetString(ctx.FlagValues, "package-dir")
+	packageID := cmdctx.GetString(ctx.FlagValues, "package-id")
+	packageRevision := cmdctx.GetString(ctx.FlagValues, "package-revision")
+
+	// Collect recipe files
+	recipeFiles, skipped, err := collectConanFiles(recipeDir, isConanRecipeFile)
+	if err != nil {
+		return fmt.Errorf("reading recipe dir: %w", err)
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(os.Stderr, "Skipping %d non-Conan file(s): %s\n", len(skipped), strings.Join(skipped, ", "))
+	}
+
+	// Derive RREV from manifest if not provided
+	if recipeRevision == "" {
+		recipeRevision, err = conanRevisionFromManifest(recipeDir)
+		if err != nil {
+			return fmt.Errorf("deriving recipe revision: %w", err)
+		}
+	}
+	if !conanRevisionPattern.MatchString(recipeRevision) {
+		return fmt.Errorf("recipe-revision must be a 32-char MD5 or 40-char SHA, got: %q", recipeRevision)
+	}
+
+	// Validate package-layer inputs before uploading anything
+	var packageFiles []string
+	if packageDir != "" {
+		if packageID == "" {
+			return fmt.Errorf("--package-id is required when --package-dir is set")
+		}
+		if !conanPackageIDPattern.MatchString(packageID) {
+			return fmt.Errorf("package-id must be a 40-char SHA-1, got: %q", packageID)
+		}
+		var pkgSkipped []string
+		packageFiles, pkgSkipped, err = collectConanFiles(packageDir, isConanPackageFile)
+		if err != nil {
+			return fmt.Errorf("reading package dir: %w", err)
+		}
+		if len(pkgSkipped) > 0 {
+			fmt.Fprintf(os.Stderr, "Skipping %d non-Conan package file(s): %s\n", len(pkgSkipped), strings.Join(pkgSkipped, ", "))
+		}
+		if packageRevision == "" {
+			packageRevision, err = conanRevisionFromManifest(packageDir)
+			if err != nil {
+				return fmt.Errorf("deriving package revision: %w", err)
+			}
+		}
+		if !conanRevisionPattern.MatchString(packageRevision) {
+			return fmt.Errorf("package-revision must be a 32-char MD5 or 40-char SHA, got: %q", packageRevision)
+		}
+	}
+
+	client := newHTTPClient()
+
+	// Upload recipe layer (manifest last)
+	fmt.Fprintf(os.Stderr, "Uploading recipe files (rrev %s) ...\n", recipeRevision)
+	for _, fp := range orderConanFiles(recipeFiles) {
+		if err := uploadConanRecipe(ctx, client, registry, ref, recipeRevision, fp); err != nil {
+			return err
+		}
+	}
+
+	// Upload package layer if requested (manifest last)
+	if packageDir != "" {
+		fmt.Fprintf(os.Stderr, "Uploading package files (pkgid %s, prev %s) ...\n", packageID, packageRevision)
+		for _, fp := range orderConanFiles(packageFiles) {
+			if err := uploadConanPackage(ctx, client, registry, ref, recipeRevision, packageID, packageRevision, fp); err != nil {
+				return err
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Successfully pushed Conan package %s to registry %q\n", ref.display(), registry)
+	return nil
+}
+
+// uploadConanRecipe PUTs a single recipe-layer file.
+// URL: /pkg/{account}/{registry}/conan/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rrev}/files/{filename}
+func uploadConanRecipe(ctx *cmdctx.Ctx, client *http.Client, registry string, ref conanRef, rrev, filePath string) error {
+	fileName := filepath.Base(filePath)
+	fmt.Fprintf(os.Stderr, "  Uploading recipe file: %s\n", fileName)
+
+	checksums, err := computeFileChecksums(filePath)
+	if err != nil {
+		return fmt.Errorf("computing checksums for %s: %w", fileName, err)
+	}
+
+	uploadURL := fmt.Sprintf("%s/pkg/%s/%s/conan/v2/conans/%s/%s/%s/%s/revisions/%s/files/%s",
+		strings.TrimRight(ctx.Auth.RegistryURL, "/"),
+		url.PathEscape(ctx.Auth.AccountID),
+		url.PathEscape(registry),
+		url.PathEscape(ref.Name),
+		url.PathEscape(ref.Version),
+		url.PathEscape(ref.User),
+		url.PathEscape(ref.Channel),
+		url.PathEscape(rrev),
+		url.PathEscape(fileName),
+	)
+
+	return conanPutFile(ctx, client, uploadURL, filePath, checksums)
+}
+
+// uploadConanPackage PUTs a single package-layer file.
+// URL: /pkg/{account}/{registry}/conan/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rrev}/packages/{pkgid}/revisions/{prev}/files/{filename}
+func uploadConanPackage(ctx *cmdctx.Ctx, client *http.Client, registry string, ref conanRef, rrev, pkgID, prev, filePath string) error {
+	fileName := filepath.Base(filePath)
+	fmt.Fprintf(os.Stderr, "  Uploading package file: %s\n", fileName)
+
+	checksums, err := computeFileChecksums(filePath)
+	if err != nil {
+		return fmt.Errorf("computing checksums for %s: %w", fileName, err)
+	}
+
+	uploadURL := fmt.Sprintf("%s/pkg/%s/%s/conan/v2/conans/%s/%s/%s/%s/revisions/%s/packages/%s/revisions/%s/files/%s",
+		strings.TrimRight(ctx.Auth.RegistryURL, "/"),
+		url.PathEscape(ctx.Auth.AccountID),
+		url.PathEscape(registry),
+		url.PathEscape(ref.Name),
+		url.PathEscape(ref.Version),
+		url.PathEscape(ref.User),
+		url.PathEscape(ref.Channel),
+		url.PathEscape(rrev),
+		url.PathEscape(pkgID),
+		url.PathEscape(prev),
+		url.PathEscape(fileName),
+	)
+
+	return conanPutFile(ctx, client, uploadURL, filePath, checksums)
+}
+
+func conanPutFile(ctx *cmdctx.Ctx, client *http.Client, uploadURL, filePath string, checksums fileChecksums) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("opening %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %q: %w", filePath, err)
+	}
+
+	req, err := http.NewRequest("PUT", uploadURL, f)
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	setAuthHeader(req, ctx.Auth)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = fi.Size()
+	req.Header.Set("X-Checksum-Sha1", checksums.SHA1)
+
+	if _, err := doRequest(client, req); err != nil {
+		return fmt.Errorf("uploading %s: %w", filepath.Base(filePath), err)
+	}
+	return nil
+}
+
+// parseConanRef parses name/version[@user/channel] into a conanRef.
+// Absent user/channel default to the "_" placeholder.
+func parseConanRef(reference string) (conanRef, error) {
+	ref := conanRef{User: conanPlaceholder, Channel: conanPlaceholder}
+
+	nameVersion := reference
+	if nv, uc, hasAt := strings.Cut(reference, "@"); hasAt {
+		nameVersion = nv
+		parts := strings.Split(uc, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return conanRef{}, fmt.Errorf("user/channel must be user/channel, got: %q", uc)
+		}
+		ref.User, ref.Channel = parts[0], parts[1]
+	}
+
+	nv := strings.Split(nameVersion, "/")
+	if len(nv) != 2 || nv[0] == "" || nv[1] == "" {
+		return conanRef{}, fmt.Errorf("reference must be name/version[@user/channel], got: %q", reference)
+	}
+	ref.Name, ref.Version = nv[0], nv[1]
+
+	if !conanNamePattern.MatchString(ref.Name) {
+		return conanRef{}, fmt.Errorf("invalid Conan package name: %q", ref.Name)
+	}
+	if !conanNamePattern.MatchString(ref.Version) {
+		return conanRef{}, fmt.Errorf("invalid Conan version: %q", ref.Version)
+	}
+	if ref.User != conanPlaceholder && !conanNamePattern.MatchString(ref.User) {
+		return conanRef{}, fmt.Errorf("invalid Conan user: %q", ref.User)
+	}
+	if ref.Channel != conanPlaceholder && !conanNamePattern.MatchString(ref.Channel) {
+		return conanRef{}, fmt.Errorf("invalid Conan channel: %q", ref.Channel)
+	}
+	return ref, nil
+}
+
+// collectConanFiles reads dir and returns the valid Conan files according to isValid,
+// plus a list of any skipped file names. conanmanifest.txt must be present.
+func collectConanFiles(dir string, isValid func(string) bool) (files []string, skipped []string, err error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("accessing directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, nil, fmt.Errorf("path must be a directory: %s", dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading directory: %w", err)
+	}
+
+	hasManifest := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isValid(name) {
+			skipped = append(skipped, name)
+			continue
+		}
+		if name == conanManifestFile {
+			hasManifest = true
+		}
+		files = append(files, filepath.Join(dir, name))
+	}
+	if !hasManifest {
+		return nil, skipped, fmt.Errorf("%s not found in directory: %s", conanManifestFile, dir)
+	}
+	return files, skipped, nil
+}
+
+// orderConanFiles sorts files with conanmanifest.txt last (server finalization marker).
+func orderConanFiles(files []string) []string {
+	ordered := make([]string, len(files))
+	copy(ordered, files)
+	sort.Slice(ordered, func(i, j int) bool {
+		iM := filepath.Base(ordered[i]) == conanManifestFile
+		jM := filepath.Base(ordered[j]) == conanManifestFile
+		if iM != jM {
+			return !iM
+		}
+		return ordered[i] < ordered[j]
+	})
+	return ordered
+}
+
+// conanRevisionFromManifest derives a revision as the hex MD5 of conanmanifest.txt.
+func conanRevisionFromManifest(dir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, conanManifestFile))
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", conanManifestFile, err)
+	}
+	sum := md5.Sum(data) //nolint:gosec
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// isConanRecipeFile reports whether name is a canonical recipe-layer file.
+func isConanRecipeFile(name string) bool {
+	name = filepath.Base(name)
+	if name == conanFilePy || name == conanManifestFile {
+		return true
+	}
+	prefix, ok := conanTarballPrefix(name)
+	return ok && (prefix == conanTarballExport || prefix == conanTarballSources)
+}
+
+// isConanPackageFile reports whether name is a canonical package-layer file.
+func isConanPackageFile(name string) bool {
+	name = filepath.Base(name)
+	if name == conanInfoTxt || name == conanManifestFile {
+		return true
+	}
+	prefix, ok := conanTarballPrefix(name)
+	return ok && prefix == conanTarballPackage
+}
+
+func conanTarballPrefix(name string) (string, bool) {
+	ext := filepath.Ext(name)
+	if !conanTarballExtensions[ext] {
+		return "", false
+	}
+	return strings.TrimSuffix(name, ext), true
+}

--- a/modules/har/pkg/har/push_debian.go
+++ b/modules/har/pkg/har/push_debian.go
@@ -1,0 +1,282 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+// pushDebianArtifact implements "push artifact:debian".
+//
+// Supports two file types:
+//   - .deb  → PUT /pkg/{account}/{registry}/debian/deb?distribution=…&component=…
+//   - .dsc  → PUT /pkg/{account}/{registry}/debian/dsc + optional source files
+//     via PUT /pkg/{account}/{registry}/debian/src
+func pushDebianArtifact(ctx *cmdctx.Ctx) error {
+	if len(ctx.Args) == 0 {
+		return fmt.Errorf("push debian artifact requires a file path: push artifact <registry> <file>")
+	}
+
+	registry, _, err := parseRegistryAndName(ctx.Id)
+	if err != nil {
+		return err
+	}
+
+	filePath := ctx.Args[0]
+	distribution := cmdctx.GetString(ctx.FlagValues, "distribution")
+	component := cmdctx.GetString(ctx.FlagValues, "component")
+
+	if distribution == "" {
+		return fmt.Errorf("--distribution is required (e.g. focal, bullseye)")
+	}
+	if component == "" {
+		return fmt.Errorf("--component is required (e.g. main, contrib, non-free)")
+	}
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".deb":
+		return uploadDebFile(ctx, registry, filePath, distribution, component)
+	case ".dsc":
+		sourceFile := cmdctx.GetString(ctx.FlagValues, "source-file")
+		originSourceFile := cmdctx.GetString(ctx.FlagValues, "origin-source-file")
+		return uploadDscPackage(ctx, registry, filePath, distribution, component, sourceFile, originSourceFile)
+	default:
+		return fmt.Errorf("unsupported file type %q: must be .deb or .dsc", ext)
+	}
+}
+
+// uploadDebFile uploads a .deb package.
+// URL: /pkg/{account}/{registry}/debian/deb?distribution=…&component=…
+func uploadDebFile(ctx *cmdctx.Ctx, registry, filePath, distribution, component string) error {
+	if err := validateRegularFile(filePath); err != nil {
+		return err
+	}
+
+	checksums, err := computeFileChecksums(filePath)
+	if err != nil {
+		return fmt.Errorf("computing checksums: %w", err)
+	}
+
+	body, contentType, err := buildMultipartBody(filePath)
+	if err != nil {
+		return err
+	}
+
+	uploadURL, err := debianURL(ctx, registry, "deb", distribution, component, "", "")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Uploading %s ...\n", filepath.Base(filePath))
+	req, err := http.NewRequest("PUT", uploadURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	setAuthHeader(req, ctx.Auth)
+	req.Header.Set("Content-Type", contentType)
+	setChecksumHeaders(req.Header, checksums)
+
+	if _, err := doRequest(newHTTPClient(), req); err != nil {
+		return fmt.Errorf("upload failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Successfully pushed %s to registry %q\n", filepath.Base(filePath), registry)
+	return nil
+}
+
+// uploadDscPackage uploads a .dsc file plus optional source/origin-source files.
+func uploadDscPackage(ctx *cmdctx.Ctx, registry, dscPath, distribution, component, sourceFile, originSourceFile string) error {
+	if sourceFile == "" && originSourceFile == "" {
+		return fmt.Errorf("at least one of --source-file or --origin-source-file is required for .dsc uploads")
+	}
+
+	if err := validateRegularFile(dscPath); err != nil {
+		return err
+	}
+
+	meta, err := parseDscMetadata(dscPath)
+	if err != nil {
+		return fmt.Errorf("parsing .dsc file: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Parsed .dsc: source=%s version=%s\n", meta.source, meta.version)
+
+	// Upload .dsc file
+	if err := uploadDebianFile(ctx, registry, dscPath, distribution, component, "", "", "dsc"); err != nil {
+		return err
+	}
+
+	// Upload tar.xz / tar.gz source file
+	if sourceFile != "" {
+		if err := validateRegularFile(sourceFile); err != nil {
+			return err
+		}
+		if err := uploadDebianFile(ctx, registry, sourceFile, distribution, component, meta.source, meta.version, "src"); err != nil {
+			return err
+		}
+	}
+
+	// Upload orig source tarball
+	if originSourceFile != "" {
+		if err := validateRegularFile(originSourceFile); err != nil {
+			return err
+		}
+		upstreamVersion := extractUpstreamVersion(meta.version)
+		if err := uploadDebianFile(ctx, registry, originSourceFile, distribution, component, meta.source, upstreamVersion, "src"); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Successfully pushed .dsc package %s to registry %q\n", meta.source, registry)
+	return nil
+}
+
+// uploadDebianFile uploads a single file to the given debian endpoint type (dsc or src).
+func uploadDebianFile(ctx *cmdctx.Ctx, registry, filePath, distribution, component, pkg, version, endpointType string) error {
+	checksums, err := computeFileChecksums(filePath)
+	if err != nil {
+		return fmt.Errorf("computing checksums for %s: %w", filePath, err)
+	}
+
+	body, contentType, err := buildMultipartBody(filePath)
+	if err != nil {
+		return err
+	}
+
+	uploadURL, err := debianURL(ctx, registry, endpointType, distribution, component, pkg, version)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Uploading %s ...\n", filepath.Base(filePath))
+	req, err := http.NewRequest("PUT", uploadURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	setAuthHeader(req, ctx.Auth)
+	req.Header.Set("Content-Type", contentType)
+	setChecksumHeaders(req.Header, checksums)
+
+	if _, err := doRequest(newHTTPClient(), req); err != nil {
+		return fmt.Errorf("upload of %s failed: %w", filepath.Base(filePath), err)
+	}
+	return nil
+}
+
+// debianURL builds the upload URL for a debian endpoint.
+// endpointType: "deb", "dsc", or "src"
+// URL pattern: {pkgURL}/pkg/{account}/{registry}/debian/{type}?distribution=…&component=…[&package=…&version=…]
+func debianURL(ctx *cmdctx.Ctx, registry, endpointType, distribution, component, pkg, version string) (string, error) {
+	base, err := url.Parse(ctx.Auth.RegistryURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid registry URL: %w", err)
+	}
+	base.Path = fmt.Sprintf("/pkg/%s/%s/debian/%s",
+		url.PathEscape(ctx.Auth.AccountID),
+		url.PathEscape(registry),
+		endpointType,
+	)
+	q := url.Values{}
+	q.Set("distribution", distribution)
+	q.Set("component", component)
+	if pkg != "" {
+		q.Set("package", pkg)
+	}
+	if version != "" {
+		q.Set("version", version)
+	}
+	base.RawQuery = q.Encode()
+	return base.String(), nil
+}
+
+// buildMultipartBody builds a multipart/form-data body with a single "file" field.
+// Returns the body bytes and the content-type header value (with boundary).
+func buildMultipartBody(filePath string) ([]byte, string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return nil, "", fmt.Errorf("creating multipart field: %w", err)
+	}
+	if _, err := io.Copy(part, f); err != nil {
+		return nil, "", fmt.Errorf("reading file into multipart: %w", err)
+	}
+	mw.Close()
+	return buf.Bytes(), mw.FormDataContentType(), nil
+}
+
+type dscMetadata struct {
+	source  string
+	version string
+}
+
+// parseDscMetadata reads Source and Version fields from a .dsc file.
+func parseDscMetadata(filePath string) (*dscMetadata, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening .dsc file: %w", err)
+	}
+	defer f.Close()
+
+	meta := &dscMetadata{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "Source:") {
+			meta.source = strings.TrimSpace(strings.TrimPrefix(line, "Source:"))
+		} else if strings.HasPrefix(line, "Version:") {
+			meta.version = strings.TrimSpace(strings.TrimPrefix(line, "Version:"))
+		}
+		if meta.source != "" && meta.version != "" {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading .dsc file: %w", err)
+	}
+	if meta.source == "" {
+		return nil, fmt.Errorf("Source field not found in .dsc file")
+	}
+	if meta.version == "" {
+		return nil, fmt.Errorf("Version field not found in .dsc file")
+	}
+	return meta, nil
+}
+
+// extractUpstreamVersion strips the debian revision suffix from a version string.
+// e.g. "1.2.3-4" → "1.2.3", "1.2.3" → "1.2.3"
+func extractUpstreamVersion(version string) string {
+	if idx := strings.LastIndex(version, "-"); idx >= 0 {
+		return version[:idx]
+	}
+	return version
+}
+
+// validateRegularFile returns an error if the path doesn't exist or is a directory.
+func validateRegularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("cannot access %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%q is a directory, expected a file", path)
+	}
+	return nil
+}

--- a/modules/har/pkg/har/push_debian.go
+++ b/modules/har/pkg/har/push_debian.go
@@ -29,11 +29,7 @@ func pushDebianArtifact(ctx *cmdctx.Ctx) error {
 		return fmt.Errorf("push debian artifact requires a file path: push artifact <registry> <file>")
 	}
 
-	registry, _, err := parseRegistryAndName(ctx.Id)
-	if err != nil {
-		return err
-	}
-
+	registry := ctx.Id
 	filePath := ctx.Args[0]
 	distribution := cmdctx.GetString(ctx.FlagValues, "distribution")
 	component := cmdctx.GetString(ctx.FlagValues, "component")

--- a/modules/har/pkg/har/push_generic.go
+++ b/modules/har/pkg/har/push_generic.go
@@ -1,0 +1,252 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+// pushGenericArtifact implements "push artifact:generic".
+//
+// Usage:
+//
+//	harness push artifact:generic <registry/name> <path> [<path>...] --name <pkg> [--version v]
+//
+// Each <path> may be a file or a directory. Directories are walked recursively.
+// Files are uploaded to: {registryURL}/pkg/{accountID}/{registry}/generic/{name}/{version}/{relPath}
+func pushGenericArtifact(ctx *cmdctx.Ctx) error {
+	if len(ctx.Args) == 0 {
+		return fmt.Errorf("push generic artifact requires at least one file or directory path")
+	}
+
+	registry, name, err := parseRegistryAndName(ctx.Id)
+	if err != nil {
+		return err
+	}
+
+	version := cmdctx.GetString(ctx.FlagValues, "version")
+	if version == "" {
+		version = "1.0.0"
+	}
+
+	includeHidden := cmdctx.GetBool(ctx.FlagValues, "include-hidden")
+
+	fmt.Fprintf(os.Stderr, "Scanning %d input(s) ...\n", len(ctx.Args))
+
+	jobs, totalFiles, totalBytes, err := collectGenericJobs(ctx.Args, includeHidden)
+	if err != nil {
+		return err
+	}
+	if len(jobs) == 0 {
+		return fmt.Errorf("no files to upload (use --include-hidden to include dotfiles inside directory inputs)")
+	}
+
+	fmt.Fprintf(os.Stderr, "Found %d file(s) (%s) to upload to %s/%s in registry %q\n",
+		totalFiles, formatBytes(totalBytes), name, version, registry)
+
+	client := newHTTPClient()
+
+	sem := make(chan struct{}, defaultMaxConcurrentUploads)
+	var wg sync.WaitGroup
+	errs := make([]error, len(jobs))
+
+	for i, job := range jobs {
+		wg.Add(1)
+		go func(i int, job genericUploadJob) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			fmt.Fprintf(os.Stderr, "Uploading %s ...\n", job.relPath)
+			if uploadErr := genericPutFile(ctx, client, registry, name, version, job.relPath, job.localPath); uploadErr != nil {
+				errs[i] = fmt.Errorf("failed to upload %s: %w", job.relPath, uploadErr)
+			}
+		}(i, job)
+	}
+	wg.Wait()
+
+	var firstErr error
+	failed := 0
+	for _, e := range errs {
+		if e != nil {
+			fmt.Fprintln(os.Stderr, e)
+			failed++
+			if firstErr == nil {
+				firstErr = e
+			}
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d of %d file(s) failed to upload", failed, len(jobs))
+	}
+
+	fmt.Fprintf(os.Stderr, "Successfully pushed %d file(s) to %s/%s in registry %q\n", totalFiles, name, version, registry)
+	return nil
+}
+
+type genericUploadJob struct {
+	relPath   string
+	localPath string
+	size      int64
+}
+
+// collectGenericJobs walks all input paths and returns a flat job list.
+func collectGenericJobs(paths []string, includeHidden bool) ([]genericUploadJob, int, int64, error) {
+	var jobs []genericUploadJob
+	var totalBytes int64
+
+	for _, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("cannot resolve %q: %w", p, err)
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("cannot access %q: %w", p, err)
+		}
+
+		if info.IsDir() {
+			dirJobs, dirBytes, err := walkDir(abs, includeHidden)
+			if err != nil {
+				return nil, 0, 0, err
+			}
+			jobs = append(jobs, dirJobs...)
+			totalBytes += dirBytes
+		} else if info.Mode().IsRegular() {
+			jobs = append(jobs, genericUploadJob{
+				relPath:   filepath.Base(abs),
+				localPath: abs,
+				size:      info.Size(),
+			})
+			totalBytes += info.Size()
+		} else {
+			return nil, 0, 0, fmt.Errorf("%s is not a regular file or directory", abs)
+		}
+	}
+
+	return jobs, len(jobs), totalBytes, nil
+}
+
+// walkDir recursively walks srcDir and returns a job per regular file.
+// The directory's basename is used as a path prefix so the internal layout is preserved.
+func walkDir(srcDir string, includeHidden bool) ([]genericUploadJob, int64, error) {
+	var jobs []genericUploadJob
+	var totalBytes int64
+
+	sourceBase := filepath.ToSlash(filepath.Base(srcDir))
+	if sourceBase == "." || sourceBase == "/" {
+		sourceBase = ""
+	}
+
+	err := filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == srcDir {
+			return nil
+		}
+
+		base := filepath.Base(path)
+		if !includeHidden && strings.HasPrefix(base, ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return fmt.Errorf("compute relative path for %s: %w", path, err)
+		}
+		relPath = filepath.ToSlash(relPath)
+		if strings.HasPrefix(relPath, "../") || relPath == ".." {
+			return fmt.Errorf("refusing to upload %s: path escapes source directory", path)
+		}
+
+		jobRelPath := relPath
+		if sourceBase != "" {
+			jobRelPath = sourceBase + "/" + relPath
+		}
+
+		jobs = append(jobs, genericUploadJob{
+			relPath:   jobRelPath,
+			localPath: path,
+			size:      info.Size(),
+		})
+		totalBytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to walk %s: %w", srcDir, err)
+	}
+	return jobs, totalBytes, nil
+}
+
+// genericPutFile uploads a single file via PUT.
+//
+// URL: {registryURL}/pkg/{accountID}/{registry}/generic/{name}/{version}/{relPath}
+func genericPutFile(ctx *cmdctx.Ctx, client *http.Client, registry, name, version, relPath, localPath string) error {
+	f, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("opening %q: %w", localPath, err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %q: %w", localPath, err)
+	}
+
+	subpath := fmt.Sprintf("%s/files/%s/%s/%s", registry, name, version, relPath)
+	uploadURL, err := buildPkgURL(ctx.Auth.RegistryURL, ctx.Auth.AccountID, subpath)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", uploadURL, f)
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	setAuthHeader(req, ctx.Auth)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = fi.Size()
+
+	if _, err := doRequest(client, req); err != nil {
+		return err
+	}
+	return nil
+}
+
+// formatBytes returns a human-readable byte size string.
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/pkg/spec/har.spec.yaml
+++ b/pkg/spec/har.spec.yaml
@@ -416,6 +416,62 @@ commands:
     handler_type: workflow
     workflow_id: push_artifact_puppet
 
+  - command: push artifact:debian
+    verb: push
+    noun: artifact
+    noun_variant: debian
+    short: Push a Debian package (.deb or .dsc) to a Harness registry
+    long: |
+      Push a Debian .deb binary package or a .dsc source package to a Harness Artifact Registry.
+      For .dsc uploads, provide --source-file and/or --origin-source-file for the accompanying source tarballs.
+    has_args: true
+    id_allow_slash: false
+    id_label: "<registry>"
+    args_label: "<local-file>"
+    completion_seq:
+      - completion_noun: registry
+    handler_type: workflow
+    workflow_id: push_artifact_debian
+    flags:
+      - name: distribution
+        description: "Debian distribution name (e.g. focal, bullseye) (required)"
+        required: true
+      - name: component
+        description: "Debian component name (e.g. main, contrib, non-free) (required)"
+        required: true
+      - name: source-file
+        description: "Path to source tarball (.tar.xz/.tar.gz) — only for .dsc uploads"
+      - name: origin-source-file
+        description: "Path to orig source tarball — only for .dsc uploads"
+
+  - command: push artifact:conan
+    verb: push
+    noun: artifact
+    noun_variant: conan
+    short: Push a Conan package to a Harness registry
+    long: |
+      Push a Conan v2 package to a Harness Artifact Registry.
+      <reference> is of the form name/version[@user/channel].
+      <recipe-dir> must contain the exported recipe-layer files (conanfile.py, conanmanifest.txt, conan_export.tgz, conan_sources.tgz).
+      Use --package-dir and --package-id to also upload a binary package layer.
+    has_args: true
+    id_allow_slash: false
+    id_label: "<registry>"
+    args_label: "<name/version[@user/channel]> <recipe-dir>"
+    completion_seq:
+      - completion_noun: registry
+    handler_type: workflow
+    workflow_id: push_artifact_conan
+    flags:
+      - name: recipe-revision
+        description: "Recipe revision (RREV). Defaults to the MD5 of conanmanifest.txt"
+      - name: package-dir
+        description: "Directory containing package-layer files (conaninfo.txt, conanmanifest.txt, conan_package.tgz)"
+      - name: package-id
+        description: "Conan package ID (PKGID, 40-char SHA-1); required with --package-dir"
+      - name: package-revision
+        description: "Package revision (PREV). Defaults to the MD5 of the package's conanmanifest.txt"
+
   - command: push artifact:helm
     verb: push
     noun: artifact

--- a/pkg/spec/har.spec.yaml
+++ b/pkg/spec/har.spec.yaml
@@ -194,6 +194,26 @@ commands:
         short: t
         description: "Package type (docker, helm, generic, maven, npm, python, nuget, rpm, cargo, go, conda, dart, composer, swift). Inferred from file extension if not set."
 
+  - command: push artifact:generic
+    verb: push
+    noun: artifact
+    noun_variant: generic
+    short: Push one or more generic artifacts to a Harness registry
+    has_args: true
+    id_allow_slash: true
+    id_label: "<registry/name>"
+    args_label: "<path> [<path>...]"
+    completion_seq:
+      - completion_noun: registry
+      - completion_noun: artifact
+    handler_type: workflow
+    workflow_id: push_artifact_generic
+    flags:
+      - name: version
+        description: "Artifact version (default: 1.0.0)"
+      - name: include-hidden
+        description: "Include hidden files and directories (names starting with '.') when walking directory inputs"
+
   - command: push artifact:maven
     verb: push
     noun: artifact

--- a/pkg/spec/har.spec.yaml
+++ b/pkg/spec/har.spec.yaml
@@ -421,9 +421,6 @@ commands:
     noun: artifact
     noun_variant: debian
     short: Push a Debian package (.deb or .dsc) to a Harness registry
-    long: |
-      Push a Debian .deb binary package or a .dsc source package to a Harness Artifact Registry.
-      For .dsc uploads, provide --source-file and/or --origin-source-file for the accompanying source tarballs.
     has_args: true
     id_allow_slash: false
     id_label: "<registry>"
@@ -449,11 +446,6 @@ commands:
     noun: artifact
     noun_variant: conan
     short: Push a Conan package to a Harness registry
-    long: |
-      Push a Conan v2 package to a Harness Artifact Registry.
-      <reference> is of the form name/version[@user/channel].
-      <recipe-dir> must contain the exported recipe-layer files (conanfile.py, conanmanifest.txt, conan_export.tgz, conan_sources.tgz).
-      Use --package-dir and --package-id to also upload a binary package layer.
     has_args: true
     id_allow_slash: false
     id_label: "<registry>"
@@ -994,11 +986,11 @@ commands:
     workflow_id: configure_registry
     flags:
       - name: client
-        description: "Package manager client to configure (npm)"
+        description: "Package manager client to configure (npm, maven, pip, nuget)"
         required: true
-        completion_values: [npm]
+        completion_values: [npm, maven, pip, nuget]
       - name: scope
         description: "npm scope, e.g. @myorg (optional; configures default registry if omitted)"
       - name: global
-        description: "Write config to ~/.npmrc (default: ./.npmrc in current directory)"
+        description: "Write config to the global/user-level config file instead of the local project directory (pip, npm)"
         is_bool: true


### PR DESCRIPTION
- **`push artifact:generic`** — uploads one or more files or directories to a generic registry. Directories are walked recursively (internal layout preserved via `{dirname}/{relPath}`), uploads run concurrently (bounded by `defaultMaxConcurrentUploads`), and hidden files/dirs are skipped by default (opt-in via `--include-hidden`).
- **`push artifact:debian`** — uploads `.deb` binary packages or `.dsc` source packages to a Debian registry. `.dsc` uploads parse `Source`/`Version` out of the control file and can additionally push the accompanying source tarball (`--source-file`) and/or the upstream orig tarball (`--origin-source-file`, with the debian revision suffix stripped from the version).
- **`push artifact:conan`** — uploads Conan v2 packages by recipe reference (`name/version[@user/channel]`). Uploads the recipe layer from `<recipe-dir>` (deriving RREV from the MD5 of `conanmanifest.txt` when not given explicitly) and, optionally, a binary package layer via `--package-dir`/`--package-id` (deriving PREV the same way). Files are validated against Conan's canonical file-name rules and the manifest is always uploaded last to signal completion to the server.
## Changes
- `modules/har/pkg/har/push_generic.go` (new)
- `modules/har/pkg/har/push_debian.go` (new)
- `modules/har/pkg/har/push_conan.go` (new)
- `modules/har/pkg/har/har.go` — registers the three new workflows (`push_artifact_generic`, `push_artifact_debian`, `push_artifact_conan`)
- `pkg/spec/har.spec.yaml` — declares the three new `push artifact:*` commands, flags, and help text
## Test plan
- [x] `harness push artifact:generic <registry>/<name> <file-or-dir>... [--version v] [--include-hidden]`
- [x] `harness push artifact:debian <registry> <pkg>.deb --distribution focal --component main`
- [x] `harness push artifact:debian <registry> <pkg>.dsc --distribution focal --component main --source-file <src>.tar.xz --origin-source-file <orig>.tar.gz`
- [x] `harness push artifact:conan <registry> name/version[@user/channel] <recipe-dir> [--package-dir <dir> --package-id <sha1>]`