### PR TITLE
feat: add firewall-wrapped pkgmgr commands for npm, pip, maven, and dotnet

### DIFF
--- a/modules/har/pkg/har/configure_maven.go
+++ b/modules/har/pkg/har/configure_maven.go
@@ -34,6 +34,13 @@ func configureMaven(ctx *cmdctx.Ctx) error {
 		return fmt.Errorf("writing settings.xml: %w", err)
 	}
 
+	_ = savePkgmgrConfig("maven", pkgmgrSavedConfig{
+		RegistryIdentifier: registryID,
+		RegistryURL:        registryURL,
+		OrgID:              a.OrgID,
+		ProjectID:          a.ProjectID,
+	})
+
 	fmt.Printf("Configured Maven → %s (%s)\n", registryURL, settingsPath)
 	return nil
 }
@@ -52,6 +59,33 @@ func writeMavenSettings(settingsPath, registryID, registryURL, authToken string)
 		URL      string   `xml:"url"`
 		MirrorOf string   `xml:"mirrorOf"`
 	}
+	type RepoEnabled struct {
+		Enabled bool `xml:"enabled"`
+	}
+	type Repository struct {
+		ID        string      `xml:"id"`
+		URL       string      `xml:"url"`
+		Releases  RepoEnabled `xml:"releases"`
+		Snapshots RepoEnabled `xml:"snapshots"`
+	}
+	type PluginRepository struct {
+		ID        string      `xml:"id"`
+		URL       string      `xml:"url"`
+		Releases  RepoEnabled `xml:"releases"`
+		Snapshots RepoEnabled `xml:"snapshots"`
+	}
+	type Profile struct {
+		XMLName      xml.Name `xml:"profile"`
+		ID           string   `xml:"id"`
+		Repositories struct {
+			XMLName    xml.Name     `xml:"repositories"`
+			Repository []Repository `xml:"repository"`
+		}
+		PluginRepositories struct {
+			XMLName          xml.Name           `xml:"pluginRepositories"`
+			PluginRepository []PluginRepository `xml:"pluginRepository"`
+		}
+	}
 	type Settings struct {
 		XMLName xml.Name `xml:"settings"`
 		Xmlns   string   `xml:"xmlns,attr"`
@@ -62,6 +96,14 @@ func writeMavenSettings(settingsPath, registryID, registryURL, authToken string)
 		Mirrors struct {
 			XMLName xml.Name `xml:"mirrors"`
 			Mirror  []Mirror `xml:"mirror"`
+		}
+		Profiles struct {
+			XMLName xml.Name  `xml:"profiles"`
+			Profile []Profile `xml:"profile"`
+		}
+		ActiveProfiles struct {
+			XMLName       xml.Name `xml:"activeProfiles"`
+			ActiveProfile []string `xml:"activeProfile"`
 		}
 	}
 
@@ -75,23 +117,50 @@ func writeMavenSettings(settingsPath, registryID, registryURL, authToken string)
 
 	serverID := "harness-" + registryID
 
+	// Strip any Harness-managed mirrors entirely — mirrorOf: "*" breaks
+	// resolution of Maven's own core lifecycle plugins, so previously
+	// written broken configs self-heal here with no replacement.
 	var mirrors []Mirror
 	for _, m := range settings.Mirrors.Mirror {
-		if m.ID == serverID {
-			continue
-		}
-		if strings.HasPrefix(m.ID, "harness-") && m.MirrorOf == "*" {
+		if strings.HasPrefix(m.ID, "harness-") {
 			continue
 		}
 		mirrors = append(mirrors, m)
 	}
-	mirrors = append(mirrors, Mirror{
-		ID:       serverID,
-		Name:     "Harness " + registryID,
-		URL:      registryURL,
-		MirrorOf: "*",
-	})
 	settings.Mirrors.Mirror = mirrors
+
+	var profiles []Profile
+	for _, p := range settings.Profiles.Profile {
+		if strings.HasPrefix(p.ID, "harness-") {
+			continue
+		}
+		profiles = append(profiles, p)
+	}
+	newProfile := Profile{ID: serverID}
+	newProfile.Repositories.Repository = []Repository{{
+		ID:        serverID,
+		URL:       registryURL,
+		Releases:  RepoEnabled{Enabled: true},
+		Snapshots: RepoEnabled{Enabled: true},
+	}}
+	newProfile.PluginRepositories.PluginRepository = []PluginRepository{{
+		ID:        serverID,
+		URL:       registryURL,
+		Releases:  RepoEnabled{Enabled: true},
+		Snapshots: RepoEnabled{Enabled: true},
+	}}
+	profiles = append(profiles, newProfile)
+	settings.Profiles.Profile = profiles
+
+	var activeProfiles []string
+	for _, ap := range settings.ActiveProfiles.ActiveProfile {
+		if strings.HasPrefix(ap, "harness-") {
+			continue
+		}
+		activeProfiles = append(activeProfiles, ap)
+	}
+	activeProfiles = append(activeProfiles, serverID)
+	settings.ActiveProfiles.ActiveProfile = activeProfiles
 
 	var servers []Server
 	for _, s := range settings.Servers.Server {

--- a/modules/har/pkg/har/configure_npm.go
+++ b/modules/har/pkg/har/configure_npm.go
@@ -61,6 +61,13 @@ func configureNpm(ctx *cmdctx.Ctx) error {
 		return fmt.Errorf("writing .npmrc: %w", err)
 	}
 
+	_ = savePkgmgrConfig("npm", pkgmgrSavedConfig{
+		RegistryIdentifier: registryID,
+		RegistryURL:        registryURL,
+		OrgID:              a.OrgID,
+		ProjectID:          a.ProjectID,
+	})
+
 	loc := npmrcPath
 	if global {
 		loc = "~/.npmrc"
@@ -126,7 +133,7 @@ func writeNpmrc(npmrcPath, registryURL, scope, authToken string) error {
 			if scope != "" && strings.HasPrefix(trimmed, scope+":registry=") {
 				lines = append(lines, scopeRegistryLine)
 				scopeFound = true
-			} else if scope == "" && strings.HasPrefix(trimmed, "registry=") && !strings.Contains(trimmed, ":") {
+			} else if scope == "" && strings.HasPrefix(trimmed, "registry="){
 				lines = append(lines, scopeRegistryLine)
 				scopeFound = true
 			} else if strings.HasPrefix(trimmed, "//"+registryHost+"/:_authToken=") {

--- a/modules/har/pkg/har/configure_nuget.go
+++ b/modules/har/pkg/har/configure_nuget.go
@@ -33,6 +33,13 @@ func configureNuget(ctx *cmdctx.Ctx) error {
 		return fmt.Errorf("writing NuGet.Config: %w", err)
 	}
 
+	_ = savePkgmgrConfig("nuget", pkgmgrSavedConfig{
+		RegistryIdentifier: registryID,
+		RegistryURL:        registryURL,
+		OrgID:              a.OrgID,
+		ProjectID:          a.ProjectID,
+	})
+
 	fmt.Printf("Configured NuGet → %s (%s)\n", registryURL, configPath)
 	return nil
 }

--- a/modules/har/pkg/har/configure_pip.go
+++ b/modules/har/pkg/har/configure_pip.go
@@ -38,6 +38,13 @@ func configurePip(ctx *cmdctx.Ctx) error {
 		return fmt.Errorf("writing pip.conf: %w", err)
 	}
 
+	_ = savePkgmgrConfig("pip", pkgmgrSavedConfig{
+		RegistryIdentifier: registryID,
+		RegistryURL:        registryURL,
+		OrgID:              a.OrgID,
+		ProjectID:          a.ProjectID,
+	})
+
 	fmt.Printf("Configured pip → %s (%s)\n", registryURL, pipConfPath)
 	return nil
 }

--- a/modules/har/pkg/har/har.go
+++ b/modules/har/pkg/har/har.go
@@ -29,4 +29,9 @@ func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterWorkflow(executeRegistryFirewallScanHandlerID, executeRegistryFirewallScanHandler)
 	reg.RegisterWorkflow(executeRegistryMigrateHandlerID, executeRegistryMigrateHandler)
 	reg.RegisterWorkflow(configureRegistryHandlerID, configureRegistryHandler)
+	reg.RegisterWorkflow(executeArtifactNpmInstallHandlerID, executeArtifactNpmInstallHandler)
+	reg.RegisterWorkflow(executeArtifactNpmCiHandlerID, executeArtifactNpmCiHandler)
+	reg.RegisterWorkflow(executeArtifactPipInstallHandlerID, executeArtifactPipInstallHandler)
+	reg.RegisterWorkflow(executeArtifactMvnInstallHandlerID, executeArtifactMvnInstallHandler)
+	reg.RegisterWorkflow(executeArtifactDotnetRestoreHandlerID, executeArtifactDotnetRestoreHandler)
 }

--- a/modules/har/pkg/har/harutil.go
+++ b/modules/har/pkg/har/harutil.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -101,6 +102,40 @@ func buildPkgURL(registryURL, accountID, subpath string) (string, error) {
 	q.Set("accountIdentifier", accountID)
 	base.RawQuery = q.Encode()
 	return base.String(), nil
+}
+
+// savePkgmgrConfig writes a pkgmgrSavedConfig to ~/.harness/<name>-pkgmgr.json.
+func savePkgmgrConfig(name string, cfg pkgmgrSavedConfig) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(home, ".harness")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWrite(filepath.Join(dir, name+"-pkgmgr.json"), data, 0600)
+}
+
+// loadPkgmgrConfig reads ~/.harness/<name>-pkgmgr.json; returns nil if absent.
+func loadPkgmgrConfig(name string) *pkgmgrSavedConfig {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".harness", name+"-pkgmgr.json"))
+	if err != nil {
+		return nil
+	}
+	var cfg pkgmgrSavedConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	return &cfg
 }
 
 // readFileFromTarGz reads the contents of the first file in archivePath whose path

