### PR TITLE
fix: include urls in JSON/jsonl output

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -108,6 +108,11 @@ func FormatArrayOutput(flags cmdctx.FormatFlags, isPty bool, data any, itemsExpr
 		if err != nil {
 			return fmt.Errorf("jsonl items_expr %q: %w", itemsExpr, err)
 		}
+		if !flags.Raw {
+			for i, it := range items {
+				items[i] = injectURL(exprEnv, it)
+			}
+		}
 		return formatJsonl(w, itemsExpr, items)
 	}
 
@@ -158,6 +163,9 @@ func FormatArrayOutput(flags cmdctx.FormatFlags, isPty bool, data any, itemsExpr
 		extracted, err := evalItemsExpr(itemsEnv, itemsExpr)
 		if err != nil {
 			return fmt.Errorf("items_expr %q: %w", itemsExpr, err)
+		}
+		for i, it := range extracted {
+			extracted[i] = injectURL(exprEnv, it)
 		}
 		payload = extracted
 	}
@@ -267,7 +275,36 @@ func FormatSingleOutput(flags cmdctx.FormatFlags, isPty bool, data any, itemExpr
 		// --raw with yaml: no pick expr applied, fall through to marshal full payload
 		return writeYAML(w, payload)
 	}
+	if !flags.Raw {
+		payload = injectURL(exprEnv, payload)
+	}
 	return writeJSON(w, payload)
