### PR TITLE
Improve error messages for nouns owned by uninstalled plugins

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -53,6 +53,7 @@ type Registry struct {
 	specs                map[string][]*spec.CommandSpec
 	nouns                map[string]spec.NounDef
 	nounAliases          map[string]string // alias name → canonical noun name
+	pluginOwnedNouns     map[string]string // noun (or alias) → owning plugin module
 	moduleMetas          []spec.ModuleMeta
 	workflows            map[string]WorkflowFn
 	textFormatters       map[string]cmdctx.TextFormatterFn
@@ -73,6 +74,7 @@ func New() *Registry {
 		specs:                map[string][]*spec.CommandSpec{},
 		nouns:                map[string]spec.NounDef{},
 		nounAliases:          map[string]string{},
+		pluginOwnedNouns:     map[string]string{},
 		workflows:            map[string]WorkflowFn{},
 		textFormatters:       map[string]cmdctx.TextFormatterFn{},
 		bodyFns:              map[string]cmdctx.CreateBodyFn{},
@@ -92,6 +94,26 @@ func New() *Registry {
 // SetModuleMeta stores metadata for a module loaded from a spec file.
 func (r *Registry) SetModuleMeta(m spec.ModuleMeta) {
 	r.moduleMetas = append(r.moduleMetas, m)
+}
+
+// RecordPluginOwnedNouns records module as the owner of nouns (and their
+// aliases), for best-effort "plugin not installed" error messages.
+func (r *Registry) RecordPluginOwnedNouns(module string, nouns []spec.NounDef) {
+	for _, nd := range nouns {
+		r.pluginOwnedNouns[nd.Noun] = module
+		for _, alias := range nd.NounAliases {
+			r.pluginOwnedNouns[alias] = module
+		}
+	}
+}
+
+// pluginOwnerOfUnregisteredNoun returns the plugin owning noun, or "" if noun
+// is already registered (plugin installed) or has no recorded owner.
+func (r *Registry) pluginOwnerOfUnregisteredNoun(noun string) string {
+	if _, registered := r.nouns[noun]; registered {
+		return ""
+	}
+	return r.pluginOwnedNouns[noun]
 }
 
 // moduleMeta returns the ModuleMeta for a module, or nil if not registered.
@@ -517,6 +539,9 @@ func (r *Registry) unknownNounError(verb, noun string) error {
 	if canonical, ok := r.nounAliases[noun]; ok {
 		resolvedNoun = canonical
 	}
+	if mod := r.pluginOwnerOfUnregisteredNoun(resolvedNoun); mod != "" {
+		return fmt.Errorf("%q is provided by the %q plugin, which isn't installed\n\nTo install it, run:\n  harness install plugin %s", noun, mod, mod)
+	}
 	nounExistsForVerb := false
 	for _, cs := range r.specs[verb] {
 		if cs.Noun == resolvedNoun || cs.FullNoun() == noun {
@@ -612,6 +637,15 @@ func (r *Registry) SuggestRootCommand(args []string) string {
 	}
 
 	first := positional[0]
+
+	// Case 0: first arg is a noun (or noun:variant) owned by a plugin that
+	// isn't installed, so it was never registered — cobra can't dispatch it
+	// as either a verb or a noun. Covers both "harness <noun> <verb>" and
+	// verb-less plugin verbs (e.g. har's push/pull/configure).
+	nounBase := strings.SplitN(first, ":", 2)[0]
+	if mod := r.pluginOwnerOfUnregisteredNoun(nounBase); mod != "" {
+		return fmt.Sprintf("%q is provided by the %q plugin, which isn't installed\n\nTo install it, run:\n  harness install plugin %s", first, mod, mod)
+	}
 
 	// Case 1: noun-verb transposition — requires at least two positional args.
 	// Handles plain nouns ("pr create"), noun aliases ("prs list"),

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -548,6 +548,15 @@ func TestUnknownNounError(t *testing.T) {
 			verb: VerbCreate, noun: "pipelines",
 			wantContain: "not supported for",
 		},
+		{
+			name: "plugin_owned_noun_not_installed",
+			setup: func(r *Registry) {
+				r.Register(wfSpec(VerbList, "pipeline", "pipeline"))
+				r.RecordPluginOwnedNouns("har", []spec.NounDef{{Noun: "registry"}})
+			},
+			verb: VerbGet, noun: "registry",
+			wantContain: `"registry" is provided by the "har" plugin, which isn't installed`,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/registry/suggest_test.go
+++ b/pkg/registry/suggest_test.go
@@ -157,6 +157,50 @@ func TestSuggestRootCommand_VerbTypo(t *testing.T) {
 	}
 }
 
+func TestSuggestRootCommand_PluginOwnedNoun(t *testing.T) {
+	r := buildTestRegistry(t)
+	r.RecordPluginOwnedNouns("har", []spec.NounDef{{Noun: "registry"}})
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantContain string
+	}{
+		{
+			name:        "noun-first form",
+			args:        []string{"registry", "list"},
+			wantContain: `"registry" is provided by the "har" plugin, which isn't installed`,
+		},
+		{
+			name:        "noun:variant-first form",
+			args:        []string{"registry:npm", "list"},
+			wantContain: `"registry:npm" is provided by the "har" plugin, which isn't installed`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.SuggestRootCommand(tt.args)
+			if !strings.Contains(got, tt.wantContain) {
+				t.Errorf("SuggestRootCommand(%v) = %q, want to contain %q", tt.args, got, tt.wantContain)
+			}
+		})
+	}
+}
+
+// registered_noun_not_intercepted verifies that a noun already registered
+// (e.g. "artifact", registered by buildTestRegistry to simulate an installed
+// plugin) is never misreported as missing, even when it also appears in the
+// pluginOwnedNouns map.
+func TestSuggestRootCommand_PluginOwnedNoun_AlreadyInstalled(t *testing.T) {
+	r := buildTestRegistry(t)
+	r.RecordPluginOwnedNouns("har", []spec.NounDef{{Noun: "artifact"}})
+
+	got := r.SuggestRootCommand([]string{"artifact", "list"})
+	if strings.Contains(got, "isn't installed") {
+		t.Errorf("expected no plugin-missing suggestion for installed noun, got %q", got)
+	}
+}
+
 func TestSuggestRootCommand_NoSuggestion(t *testing.T) {
 	r := buildTestRegistry(t)
 

--- a/pkg/specloader/specloader.go
+++ b/pkg/specloader/specloader.go
@@ -34,20 +34,6 @@ type specVersionOnly struct {
 	SpecVersion int `yaml:"spec_version"`
 }
 
-type specTypeOnly struct {
-	ModuleType string `yaml:"module_type"`
-}
-
-// isEmbeddedPluginSpec reports whether an embedded spec declares module_type:
-// plugin. Such specs are not builtins — the host loads them dynamically from the
-// home spec dir (via a binary_path), so the main binary must not auto-register
-// them from the embedded FS.
-func isEmbeddedPluginSpec(data []byte) bool {
-	var t specTypeOnly
-	_ = yaml.Unmarshal(data, &t)
-	return t.ModuleType == "plugin"
-}
-
 type specFile struct {
 	SpecVersion     int                 `yaml:"spec_version"`
 	ModuleType      string              `yaml:"module_type"`
@@ -79,20 +65,18 @@ func specParseError(name string, data []byte, parseErr error) error {
 // win: a home spec whose module name is already registered is skipped with a
 // warning.
 //
-// Embedded specs that declare module_type: plugin (e.g. har) are NOT loaded here
-// — they are plugins, not builtins, and reach the host only through the home
-// spec dir (with a binary_path to dispatch to). This lets a dev-installed plugin
-// spec in ~/.harness/spec drive the real dynamic path instead of being masked by
-// an embedded copy.
+// Embedded specs that declare module_type: plugin (e.g. har) are not registered
+// as builtins here — they are plugins, not builtins, and reach the host only
+// through the home spec dir (with a binary_path to dispatch to). This lets a
+// dev-installed plugin spec in ~/.harness/spec drive the real dynamic path
+// instead of being masked by an embedded copy. loadSpecData still records their
+// noun ownership (best-effort, for "plugin not installed" error messages).
 func LoadSpecs(reg *registry.Registry) error {
 	isHarnessUser := config.AnyProfileMatchesDomain("harness.io")
 	for _, name := range spec.Files() {
 		data, err := spec.Read(name)
 		if err != nil {
 			return fmt.Errorf("spec: read %s: %w", name, err)
-		}
-		if isEmbeddedPluginSpec(data) {
-			continue
 		}
 		if err := loadSpecData(reg, name, data, isHarnessUser, false); err != nil {
 			return err
@@ -222,6 +206,11 @@ func loadSpecData(reg *registry.Registry, name string, data []byte, isHarnessUse
 		return fmt.Errorf("spec: %s: spec_version %d out of supported range [%d, %d]", name, f.SpecVersion, MinSpecVersion, MaxSpecVersion)
 	}
 	if f.HarnessInternal && !isHarnessUser {
+		return nil
+	}
+	// Embedded plugin specs (e.g. har) aren't builtins; only record noun ownership.
+	if !fromSpecDir && f.ModuleType == "plugin" {
+		reg.RecordPluginOwnedNouns(module, f.Nouns)
 		return nil
 	}
 	if fromSpecDir {


### PR DESCRIPTION
When a noun belongs to a plugin (e.g. har) that isn't installed, the noun is never registered, so cobra previously fell through to a generic "unknown command" error regardless of whether the user typed <noun> <verb> or <verb> <noun>. The registry now tracks plugin-owned nouns (and their aliases) via RecordPluginOwnedNouns, populated from embedded plugin specs during spec loading, and both unknownNounError and SuggestRootCommand check this map first to surface a clear "is provided by the X plugin, which isn't installed" message with an install hint.

specloader no longer skips embedded module_type: plugin specs entirely — it now records their noun ownership before bailing out of builtin registration, since a plugin's spec never reaches the registry unless it's actually installed in the home spec dir.

AI-Tool: claude-code
AI-Model: Claude Sonnet 5