--- a/modules/har/pkg/har/pkgmgr_client.go
+++ b/modules/har/pkg/har/pkgmgr_client.go
@@ -1,0 +1,48 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+// pkgmgrRegistryInfo holds the HAR registry info detected from a client config file.
+type pkgmgrRegistryInfo struct {
+	RegistryURL        string
+	RegistryIdentifier string
+	OrgID              string
+	ProjectID          string
+}
+
+// pkgmgrSavedConfig is persisted to ~/.harness/<client>-pkgmgr.json by configure commands.
+type pkgmgrSavedConfig struct {
+	RegistryIdentifier string `json:"registryIdentifier"`
+	RegistryURL        string `json:"registryUrl"`
+	OrgID              string `json:"orgId,omitempty"`
+	ProjectID          string `json:"projectId,omitempty"`
+}
+
+// pkgmgrInstallResult holds the outcome of running a native package manager command.
+type pkgmgrInstallResult struct {
+	Status string // "SUCCESS" or "FAILURE"
+	Stderr string
+	Err    error
+}
+
+// pkgmgrClient is the interface each package manager client must implement.
+type pkgmgrClient interface {
+	// Name returns the human-readable client name (e.g. "npm").
+	Name() string
+
+	// DetectRegistry finds the HAR registry from the config file written by
+	// `configure registry`. explicitRegistry overrides detection when non-empty.
+	DetectRegistry(explicitRegistry string) (*pkgmgrRegistryInfo, error)
+
+	// RunCommand executes the native tool with args and streams output live.
+	RunCommand(subcommand string, args []string) (*pkgmgrInstallResult, error)
+
+	// DetectFirewallError returns true if stderr contains a 403 / firewall pattern.
+	DetectFirewallError(stderr string) bool
+
+	// ResolveDeps returns the full dependency list for firewall evaluation.
+	// Checks well-known lock files first; falls back to native tool generation.
+	// The returned cleanup func (may be nil) removes any temp files created.
+	ResolveDeps() ([]dependency, func(), error)
+}

--- a/modules/har/pkg/har/pkgmgr_handlers.go
+++ b/modules/har/pkg/har/pkgmgr_handlers.go
@@ -1,0 +1,39 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import "github.com/harness/cli/pkg/cmdctx"
+
+const (
+	executeArtifactNpmInstallHandlerID    = "execute_artifact_npm_install"
+	executeArtifactNpmCiHandlerID         = "execute_artifact_npm_ci"
+	executeArtifactPipInstallHandlerID    = "execute_artifact_pip_install"
+	executeArtifactMvnInstallHandlerID    = "execute_artifact_mvn_install"
+	executeArtifactDotnetRestoreHandlerID = "execute_artifact_dotnet_restore"
+)
+
+func executeArtifactNpmInstallHandler(ctx *cmdctx.Ctx) error {
+	_, nativeArgs := pkgmgrParseArgs(ctx.Args)
+	return pkgmgrExecute(ctx, &npmClient{}, "install", nativeArgs)
+}
+
+func executeArtifactNpmCiHandler(ctx *cmdctx.Ctx) error {
+	_, nativeArgs := pkgmgrParseArgs(ctx.Args)
+	return pkgmgrExecute(ctx, &npmClient{}, "ci", nativeArgs)
+}
+
+func executeArtifactPipInstallHandler(ctx *cmdctx.Ctx) error {
+	_, nativeArgs := pkgmgrParseArgs(ctx.Args)
+	return pkgmgrExecute(ctx, &pipClient{}, "install", nativeArgs)
+}
+
+func executeArtifactMvnInstallHandler(ctx *cmdctx.Ctx) error {
+	_, nativeArgs := pkgmgrParseArgs(ctx.Args)
+	return pkgmgrExecute(ctx, &mavenClient{}, "install", nativeArgs)
+}
+
+func executeArtifactDotnetRestoreHandler(ctx *cmdctx.Ctx) error {
+	_, nativeArgs := pkgmgrParseArgs(ctx.Args)
+	return pkgmgrExecute(ctx, &nugetClient{}, "restore", nativeArgs)
+}