+}
+
+// injectURL returns item with a "url" key added, computed via exprEnv["url"](item) — the
+// same url(it) function noun fields already call for table/text output. No-op if url isn't
+// registered, item isn't a map, item already has a "url" key, or the resolved URL is empty,
+// so it never overwrites data the API actually returned.
+func injectURL(exprEnv map[string]any, item any) any {
+	urlFn, ok := exprEnv["url"].(func(any) string)
+	if !ok {
+		return item
+	}
+	m, ok := item.(map[string]any)
+	if !ok {
+		return item
+	}
+	if _, exists := m["url"]; exists {
+		return item
+	}
+	u := urlFn(item)
+	if u == "" {
+		return item
+	}
+	out := make(map[string]any, len(m)+1)
+	maps.Copy(out, m)
+	out["url"] = u
+	return out
 }
 
 func OpenWriter(outFile string) (io.Writer, func(), error) {

--- a/pkg/format/url_test.go
+++ b/pkg/format/url_test.go
@@ -1,0 +1,186 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package format
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/harness/cli/pkg/cmdctx"
+)
+
+func urlEnv(fn func(any) string) map[string]any {
+	if fn == nil {
+		return map[string]any{}
+	}
+	return map[string]any{"url": fn}
+}
+
+// outFile returns a FormatFlags.OutFile path under a fresh temp dir, and a reader that
+// returns the file's contents. FormatSingleOutput/FormatArrayOutput write to OutFile via
+// OpenWriter when it's non-empty, so this captures output without touching os.Stdout.
+func outFile(t *testing.T) (string, func() []byte) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "out")
+	return path, func() []byte {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading captured output: %v", err)
+		}
+		return b
+	}
+}
+
+func TestInjectURL(t *testing.T) {
+	always := func(it any) string { return "https://example.com/thing" }
+	empty := func(it any) string { return "" }
+
+	tests := []struct {
+		name string
+		env  map[string]any
+		item any
+		want any
+	}{
+		{
+			name: "adds url when fn present and item is a map",
+			env:  urlEnv(always),
+			item: map[string]any{"id": "abc"},
+			want: map[string]any{"id": "abc", "url": "https://example.com/thing"},
+		},
+		{
+			name: "no-op when url fn not registered",
+			env:  urlEnv(nil),
+			item: map[string]any{"id": "abc"},
+			want: map[string]any{"id": "abc"},
+		},
+		{
+			name: "no-op when resolved url is empty",
+			env:  urlEnv(empty),
+			item: map[string]any{"id": "abc"},
+			want: map[string]any{"id": "abc"},
+		},
+		{
+			name: "no-op when item already has a url key",
+			env:  urlEnv(always),
+			item: map[string]any{"id": "abc", "url": "https://api.example.com/native"},
+			want: map[string]any{"id": "abc", "url": "https://api.example.com/native"},
+		},
+		{
+			name: "no-op when item is not a map",
+			env:  urlEnv(always),
+			item: []any{"a", "b"},
+			want: []any{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := injectURL(tt.env, tt.item)
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(tt.want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("injectURL() = %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestFormatSingleOutput_JSONIncludesURL(t *testing.T) {
+	env := urlEnv(func(it any) string { return "https://example.com/pipelines/p1" })
+	data := map[string]any{"identifier": "p1"}
+
+	path, read := outFile(t)
+	flags := cmdctx.FormatFlags{Format: "json", OutFile: path}
+
+	if err := FormatSingleOutput(flags, false, data, "it", "", nil, nil, env); err != nil {
+		t.Fatalf("FormatSingleOutput: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(read(), &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if out["url"] != "https://example.com/pipelines/p1" {
+		t.Errorf("expected url field in JSON output, got %v", out)
+	}
+}
+
+func TestFormatSingleOutput_RawSkipsURL(t *testing.T) {
+	env := urlEnv(func(it any) string { return "https://example.com/pipelines/p1" })
+	data := map[string]any{"identifier": "p1"}
+
+	path, read := outFile(t)
+	flags := cmdctx.FormatFlags{Format: "json", Raw: true, OutFile: path}
+
+	if err := FormatSingleOutput(flags, false, data, "it", "", nil, nil, env); err != nil {
+		t.Fatalf("FormatSingleOutput: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(read(), &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if _, exists := out["url"]; exists {
+		t.Errorf("expected no url field with --raw, got %v", out)
+	}
+}
+
+func TestFormatArrayOutput_JSONIncludesURLPerItem(t *testing.T) {
+	env := urlEnv(func(it any) string {
+		m, _ := it.(map[string]any)
+		return "https://example.com/executions/" + m["id"].(string)
+	})
+	data := []any{
+		map[string]any{"id": "e1"},
+		map[string]any{"id": "e2"},
+	}
+
+	path, read := outFile(t)
+	flags := cmdctx.FormatFlags{Format: "json", OutFile: path}
+
+	if err := FormatArrayOutput(flags, false, data, "it", nil, nil, env, nil); err != nil {
+		t.Fatalf("FormatArrayOutput: %v", err)
+	}
+
+	var out []map[string]any
+	if err := json.Unmarshal(read(), &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(out))
+	}
+	if out[0]["url"] != "https://example.com/executions/e1" {
+		t.Errorf("item 0: expected url, got %v", out[0])
+	}
+	if out[1]["url"] != "https://example.com/executions/e2" {
+		t.Errorf("item 1: expected url, got %v", out[1])
+	}
+}
+
+func TestFormatArrayOutput_JSONLIncludesURLPerItem(t *testing.T) {
+	env := urlEnv(func(it any) string {
+		m, _ := it.(map[string]any)
+		return "https://example.com/executions/" + m["id"].(string)
+	})
+	data := []any{
+		map[string]any{"id": "e1"},
+	}
+
+	path, read := outFile(t)
+	flags := cmdctx.FormatFlags{Format: "jsonl", OutFile: path}
+
+	if err := FormatArrayOutput(flags, false, data, "it", nil, nil, env, nil); err != nil {
+		t.Fatalf("FormatArrayOutput: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(read(), &out); err != nil {
+		t.Fatalf("unmarshal jsonl line: %v", err)
+	}
+	if out["url"] != "https://example.com/executions/e1" {
+		t.Errorf("expected url in jsonl output, got %v", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Inject a computed `url` field into non-raw `--format json` / `jsonl` for list and get when the noun has a `url_path`
- Addresses tooling use-case from #62 where list consumers needed UI links without hand-assembling paths or calling `get` per item