--- a/modules/har/pkg/har/pkgmgr_maven.go
+++ b/modules/har/pkg/har/pkgmgr_maven.go
@@ -1,0 +1,152 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var mvnHarURLPattern = regexp.MustCompile(`(?:https?://[^/]+)/(?:pkg/)?([^/]+)/([^/]+)/maven/?`)
+var mvn403Pattern = regexp.MustCompile(`(?i)(403\s*Forbidden|status\s*code:\s*403|Return code is:\s*403|HTTP/\S+\s+403)`)
+
+type mavenClient struct{}
+
+func (c *mavenClient) Name() string { return "mvn" }
+
+func (c *mavenClient) DetectRegistry(explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	if saved := loadPkgmgrConfig("maven"); saved != nil {
+		if explicitRegistry == "" || explicitRegistry == saved.RegistryIdentifier {
+			return &pkgmgrRegistryInfo{
+				RegistryURL:        saved.RegistryURL,
+				RegistryIdentifier: saved.RegistryIdentifier,
+				OrgID:              saved.OrgID,
+				ProjectID:          saved.ProjectID,
+			}, nil
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		info, err := mvnParseSettings(filepath.Join(home, ".m2", "settings.xml"), explicitRegistry)
+		if err == nil && info != nil {
+			return info, nil
+		}
+	}
+	if explicitRegistry != "" {
+		return nil, fmt.Errorf("HAR registry %q not found in Maven settings.xml", explicitRegistry)
+	}
+	return nil, fmt.Errorf("no HAR registry found — run `harness configure registry --client maven` first")
+}
+
+func (c *mavenClient) RunCommand(subcommand string, args []string) (*pkgmgrInstallResult, error) {
+	cmdArgs := append([]string{subcommand}, args...)
+	cmd := exec.Command("mvn", cmdArgs...)
+	cmd.Stdin = os.Stdin
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	err := cmd.Run()
+	combined := stdoutBuf.String() + "\n" + stderrBuf.String()
+	if err != nil {
+		return &pkgmgrInstallResult{Status: "FAILURE", Stderr: combined, Err: err}, nil
+	}
+	return &pkgmgrInstallResult{Status: "SUCCESS", Stderr: combined}, nil
+}
+
+func (c *mavenClient) DetectFirewallError(stderr string) bool {
+	return mvn403Pattern.MatchString(stderr)
+}
+
+func (c *mavenClient) ResolveDeps() ([]dependency, func(), error) {
+	noop := func() {}
+
+	cmd := exec.Command("mvn", "dependency:tree", "-DoutputType=text")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if _, statErr := os.Stat("pom.xml"); statErr == nil {
+			deps, err := parseLockFile("pom.xml")
+			return deps, noop, err
+		}
+		return nil, noop, fmt.Errorf("mvn dependency:tree failed and no pom.xml found: %w", err)
+	}
+
+	deps := mvnParseDependencyTree(stdout.String())
+	if len(deps) == 0 {
+		if _, statErr := os.Stat("pom.xml"); statErr == nil {
+			deps, err := parseLockFile("pom.xml")
+			return deps, noop, err
+		}
+		return nil, noop, fmt.Errorf("no dependencies resolved from mvn dependency:tree")
+	}
+	return deps, noop, nil
+}
+
+// mvnParseDependencyTree parses `mvn dependency:tree -DoutputType=text` output.
+// Lines look like: [INFO] +- com.google.guava:guava:jar:31.1-jre:compile
+func mvnParseDependencyTree(output string) []dependency {
+	depRe := regexp.MustCompile(`[|+\\\- ]+\s*(\S+):(\S+):(\S+):(\S+):(\S+)`)
+	seen := map[string]bool{}
+	var deps []dependency
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "[INFO]") {
+			continue
+		}
+		m := depRe.FindStringSubmatch(strings.TrimPrefix(line, "[INFO] "))
+		if len(m) < 6 {
+			continue
+		}
+		name := m[1] + ":" + m[2]
+		version := m[4]
+		key := name + "@" + version
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deps = append(deps, dependency{Name: name, Version: version})
+	}
+	return deps
+}
+
+func mvnParseSettings(settingsPath, explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return nil, err
+	}
+	type Mirror struct {
+		ID  string `xml:"id"`
+		URL string `xml:"url"`
+	}
+	type Settings struct {
+		Mirrors struct {
+			Mirror []Mirror `xml:"mirror"`
+		} `xml:"mirrors"`
+	}
+	var settings Settings
+	if err := xml.Unmarshal(data, &settings); err != nil {
+		return nil, err
+	}
+	for _, m := range settings.Mirrors.Mirror {
+		if !mvnHarURLPattern.MatchString(m.URL) {
+			continue
+		}
+		matches := mvnHarURLPattern.FindStringSubmatch(m.URL)
+		if len(matches) < 3 {
+			continue
+		}
+		regID := matches[2]
+		if explicitRegistry != "" && regID != explicitRegistry {
+			continue
+		}
+		return &pkgmgrRegistryInfo{RegistryURL: m.URL, RegistryIdentifier: regID}, nil
+	}
+	return nil, fmt.Errorf("no HAR registry URL found in %s", settingsPath)
+}

--- a/modules/har/pkg/har/pkgmgr_npm.go
+++ b/modules/har/pkg/har/pkgmgr_npm.go
@@ -1,0 +1,132 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var npmHarURLPattern = regexp.MustCompile(`(?:https?://[^/]+)/(?:pkg/)?([^/]+)/([^/]+)/npm/?$`)
+var npm403Pattern = regexp.MustCompile(`(?i)(403\s*forbidden|E403|\bstatus\s+403\b)`)
+
+type npmClient struct{}
+
+func (c *npmClient) Name() string { return "npm" }
+
+func (c *npmClient) DetectRegistry(explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	if saved := loadPkgmgrConfig("npm"); saved != nil {
+		if explicitRegistry == "" || explicitRegistry == saved.RegistryIdentifier {
+			return &pkgmgrRegistryInfo{
+				RegistryURL:        saved.RegistryURL,
+				RegistryIdentifier: saved.RegistryIdentifier,
+				OrgID:              saved.OrgID,
+				ProjectID:          saved.ProjectID,
+			}, nil
+		}
+	}
+	paths := []string{filepath.Join(".", ".npmrc")}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".npmrc"))
+	}
+	for _, p := range paths {
+		info, err := npmParseNpmrc(p, explicitRegistry)
+		if err == nil && info != nil {
+			return info, nil
+		}
+	}
+	if explicitRegistry != "" {
+		return nil, fmt.Errorf("HAR registry %q not found in .npmrc", explicitRegistry)
+	}
+	return nil, fmt.Errorf("no HAR registry found — run `harness configure registry --client npm` first")
+}
+
+func (c *npmClient) RunCommand(subcommand string, args []string) (*pkgmgrInstallResult, error) {
+	cmdArgs := append([]string{subcommand}, args...)
+	cmd := exec.Command("npm", cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	err := cmd.Run()
+	stderrStr := stderrBuf.String()
+	if err != nil {
+		return &pkgmgrInstallResult{Status: "FAILURE", Stderr: stderrStr, Err: err}, nil
+	}
+	return &pkgmgrInstallResult{Status: "SUCCESS", Stderr: stderrStr}, nil
+}
+
+func (c *npmClient) DetectFirewallError(stderr string) bool {
+	return npm403Pattern.MatchString(stderr)
+}
+
+func (c *npmClient) ResolveDeps() ([]dependency, func(), error) {
+	noop := func() {}
+	lockFiles := []string{"package-lock.json", "yarn.lock", "pnpm-lock.yaml"}
+	for _, lf := range lockFiles {
+		if _, err := os.Stat(lf); err == nil {
+			deps, err := parseLockFile(lf)
+			if err == nil && len(deps) > 0 {
+				return deps, noop, nil
+			}
+		}
+	}
+
+	// Generate lock file
+	cmd := exec.Command("npm", "install", "--package-lock-only")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if _, statErr := os.Stat("package.json"); statErr == nil {
+			deps, err := parseLockFile("package.json")
+			return deps, noop, err
+		}
+		return nil, noop, fmt.Errorf("no dependency files found: %w", err)
+	}
+	cleanup := func() { os.Remove("package-lock.json") }
+	deps, err := parseLockFile("package-lock.json")
+	return deps, cleanup, err
+}
+
+func npmParseNpmrc(path, explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var registryURL string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "registry=") {
+			parts := strings.SplitN(line, "registry=", 2)
+			if len(parts) == 2 {
+				candidate := strings.TrimSpace(parts[1])
+				if npmHarURLPattern.MatchString(candidate) {
+					registryURL = candidate
+				}
+			}
+		}
+	}
+	if registryURL == "" {
+		return nil, fmt.Errorf("no HAR registry URL in %s", path)
+	}
+	matches := npmHarURLPattern.FindStringSubmatch(registryURL)
+	if len(matches) < 3 {
+		return nil, fmt.Errorf("failed to parse HAR URL: %s", registryURL)
+	}
+	regID := matches[2]
+	if explicitRegistry != "" && regID != explicitRegistry {
+		return nil, fmt.Errorf("registry mismatch")
+	}
+	return &pkgmgrRegistryInfo{RegistryURL: registryURL, RegistryIdentifier: regID}, nil
+}
+

--- a/modules/har/pkg/har/pkgmgr_nuget.go
+++ b/modules/har/pkg/har/pkgmgr_nuget.go
@@ -1,0 +1,278 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var nugetHarURLPattern = regexp.MustCompile(`(?:https?://[^/]+)/(?:pkg/)?([^/]+)/([^/]+)/nuget/?`)
+var nuget403Pattern = regexp.MustCompile(`(?i)(403\s*\(Forbidden\)|Response status code does not indicate success:\s*403|HTTP\s+403)`)
+
+type nugetClient struct{}
+
+func (c *nugetClient) Name() string { return "dotnet" }
+
+func (c *nugetClient) DetectRegistry(explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	if saved := loadPkgmgrConfig("nuget"); saved != nil {
+		if explicitRegistry == "" || explicitRegistry == saved.RegistryIdentifier {
+			return &pkgmgrRegistryInfo{
+				RegistryURL:        saved.RegistryURL,
+				RegistryIdentifier: saved.RegistryIdentifier,
+				OrgID:              saved.OrgID,
+				ProjectID:          saved.ProjectID,
+			}, nil
+		}
+	}
+	paths := nugetConfPaths()
+	for _, p := range paths {
+		info, err := nugetParseConf(p, explicitRegistry)
+		if err == nil && info != nil {
+			return info, nil
+		}
+	}
+	if explicitRegistry != "" {
+		return nil, fmt.Errorf("HAR registry %q not found in NuGet configuration", explicitRegistry)
+	}
+	return nil, fmt.Errorf("no HAR registry found — run `harness configure registry --client nuget` first")
+}
+
+func (c *nugetClient) RunCommand(subcommand string, args []string) (*pkgmgrInstallResult, error) {
+	cmdArgs := append([]string{subcommand}, args...)
+	cmd := exec.Command("dotnet", cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	err := cmd.Run()
+	stderrStr := stderrBuf.String()
+	if err != nil {
+		return &pkgmgrInstallResult{Status: "FAILURE", Stderr: stderrStr, Err: err}, nil
+	}
+	return &pkgmgrInstallResult{Status: "SUCCESS", Stderr: stderrStr}, nil
+}
+
+func (c *nugetClient) DetectFirewallError(stderr string) bool {
+	return nuget403Pattern.MatchString(stderr)
+}
+
+func (c *nugetClient) ResolveDeps() ([]dependency, func(), error) {
+	noop := func() {}
+
+	// Try packages.lock.json or obj/project.assets.json first
+	lockFiles := []string{"packages.lock.json"}
+	if entries, err := filepath.Glob("**/obj/project.assets.json"); err == nil {
+		lockFiles = append(lockFiles, entries...)
+	}
+	if _, err := os.Stat("obj/project.assets.json"); err == nil {
+		lockFiles = append(lockFiles, "obj/project.assets.json")
+	}
+	for _, lf := range lockFiles {
+		if _, err := os.Stat(lf); err == nil {
+			deps, err := nugetParseLockFile(lf)
+			if err == nil && len(deps) > 0 {
+				return deps, noop, nil
+			}
+		}
+	}
+
+	// dotnet list package --include-transitive --format json
+	cmd := exec.Command("dotnet", "list", "package", "--include-transitive", "--format", "json")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		deps, parseErr := nugetParseCsproj()
+		if parseErr != nil || len(deps) == 0 {
+			return nil, noop, fmt.Errorf("dotnet list package failed and no csproj deps found: %w", err)
+		}
+		return deps, noop, nil
+	}
+
+	deps, err := nugetParseDotnetListJSON(stdout.String())
+	if err != nil || len(deps) == 0 {
+		deps, _ = nugetParseCsproj()
+	}
+	return deps, noop, nil
+}
+
+func nugetParseLockFile(path string) ([]dependency, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasSuffix(path, "packages.lock.json") {
+		var lf struct {
+			Dependencies map[string]map[string]struct {
+				Resolved string `json:"resolved"`
+			} `json:"dependencies"`
+		}
+		if err := json.Unmarshal(data, &lf); err != nil {
+			return nil, err
+		}
+		seen := map[string]bool{}
+		var deps []dependency
+		for _, framework := range lf.Dependencies {
+			for name, info := range framework {
+				key := name + "@" + info.Resolved
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				deps = append(deps, dependency{Name: name, Version: info.Resolved})
+			}
+		}
+		return deps, nil
+	}
+	// project.assets.json
+	var assets struct {
+		Libraries map[string]struct {
+			Type string `json:"type"`
+		} `json:"libraries"`
+	}
+	if err := json.Unmarshal(data, &assets); err != nil {
+		return nil, err
+	}
+	var deps []dependency
+	for lib, info := range assets.Libraries {
+		if info.Type != "package" {
+			continue
+		}
+		parts := strings.SplitN(lib, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		deps = append(deps, dependency{Name: parts[0], Version: parts[1]})
+	}
+	return deps, nil
+}
+
+func nugetParseDotnetListJSON(output string) ([]dependency, error) {
+	var out struct {
+		Projects []struct {
+			Frameworks []struct {
+				TopLevelPackages   []struct{ ID, Version string } `json:"topLevelPackages"`
+				TransitivePackages []struct{ ID, Version string } `json:"transitivePackages"`
+			} `json:"frameworks"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal([]byte(output), &out); err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var deps []dependency
+	for _, proj := range out.Projects {
+		for _, fw := range proj.Frameworks {
+			for _, pkg := range append(fw.TopLevelPackages, fw.TransitivePackages...) {
+				key := pkg.ID + "@" + pkg.Version
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				deps = append(deps, dependency{Name: pkg.ID, Version: pkg.Version})
+			}
+		}
+	}
+	return deps, nil
+}
+
+func nugetParseCsproj() ([]dependency, error) {
+	files, _ := filepath.Glob("*.csproj")
+	if len(files) == 0 {
+		_ = filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
+			if err == nil && !d.IsDir() && strings.HasSuffix(path, ".csproj") {
+				files = append(files, path)
+			}
+			return nil
+		})
+	}
+	seen := map[string]bool{}
+	var deps []dependency
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		type PackageRef struct {
+			Include string `xml:"Include,attr"`
+			Version string `xml:"Version,attr"`
+		}
+		type ItemGroup struct {
+			PackageReferences []PackageRef `xml:"PackageReference"`
+		}
+		type Project struct {
+			ItemGroups []ItemGroup `xml:"ItemGroup"`
+		}
+		var proj Project
+		if err := xml.Unmarshal(data, &proj); err != nil {
+			continue
+		}
+		for _, ig := range proj.ItemGroups {
+			for _, ref := range ig.PackageReferences {
+				if ref.Include == "" || seen[ref.Include] {
+					continue
+				}
+				seen[ref.Include] = true
+				ver := ref.Version
+				if ver == "" {
+					ver = "latest"
+				}
+				deps = append(deps, dependency{Name: ref.Include, Version: ver})
+			}
+		}
+	}
+	return deps, nil
+}
+
+func nugetConfPaths() []string {
+	paths := []string{"nuget.config", "NuGet.Config", "NuGet.config"}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".nuget", "NuGet", "NuGet.Config"))
+	}
+	return paths
+}
+
+func nugetParseConf(confPath, explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return nil, err
+	}
+	type PackageSource struct {
+		Key   string `xml:"key,attr"`
+		Value string `xml:"value,attr"`
+	}
+	type Configuration struct {
+		PackageSources struct {
+			Sources []PackageSource `xml:"add"`
+		} `xml:"packageSources"`
+	}
+	var conf Configuration
+	if err := xml.Unmarshal(data, &conf); err != nil {
+		return nil, err
+	}
+	for _, s := range conf.PackageSources.Sources {
+		if !nugetHarURLPattern.MatchString(s.Value) {
+			continue
+		}
+		matches := nugetHarURLPattern.FindStringSubmatch(s.Value)
+		if len(matches) < 3 {
+			continue
+		}
+		regID := matches[2]
+		if explicitRegistry != "" && regID != explicitRegistry {
+			continue
+		}
+		return &pkgmgrRegistryInfo{RegistryURL: s.Value, RegistryIdentifier: regID}, nil
+	}
+	return nil, fmt.Errorf("no HAR registry URL found in %s", confPath)
+}

--- a/modules/har/pkg/har/pkgmgr_orchestrator.go
+++ b/modules/har/pkg/har/pkgmgr_orchestrator.go
@@ -1,0 +1,305 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/harness/cli/pkg/auth"
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+// pkgmgrExecute is the shared 4-phase flow for all package manager wrappers:
+//  1. Detect HAR registry from config files written by `configure registry`
+//  2. Resolve registry UUID via HAR API
+//  3. Run the native command; stream output live
+//  4. On 403: resolve deps → bulk firewall evaluation → display results
+func pkgmgrExecute(cmdCtx *cmdctx.Ctx, client pkgmgrClient, subcommand string, nativeArgs []string) error {
+	a := cmdCtx.Auth
+	explicitRegistry := cmdCtx.Id
+
+	// Phase 1 — detect registry
+	fmt.Fprintf(os.Stderr, "Detecting HAR registry...\n")
+	regInfo, err := client.DetectRegistry(explicitRegistry)
+	if err != nil {
+		return fmt.Errorf("detecting HAR registry: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Found HAR registry: %s\n", regInfo.RegistryIdentifier)
+
+	// Phase 2 — resolve UUID; prefer org/project from configure-saved config
+	// so that pipeline env vars (ORG_IDENTIFIER, PROJECT_IDENTIFIER) cannot
+	// silently redirect an account-level registry lookup to the wrong scope.
+	fmt.Fprintf(os.Stderr, "Resolving registry details...\n")
+	ctx := context.Background()
+	hc := newHTTPClient()
+	scopedAuth := *a
+	if regInfo.OrgID != "" {
+		scopedAuth.OrgID = regInfo.OrgID
+		scopedAuth.ProjectID = regInfo.ProjectID
+	}
+	registryUUID, err := getRegistryUUID(ctx, hc, &scopedAuth, regInfo.RegistryIdentifier)
+	if err != nil {
+		return fmt.Errorf("resolving registry UUID: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Registry UUID: %s\n", registryUUID)
+
+	// Phase 3 — run native command
+	fmt.Fprintf(os.Stderr, "Running %s %s...\n", client.Name(), subcommand)
+	result, err := client.RunCommand(subcommand, nativeArgs)
+	if err != nil && result == nil {
+		return fmt.Errorf("%s %s failed: %w", client.Name(), subcommand, err)
+	}
+
+	if result.Status == "SUCCESS" {
+		return nil
+	}
+
+	// Phase 4 — 403 / firewall block detected?
+	if !client.DetectFirewallError(result.Stderr) {
+		return fmt.Errorf("%s %s failed", client.Name(), subcommand)
+	}
+
+	fmt.Fprintf(os.Stderr, "\n%s %s failed — firewall may have blocked packages\n\n", client.Name(), subcommand)
+
+	fmt.Fprintf(os.Stderr, "Resolving complete dependency list...\n")
+	deps, cleanup, err := client.ResolveDeps()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return fmt.Errorf("%s %s failed: dependency resolution: %w", client.Name(), subcommand, err)
+	}
+	if len(deps) == 0 {
+		return fmt.Errorf("%s %s failed: no dependencies found to evaluate", client.Name(), subcommand)
+	}
+	fmt.Fprintf(os.Stderr, "Resolved %d dependencies (including transitive)\n", len(deps))
+
+	pkgmgrSaveBuildInfo(client.Name(), subcommand, regInfo.RegistryIdentifier, deps)
+
+	artifacts := make([]artifactScanInput, 0, len(deps))
+	for _, d := range deps {
+		artifacts = append(artifacts, artifactScanInput{PackageName: d.Name, Version: d.Version})
+	}
+
+	fmt.Fprintf(os.Stderr, "Fetching firewall evaluation...\n")
+	if _, evalErr := pkgmgrBulkEvalAndDisplay(ctx, hc, &scopedAuth, registryUUID, artifacts); evalErr != nil {
+		fmt.Fprintf(os.Stderr, "Firewall evaluation failed: %v\n", evalErr)
+	}
+
+	return fmt.Errorf("%s %s failed", client.Name(), subcommand)
+}
+
+const (
+	pkgmgrMaxRetries     = 3
+	pkgmgrRetryInterval  = 30 * time.Second
+)
+
+// pkgmgrBulkEvalAndDisplay batches artifacts into ≤50-item chunks, polls each
+// evaluation to completion, and prints BLOCKED/WARN/ALLOWED results with scan details.
+func pkgmgrBulkEvalAndDisplay(ctx context.Context, hc *http.Client, a *auth.ResolvedAuth, registryUUID string, artifacts []artifactScanInput) (int, error) {
+	const batchSize = 50
+	totalBatches := (len(artifacts) + batchSize - 1) / batchSize
+	var allScans []bulkScanItem
+
+	for i := 0; i < totalBatches; i++ {
+		start := i * batchSize
+		end := start + batchSize
+		if end > len(artifacts) {
+			end = len(artifacts)
+		}
+		batch := artifacts[start:end]
+
+		if totalBatches > 1 {
+			fmt.Fprintf(os.Stderr, "Evaluating batch %d/%d (%d packages)...\n", i+1, totalBatches, len(batch))
+		}
+
+		scans, err := pkgmgrRunBatch(ctx, hc, a, registryUUID, batch, i+1)
+		if err != nil {
+			return 0, err
+		}
+		allScans = append(allScans, scans...)
+	}
+
+	results := make([]auditScanResult, 0, len(allScans))
+	for _, s := range allScans {
+		r := auditScanResult{}
+		if s.PackageName != nil {
+			r.PackageName = *s.PackageName
+		}
+		if s.Version != nil {
+			r.Version = *s.Version
+		}
+		if s.ScanId != nil {
+			r.ScanID = *s.ScanId
+		}
+		if s.ScanStatus != nil {
+			r.ScanStatus = *s.ScanStatus
+		}
+		results = append(results, r)
+	}
+
+	fmt.Printf("\nFirewall evaluation: %d package(s) evaluated\n", len(results))
+	for _, r := range results {
+		switch r.ScanStatus {
+		case "BLOCKED":
+			fmt.Printf("  BLOCKED  %s@%s\n", r.PackageName, r.Version)
+		case "WARN":
+			fmt.Printf("  WARN     %s@%s\n", r.PackageName, r.Version)
+		case "ALLOWED":
+			fmt.Printf("  ALLOWED  %s@%s\n", r.PackageName, r.Version)
+			continue
+		default:
+			fmt.Printf("  %-7s  %s@%s\n", r.ScanStatus, r.PackageName, r.Version)
+			continue
+		}
+		// Fetch and print policy-set violation details for BLOCKED/WARN.
+		if r.ScanID != "" {
+			detailURL := buildScanDetailsURL(a.APIUrl, r.ScanID, a.AccountID)
+			var detailResp scanDetailsResp
+			if err := doHAR(ctx, hc, a, detailURL, "GET", nil, &detailResp); err == nil && detailResp.Data != nil {
+				printScanDetails(detailResp.Data)
+			}
+		}
+	}
+
+	return len(results), nil
+}
+
+// pkgmgrRunBatch initiates a single bulk eval batch and polls to completion with retry/backoff.
+func pkgmgrRunBatch(ctx context.Context, hc *http.Client, a *auth.ResolvedAuth, registryUUID string, batch []artifactScanInput, batchNum int) ([]bulkScanItem, error) {
+	var lastErr error
+	for attempt := 1; attempt <= pkgmgrMaxRetries; attempt++ {
+		scans, err := pkgmgrInitiateAndPoll(ctx, hc, a, registryUUID, batch, batchNum)
+		if err == nil {
+			return scans, nil
+		}
+		lastErr = err
+		if attempt < pkgmgrMaxRetries {
+			fmt.Fprintf(os.Stderr, "batch %d: evaluation failed (attempt %d/%d), retrying in %ds: %v\n",
+				batchNum, attempt, pkgmgrMaxRetries, int(pkgmgrRetryInterval.Seconds()), err)
+			time.Sleep(pkgmgrRetryInterval)
+		}
+	}
+	return nil, fmt.Errorf("batch %d: evaluation failed after %d attempts: %w", batchNum, pkgmgrMaxRetries, lastErr)
+}
+
+// pkgmgrInitiateAndPoll initiates a bulk eval and polls until SUCCESS or FAILURE.
+func pkgmgrInitiateAndPoll(ctx context.Context, hc *http.Client, a *auth.ResolvedAuth, registryUUID string, batch []artifactScanInput, batchNum int) ([]bulkScanItem, error) {
+	evalURL := buildEvalURL(a.APIUrl, a.AccountID, a.OrgID, a.ProjectID)
+	var initResp bulkEvalAcceptedResp
+	if err := doHAR(ctx, hc, a, evalURL, "POST", bulkEvalRequest{
+		RegistryId: registryUUID,
+		Artifacts:  batch,
+	}, &initResp); err != nil {
+		return nil, fmt.Errorf("initiating evaluation: %w", err)
+	}
+	if initResp.Data == nil || initResp.Data.EvaluationId == nil {
+		return nil, fmt.Errorf("missing evaluationId in response")
+	}
+	evaluationID := *initResp.Data.EvaluationId
+
+	statusURL := buildEvalStatusURL(a.APIUrl, evaluationID, a.AccountID, a.OrgID, a.ProjectID)
+	pollRetries := 0
+	for poll := 0; poll < 120; poll++ {
+		var statusResp bulkEvalStatusResp
+		if err := doHAR(ctx, hc, a, statusURL, "GET", nil, &statusResp); err != nil {
+			pollRetries++
+			if pollRetries <= pkgmgrMaxRetries {
+				fmt.Fprintf(os.Stderr, "batch %d: poll failed (attempt %d/%d), retrying in %ds: %v\n",
+					batchNum, pollRetries, pkgmgrMaxRetries, int(pkgmgrRetryInterval.Seconds()), err)
+				time.Sleep(pkgmgrRetryInterval)
+				continue
+			}
+			return nil, fmt.Errorf("polling status failed after retries: %w", err)
+		}
+		if statusResp.Data == nil || statusResp.Data.Status == nil {
+			pollRetries++
+			if pollRetries <= pkgmgrMaxRetries {
+				time.Sleep(pkgmgrRetryInterval)
+				continue
+			}
+			return nil, fmt.Errorf("invalid status response after retries")
+		}
+		pollRetries = 0
+		switch *statusResp.Data.Status {
+		case "SUCCESS":
+			if statusResp.Data.Scans != nil {
+				return *statusResp.Data.Scans, nil
+			}
+			return nil, nil
+		case "FAILURE":
+			msg := "evaluation failed"
+			if statusResp.Data.Error != nil {
+				msg = *statusResp.Data.Error
+			}
+			return nil, fmt.Errorf("%s", msg)
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return nil, fmt.Errorf("timeout waiting for evaluation")
+}
+
+// pkgmgrSaveBuildInfo writes the resolved dependency list to .harness/build-info.json.
+func pkgmgrSaveBuildInfo(clientName, command, registry string, deps []dependency) {
+	type entry struct {
+		Client       string       `json:"client"`
+		Command      string       `json:"command"`
+		Registry     string       `json:"registry"`
+		Timestamp    string       `json:"timestamp"`
+		Dependencies []dependency `json:"dependencies"`
+	}
+	data, err := json.MarshalIndent(entry{
+		Client:       clientName,
+		Command:      command,
+		Registry:     registry,
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Dependencies: deps,
+	}, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(".harness", 0755)
+	_ = os.WriteFile(filepath.Join(".harness", "build-info.json"), data, 0644)
+}
+
+// pkgmgrParseArgs splits args at "--" and extracts an optional --registry value.
+// Everything before "--" is parsed for --registry; everything after is passed through.
+func pkgmgrParseArgs(args []string) (registry string, nativeArgs []string) {
+	sepIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+
+	var harArgs []string
+	if sepIdx >= 0 {
+		harArgs = args[:sepIdx]
+		nativeArgs = args[sepIdx+1:]
+	} else {
+		harArgs = args
+	}
+
+	for i := 0; i < len(harArgs); i++ {
+		switch {
+		case harArgs[i] == "--registry" && i+1 < len(harArgs):
+			registry = harArgs[i+1]
+			i++
+		case strings.HasPrefix(harArgs[i], "--registry="):
+			registry = strings.TrimPrefix(harArgs[i], "--registry=")
+		default:
+			nativeArgs = append(nativeArgs, harArgs[i])
+		}
+	}
+
+	return registry, nativeArgs
+}

--- a/modules/har/pkg/har/pkgmgr_pip.go
+++ b/modules/har/pkg/har/pkgmgr_pip.go
@@ -1,0 +1,196 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package har
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var pipHarURLPattern = regexp.MustCompile(`(?:https?://[^/@]+@?[^/]+)/(?:pkg/)?([^/]+)/([^/]+)/pypi/?`)
+var pip403Pattern = regexp.MustCompile(`(?i)(403\s*Forbidden|HTTP\s+error\s+403|status\s*code\s*403|Client Error:\s*403)`)
+
+type pipClient struct{}
+
+func (c *pipClient) Name() string { return "pip" }
+
+func (c *pipClient) DetectRegistry(explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	if saved := loadPkgmgrConfig("pip"); saved != nil {
+		if explicitRegistry == "" || explicitRegistry == saved.RegistryIdentifier {
+			return &pkgmgrRegistryInfo{
+				RegistryURL:        saved.RegistryURL,
+				RegistryIdentifier: saved.RegistryIdentifier,
+				OrgID:              saved.OrgID,
+				ProjectID:          saved.ProjectID,
+			}, nil
+		}
+	}
+	paths := pipConfPaths()
+	for _, p := range paths {
+		info, err := pipParseConf(p, explicitRegistry)
+		if err == nil && info != nil {
+			return info, nil
+		}
+	}
+	if explicitRegistry != "" {
+		return nil, fmt.Errorf("HAR registry %q not found in pip configuration", explicitRegistry)
+	}
+	return nil, fmt.Errorf("no HAR registry found — run `harness configure registry --client pip` first")
+}
+
+func (c *pipClient) RunCommand(subcommand string, args []string) (*pkgmgrInstallResult, error) {
+	bin := pipBinary()
+	cmdArgs := append([]string{subcommand}, args...)
+	cmd := exec.Command(bin, cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	err := cmd.Run()
+	stderrStr := stderrBuf.String()
+	if err != nil {
+		return &pkgmgrInstallResult{Status: "FAILURE", Stderr: stderrStr, Err: err}, nil
+	}
+	return &pkgmgrInstallResult{Status: "SUCCESS", Stderr: stderrStr}, nil
+}
+
+func (c *pipClient) DetectFirewallError(stderr string) bool {
+	return pip403Pattern.MatchString(stderr)
+}
+
+func (c *pipClient) ResolveDeps() ([]dependency, func(), error) {
+	noop := func() {}
+	for _, lf := range []string{"Pipfile.lock", "poetry.lock", "requirements.txt"} {
+		if _, err := os.Stat(lf); err == nil {
+			deps, err := parseLockFile(lf)
+			if err == nil && len(deps) > 0 {
+				return deps, noop, nil
+			}
+		}
+	}
+
+	// pip install --dry-run --report
+	reportPath := filepath.Join(os.TempDir(), "pip-report.json")
+	cleanup := func() { os.Remove(reportPath) }
+
+	reqsArg, reqsFile := "-r", "requirements.txt"
+	if _, err := os.Stat("requirements.txt"); err != nil {
+		if _, err := os.Stat("pyproject.toml"); err == nil {
+			reqsArg, reqsFile = ".", ""
+		} else {
+			return nil, noop, fmt.Errorf("no requirements.txt or pyproject.toml found")
+		}
+	}
+
+	var cmdArgs []string
+	if reqsFile != "" {
+		cmdArgs = []string{"install", "--dry-run", "--report", reportPath, reqsArg, reqsFile}
+	} else {
+		cmdArgs = []string{"install", "--dry-run", "--report", reportPath, reqsArg}
+	}
+
+	cmd := exec.Command(pipBinary(), cmdArgs...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		cleanup()
+		if _, statErr := os.Stat("requirements.txt"); statErr == nil {
+			deps, err := parseLockFile("requirements.txt")
+			return deps, noop, err
+		}
+		return nil, noop, fmt.Errorf("pip dry-run failed and no requirements.txt found: %w", err)
+	}
+
+	deps, err := pipParseDryRunReport(reportPath)
+	if err != nil {
+		cleanup()
+		return nil, noop, err
+	}
+	return deps, cleanup, nil
+}
+
+func pipParseDryRunReport(reportPath string) ([]dependency, error) {
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading pip report: %w", err)
+	}
+	var report struct {
+		Install []struct {
+			Metadata struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+			} `json:"metadata"`
+		} `json:"install"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parsing pip report: %w", err)
+	}
+	deps := make([]dependency, 0, len(report.Install))
+	for _, pkg := range report.Install {
+		if pkg.Metadata.Name == "" {
+			continue
+		}
+		deps = append(deps, dependency{Name: pkg.Metadata.Name, Version: pkg.Metadata.Version})
+	}
+	return deps, nil
+}
+
+func pipConfPaths() []string {
+	var paths []string
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths,
+			filepath.Join(home, ".config", "pip", "pip.conf"),
+			filepath.Join(home, ".pip", "pip.conf"),
+		)
+	}
+	paths = append(paths, "pip.conf")
+	return paths
+}
+
+func pipParseConf(confPath, explicitRegistry string) (*pkgmgrRegistryInfo, error) {
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "index-url") && !strings.HasPrefix(line, "extra-index-url") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		rawURL := strings.TrimSpace(parts[1])
+		if !pipHarURLPattern.MatchString(rawURL) {
+			continue
+		}
+		matches := pipHarURLPattern.FindStringSubmatch(rawURL)
+		if len(matches) < 3 {
+			continue
+		}
+		regID := matches[2]
+		if explicitRegistry != "" && regID != explicitRegistry {
+			continue
+		}
+		return &pkgmgrRegistryInfo{RegistryURL: rawURL, RegistryIdentifier: regID}, nil
+	}
+	return nil, fmt.Errorf("no HAR registry URL found in %s", confPath)
+}
+
+func pipBinary() string {
+	for _, b := range []string{"pip", "pip3"} {
+		if _, err := exec.LookPath(b); err == nil {
+			return b
+		}
+	}
+	return "pip"
+}

--- a/pkg/spec/har.spec.yaml
+++ b/pkg/spec/har.spec.yaml
@@ -954,6 +954,61 @@ commands:
         description: "Path to lock file (package-lock.json, pnpm-lock.yaml, yarn.lock, requirements.txt, pyproject.toml, Pipfile.lock, poetry.lock, pom.xml, build.gradle)"
         required: true
 
+  - command: execute artifact:npm_install
+    verb: execute
+    noun: artifact
+    noun_variant: npm_install
+    short: Run npm install via the Harness firewall wrapper
+    no_id: true
+    has_args: true
+    args_label: "[-- <npm-args...>]"
+    handler_type: workflow
+    workflow_id: execute_artifact_npm_install
+
+  - command: execute artifact:npm_ci
+    verb: execute
+    noun: artifact
+    noun_variant: npm_ci
+    short: Run npm ci via the Harness firewall wrapper
+    no_id: true
+    has_args: true
+    args_label: "[-- <npm-args...>]"
+    handler_type: workflow
+    workflow_id: execute_artifact_npm_ci
+
+  - command: execute artifact:pip_install
+    verb: execute
+    noun: artifact
+    noun_variant: pip_install
+    short: Run pip install via the Harness firewall wrapper
+    no_id: true
+    has_args: true
+    args_label: "[-- <pip-args...>]"
+    handler_type: workflow
+    workflow_id: execute_artifact_pip_install
+
+  - command: execute artifact:mvn_install
+    verb: execute
+    noun: artifact
+    noun_variant: mvn_install
+    short: Run mvn install via the Harness firewall wrapper
+    no_id: true
+    has_args: true
+    args_label: "[-- <mvn-args...>]"
+    handler_type: workflow
+    workflow_id: execute_artifact_mvn_install
+
+  - command: execute artifact:dotnet_restore
+    verb: execute
+    noun: artifact
+    noun_variant: dotnet_restore
+    short: Run dotnet restore via the Harness firewall wrapper
+    no_id: true
+    has_args: true
+    args_label: "[-- <dotnet-args...>]"
+    handler_type: workflow
+    workflow_id: execute_artifact_dotnet_restore
+
   - command: execute registry:migrate
     verb: execute
     noun: registry


### PR DESCRIPTION
## Summary

Adds five `execute artifact:*` commands that wrap native package manager
commands with Harness firewall protection: `npm_install`, `npm_ci`,
`pip_install`, `mvn_install`, `dotnet_restore`.

Each wrapper runs the native tool as-is. On a 403/forbidden failure, it
resolves the full dependency graph (including transitive deps) and submits
it for bulk Harness firewall evaluation, printing BLOCKED/WARN/ALLOWED
results.

## What's included

- `pkgmgr_orchestrator.go` — shared flow: detect registry → resolve UUID →
  run native command → on 403, resolve deps + firewall evaluation.
- `pkgmgr_client.go` + one file per client (npm/pip/maven/nuget).
- `configure_*.go` — each now persists registry info to
  `~/.harness/<client>-pkgmgr.json` for the wrappers to read.

## Bug fixes bundled in

- `configure_maven.go`: replaced `mirrorOf: "*"` with an additive
  `<repositories>`/`<pluginRepositories>` profile — the mirror was
  intercepting Maven's own core plugin lookups too, breaking
  `mvn install` on every registry tested.
- `configure_npm.go`: fixed `.npmrc` duplicating `registry=`/
  `always-auth` lines on repeated `configure registry` runs.

## Testing

- `mvn install` and `execute artifact:mvn_install` validated end-to-end
  against two live registries (hosted + upstream-proxy).
- `.npmrc` dedup fix verified across repeated runs.