### PR TITLE
Fix (Composer migration): multi-version packages, naming, and failure reporting

### DIFF
--- a/modules/har/pkg/har/migrate/adapter/har/client.go
+++ b/modules/har/pkg/har/migrate/adapter/har/client.go
@@ -455,13 +455,16 @@ func (c *client) uploadComposerFile(
 	}
 	defer resp.Body.Close()
 
-	// Check for successful response
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+	switch {
+	case resp.StatusCode == http2.StatusConflict:
+		return types.ErrArtifactAlreadyExists
+	case resp.StatusCode >= 200 && resp.StatusCode <= 299:
+		return nil
+	default:
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed to upload file '%s', status code: %d, response: %s",
 			filename, resp.StatusCode, string(body))
 	}
-	return nil
 }
 
 func (c *client) uploadSwiftFile(

--- a/modules/har/pkg/har/migrate/adapter/jfrog/adapter.go
+++ b/modules/har/pkg/har/migrate/adapter/jfrog/adapter.go
@@ -339,7 +339,7 @@ func (a *adapter) GetPackages(registry string, artifactType types.ArtifactType, 
 		return packages, nil
 	} else if artifactType == types.COMPOSER {
 		leaves, _ := tree.GetAllFiles(root)
-		packageMap := make(map[string]bool)
+		packageMap := make(map[string]types.Package)
 		for _, leaf := range leaves {
 			if leaf.Folder {
 				continue
@@ -347,27 +347,24 @@ func (a *adapter) GetPackages(registry string, artifactType types.ArtifactType, 
 			if !strings.HasSuffix(leaf.Uri, ".zip") {
 				continue
 			}
-			// Extract package name from ZIP filename
-			// Composer packages are typically named: vendor-package-version.zip
-			filename := leaf.Name
-			nameWithoutExt := strings.TrimSuffix(filename, ".zip")
-
-			// For Composer, we'll use the full filename as package name
-			// since Composer packages can have complex naming patterns
-			pkgName := nameWithoutExt
-
-			path := "/"
-			if _, ok := packageMap[pkgName]; ok {
+			logicalName, ok := util.ComposerLogicalNameFromZipURI(leaf.Uri)
+			if !ok {
+				log.Warn().Msgf("Skipping Composer zip %q: cannot derive vendor/package name from URI", leaf.Uri)
 				continue
 			}
-			packageMap[pkgName] = true
-			packages = append(packages, types.Package{
+			if _, ok := packageMap[logicalName]; ok {
+				continue
+			}
+			packageMap[logicalName] = types.Package{
 				Registry: registry,
-				Path:     path,
-				Name:     pkgName,
+				Path:     "/",
+				Name:     logicalName,
 				Size:     leaf.Size,
 				URL:      leaf.Uri,
-			})
+			}
+		}
+		for _, pkg := range packageMap {
+			packages = append(packages, pkg)
 		}
 		return packages, nil
 	} else if artifactType == types.SWIFT {
@@ -1160,14 +1157,31 @@ func (a *adapter) GetVersions(
 		return versions, nil
 	}
 	if artifactType == types.COMPOSER {
+		if node == nil {
+			return nil, errors.New("node is nil")
+		}
+		files, err := tree.GetAllFiles(node)
+		if err != nil {
+			return nil, fmt.Errorf("get all files: %w", err)
+		}
 		var versions []types.Version
-		versions = append(versions, types.Version{
-			Registry: registry,
-			Pkg:      pkg,
-			Path:     p.URL,
-			Name:     p.Name,
-			Size:     p.Size,
-		})
+		for _, file := range files {
+			if file.Folder || !strings.HasSuffix(file.Uri, ".zip") {
+				continue
+			}
+			logicalName, ok := util.ComposerLogicalNameFromZipURI(file.Uri)
+			if !ok || logicalName != pkg {
+				continue
+			}
+			versions = append(versions, types.Version{
+				Registry: registry,
+				Pkg:      pkg,
+				Path:     file.Uri,
+				Name:     util.ComposerVersionFromZipFilename(file.Name),
+				Size:     file.Size,
+			})
+		}
+		log.Info().Msgf("Found %d versions for COMPOSER package %s", len(versions), pkg)
 		return versions, nil
 	}
 	if artifactType == types.SWIFT {

--- a/modules/har/pkg/har/migrate/migratable/package.go
+++ b/modules/har/pkg/har/migrate/migratable/package.go
@@ -477,11 +477,13 @@ func (r *Package) migrateComposer(ctx context.Context) error {
 	versions, err := r.srcAdapter.GetVersions(r.pkg, r.node, r.srcRegistry, r.pkg.Name, types.COMPOSER)
 	if err != nil {
 		log.Error().Ctx(ctx).Err(err).Msgf("Failed to get Composer versions for %s", r.pkg.Name)
+		util.AddPackageErrorToStat(r.stats, r.pkg, r.srcRegistry, err)
 		return err
 	}
 	if len(versions) == 0 {
 		err := fmt.Errorf("no Composer versions found for package %s", r.pkg.Name)
 		log.Error().Ctx(ctx).Err(err).Msgf("No Composer versions for %s", r.pkg.Name)
+		util.AddPackageErrorToStat(r.stats, r.pkg, r.srcRegistry, err)
 		return nil
 	}
 

--- a/modules/har/pkg/har/migrate/migratable/package.go
+++ b/modules/har/pkg/har/migrate/migratable/package.go
@@ -474,30 +474,69 @@ func (r *Package) migrateRPM(ctx context.Context) error {
 }
 
 func (r *Package) migrateComposer(ctx context.Context) error {
-	file, header, err := r.srcAdapter.DownloadFile(r.srcRegistry, r.pkg.URL)
+	versions, err := r.srcAdapter.GetVersions(r.pkg, r.node, r.srcRegistry, r.pkg.Name, types.COMPOSER)
 	if err != nil {
-		log.Error().Ctx(ctx).Err(err).Msgf("Failed to download Composer package %s", r.pkg.URL)
-		pterm.Error.Println(fmt.Sprintf("Failed to download Composer package %s", r.pkg.URL))
+		log.Error().Ctx(ctx).Err(err).Msgf("Failed to get Composer versions for %s", r.pkg.Name)
 		return err
+	}
+	if len(versions) == 0 {
+		err := fmt.Errorf("no Composer versions found for package %s", r.pkg.Name)
+		log.Error().Ctx(ctx).Err(err).Msgf("No Composer versions for %s", r.pkg.Name)
+		return nil
+	}
+
+	if r.config.DryRun {
+		for _, v := range versions {
+			log.Info().Ctx(ctx).Msgf("Dry-run: would migrate Composer package %s version %s at %s", r.pkg.Name, v.Name, v.Path)
+		}
+		return nil
+	}
+
+	for _, v := range versions {
+		_ = r.migrateComposerVersion(ctx, v)
+	}
+	return nil
+}
+
+func (r *Package) migrateComposerVersion(ctx context.Context, v types.Version) error {
+	zipName := util.ComposerZipBasename(v.Path)
+	file, header, err := r.srcAdapter.DownloadFile(r.srcRegistry, v.Path)
+	if err != nil {
+		log.Error().Ctx(ctx).Err(err).Msgf("Failed to download Composer package %s at %s", r.pkg.Name, v.Path)
+		pterm.Error.Println(fmt.Sprintf("Failed to download Composer package %s version %s", r.pkg.Name, v.Name))
+		r.stats.FileStats = append(r.stats.FileStats, types.FileStat{
+			Name:     zipName,
+			Registry: r.srcRegistry,
+			Uri:      v.Path,
+			Size:     int64(v.Size),
+			Status:   types.StatusFail,
+			Error:    err.Error(),
+		})
+		return nil
 	}
 	defer file.Close()
 
-	title := fmt.Sprintf("%s (%s)", r.pkg.Name, sizeutil.GetSize(int64(r.pkg.Size)))
-	pterm.Info.Println(fmt.Sprintf("Copying file %s from %s to %s", r.pkg.Name, r.srcRegistry, r.destRegistry))
-	err = r.destAdapter.UploadFile(r.destRegistry, file, &types.File{Uri: r.pkg.URL}, header, r.pkg.Name, r.pkg.Version,
+	title := fmt.Sprintf("%s@%s (%s)", r.pkg.Name, v.Name, sizeutil.GetSize(int64(v.Size)))
+	pterm.Info.Println(fmt.Sprintf("Copying file %s from %s to %s", zipName, r.srcRegistry, r.destRegistry))
+	err = r.destAdapter.UploadFile(r.destRegistry, file, &types.File{Uri: v.Path, Name: zipName}, header, r.pkg.Name, v.Name,
 		r.artifactType, nil)
 	stat := types.FileStat{
-		Name:     r.pkg.Name,
+		Name:     zipName,
 		Registry: r.srcRegistry,
-		Uri:      r.pkg.URL,
-		Size:     int64(r.pkg.Size),
+		Uri:      v.Path,
+		Size:     int64(v.Size),
 		Status:   types.StatusSuccess,
 	}
 	if err != nil {
-		r.logger.Error().Err(err).Msg("Failed to upload file")
-		stat.Status = types.StatusFail
-		stat.Error = err.Error()
-		pterm.Error.Println(title)
+		if errors.Is(err, types.ErrArtifactAlreadyExists) {
+			stat.Status = types.StatusSkip
+			pterm.Info.Println(fmt.Sprintf("%s already exists, skipping", title))
+		} else {
+			r.logger.Error().Err(err).Msg("Failed to upload file")
+			stat.Status = types.StatusFail
+			stat.Error = err.Error()
+			pterm.Error.Println(title)
+		}
 	} else {
 		pterm.Success.Println(title)
 	}

--- a/modules/har/pkg/har/migrate/migratable/package_composer_test.go
+++ b/modules/har/pkg/har/migrate/migratable/package_composer_test.go
@@ -1,0 +1,160 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package migratable
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/modules/har/pkg/har/migrate/types"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/rs/zerolog"
+)
+
+// noopComposerAdapter provides zero-value implementations of every
+// adapter.Adapter method so tests only need to override what they exercise.
+type noopComposerAdapter struct{}
+
+func (noopComposerAdapter) GetKeyChain(string) (authn.Keychain, error) { return nil, nil }
+func (noopComposerAdapter) GetConfig() types.RegistryConfig            { return types.RegistryConfig{} }
+func (noopComposerAdapter) ValidateCredentials() (bool, error)         { return false, nil }
+func (noopComposerAdapter) GetRegistry(context.Context, string) (types.RegistryInfo, error) {
+	return types.RegistryInfo{}, nil
+}
+func (noopComposerAdapter) CreateRegistryIfDoesntExist(string) (bool, error) { return false, nil }
+func (noopComposerAdapter) GetPackages(string, types.ArtifactType, *types.TreeNode) ([]types.Package, error) {
+	return nil, nil
+}
+func (noopComposerAdapter) GetVersions(types.Package, *types.TreeNode, string, string, types.ArtifactType) ([]types.Version, error) {
+	return nil, nil
+}
+func (noopComposerAdapter) GetFiles(string) ([]types.File, error) { return nil, nil }
+func (noopComposerAdapter) DownloadFile(string, string) (io.ReadCloser, http.Header, error) {
+	return nil, nil, nil
+}
+func (noopComposerAdapter) UploadFile(string, io.ReadCloser, *types.File, http.Header, string, string, types.ArtifactType, map[string]interface{}) error {
+	return nil
+}
+func (noopComposerAdapter) GetOCIImagePath(string, string, string) (string, error) { return "", nil }
+func (noopComposerAdapter) AddNPMTag(string, string, string, string) error         { return nil }
+func (noopComposerAdapter) VersionExists(context.Context, types.Package, string, string, string, types.ArtifactType) (bool, error) {
+	return false, nil
+}
+func (noopComposerAdapter) FileExists(context.Context, string, string, string, *types.File, types.ArtifactType) (bool, error) {
+	return false, nil
+}
+func (noopComposerAdapter) GetAllFilesForVersion(context.Context, string, string, string) ([]string, error) {
+	return nil, nil
+}
+func (noopComposerAdapter) CreateVersion(string, string, string, types.ArtifactType, []*types.PackageFiles, map[string]interface{}) error {
+	return nil
+}
+func (noopComposerAdapter) SearchFiles(string) ([]types.SearchedFile, error) { return nil, nil }
+func (noopComposerAdapter) BuildExistingIndex(context.Context, string, int) (*types.ExistingIndex, error) {
+	return nil, nil
+}
+
+type composerFakeSrc struct {
+	noopComposerAdapter
+	content        map[string][]byte
+	versions       []types.Version
+	getVersionsErr error
+}
+
+func (s *composerFakeSrc) DownloadFile(_ string, uri string) (io.ReadCloser, http.Header, error) {
+	b, ok := s.content[uri]
+	if !ok {
+		return nil, nil, fmt.Errorf("download %q: not found", uri)
+	}
+	return io.NopCloser(strings.NewReader(string(b))), http.Header{}, nil
+}
+
+func (s *composerFakeSrc) GetVersions(_ types.Package, _ *types.TreeNode, _, _ string, artifactType types.ArtifactType) ([]types.Version, error) {
+	if artifactType != types.COMPOSER {
+		return nil, fmt.Errorf("unexpected artifact type %s", artifactType)
+	}
+	if s.getVersionsErr != nil {
+		return nil, s.getVersionsErr
+	}
+	return s.versions, nil
+}
+
+type composerFakeDest struct {
+	noopComposerAdapter
+	uploads []string
+}
+
+func (d *composerFakeDest) UploadFile(
+	_ string,
+	_ io.ReadCloser,
+	f *types.File,
+	_ http.Header,
+	_ string,
+	_ string,
+	_ types.ArtifactType,
+	_ map[string]interface{},
+) error {
+	d.uploads = append(d.uploads, f.Name)
+	return nil
+}
+
+func newComposerJob(src *composerFakeSrc, dest *composerFakeDest, stats *types.TransferStats) *Package {
+	return &Package{
+		srcRegistry:  "src-reg",
+		destRegistry: "dst-reg",
+		srcAdapter:   src,
+		destAdapter:  dest,
+		artifactType: types.COMPOSER,
+		logger:       zerolog.Nop(),
+		pkg: types.Package{
+			Name: "harness/migtest",
+			Path: "/",
+		},
+		node:   &types.TreeNode{Name: "/", Key: "/"},
+		stats:  stats,
+		config: &types.Config{Concurrency: 1, DryRun: false, Overwrite: false},
+	}
+}
+
+// TestMigrateComposerGetVersionsErrorRecordsStat is a regression guard: a
+// GetVersions failure for a Composer package must be recorded in transfer
+// stats (matching hc's AddPackageErrorToStat), not silently dropped.
+func TestMigrateComposerGetVersionsErrorRecordsStat(t *testing.T) {
+	src := &composerFakeSrc{getVersionsErr: fmt.Errorf("source unavailable")}
+	dest := &composerFakeDest{}
+	stats := &types.TransferStats{}
+
+	job := newComposerJob(src, dest, stats)
+	if err := job.migrateComposer(context.Background()); err == nil {
+		t.Fatal("expected GetVersions error to be returned")
+	}
+	if len(stats.FileStats) != 1 || stats.FileStats[0].Status != types.StatusFail {
+		t.Fatalf("stats = %+v, want 1 StatusFail entry for the GetVersions error", stats.FileStats)
+	}
+	if stats.FileStats[0].Name != "harness/migtest" {
+		t.Errorf("stat.Name = %q, want package name %q", stats.FileStats[0].Name, "harness/migtest")
+	}
+}
+
+// TestMigrateComposerNoVersionsFoundRecordsStat is a regression guard: a
+// Composer package that resolves to zero versions must be recorded as a
+// failure in transfer stats, not silently skipped.
+func TestMigrateComposerNoVersionsFoundRecordsStat(t *testing.T) {
+	src := &composerFakeSrc{versions: nil}
+	dest := &composerFakeDest{}
+	stats := &types.TransferStats{}
+
+	job := newComposerJob(src, dest, stats)
+	if err := job.migrateComposer(context.Background()); err != nil {
+		t.Fatalf("migrateComposer should record failure in stats, not return error: %v", err)
+	}
+	if len(stats.FileStats) != 1 || stats.FileStats[0].Status != types.StatusFail {
+		t.Fatalf("stats = %+v, want 1 StatusFail entry for the empty version list", stats.FileStats)
+	}
+}

--- a/modules/har/pkg/har/migrate/migratable/registry.go
+++ b/modules/har/pkg/har/migrate/migratable/registry.go
@@ -254,6 +254,10 @@ func (r *Registry) Migrate(ctx context.Context) error {
 	}
 
 	// applying package level filter
+	composerPkgsBeforeFilters := 0
+	if r.artifactType == types.COMPOSER {
+		composerPkgsBeforeFilters = len(pkgs)
+	}
 	if util.IsPackageLevelFilterableArtifact(currArtifactType) {
 		if len(r.mapping.IncludePatterns) > 0 || len(r.mapping.ExcludePatterns) > 0 {
 			originalCount := len(pkgs)
@@ -262,6 +266,19 @@ func (r *Registry) Migrate(ctx context.Context) error {
 			logger.Info().Msgf("Filtered packages: %d -> %d (includePatterns: %v, excludePatterns: %v)",
 				originalCount, len(pkgs), r.mapping.IncludePatterns, r.mapping.ExcludePatterns)
 		}
+	}
+
+	if r.artifactType == types.COMPOSER &&
+		composerPkgsBeforeFilters > 0 &&
+		len(pkgs) == 0 &&
+		(len(r.mapping.IncludePatterns) > 0 || len(r.mapping.ExcludePatterns) > 0) {
+		warnMsg := fmt.Sprintf(
+			"Registry %s: Composer package filters reduced %d package(s) to 0; nothing will be migrated — "+
+				"use vendor/package names (e.g. harness/migtest, acme/*), not zip basenames, in includePatterns and excludePatterns",
+			r.srcRegistry, composerPkgsBeforeFilters,
+		)
+		logger.Warn().Msg(warnMsg)
+		pterm.Warning.Println(warnMsg)
 	}
 
 	// Build a registry-wide snapshot of existing files so re-runs can skip

--- a/modules/har/pkg/har/migrate/util/composer_util.go
+++ b/modules/har/pkg/har/migrate/util/composer_util.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// composerSemverSuffix matches a semver (or four-part) suffix at the end of a zip base name.
+var composerSemverSuffix = regexp.MustCompile(`-(\d+\.\d+\.\d+(?:\.\d+)?)$`)
+
+// ComposerLogicalNameFromZipURI derives the logical Composer package name (vendor/package)
+// from a registry-relative .zip URI. This matches HAR/Composer identity (see
+// artifact-registry registry/pkg/composer ParsePackageName).
+//
+// Migration configs must use the same vendor/package names in includePatterns and
+// excludePatterns (not legacy zip basenames).
+//
+// Supported layouts:
+//   - /vendor/package/any.zip              -> vendor/package
+//   - /vendor-package/file.zip             -> vendor/package (directory split on first '-')
+//   - /vendor-package-version.zip          -> vendor/package (repo root; version stripped from basename)
+//
+// Flat layout assumes a single '-' separates vendor from package. Vendors whose
+// names contain hyphens (e.g. my-org/widget) must use the /vendor/package/ path
+// layout; /my-org-widget/file.zip would be parsed as my/org-widget.
+func ComposerLogicalNameFromZipURI(uri string) (string, bool) {
+	uri = strings.TrimPrefix(uri, "/")
+	if uri == "" || !strings.HasSuffix(uri, ".zip") {
+		return "", false
+	}
+	parts := strings.Split(uri, "/")
+	switch len(parts) {
+	case 1:
+		base := strings.TrimSuffix(parts[0], ".zip")
+		m := composerSemverSuffix.FindStringSubmatch(base)
+		if len(m) != 2 {
+			return "", false
+		}
+		name := strings.TrimSuffix(base, m[0])
+		name = strings.TrimSuffix(name, "-")
+		if name == "" {
+			return "", false
+		}
+		return composerLogicalNameFromSegment(name, uri)
+	case 2:
+		return composerLogicalNameFromSegment(parts[0], uri)
+	default:
+		return parts[0] + "/" + parts[1], true
+	}
+}
+
+func composerLogicalNameFromSegment(segment, uri string) (string, bool) {
+	if i := strings.Index(segment, "-"); i > 0 {
+		logical := segment[:i] + "/" + segment[i+1:]
+		if strings.Contains(segment[i+1:], "-") {
+			log.Debug().Msgf(
+				"Composer zip %q: name %q has multiple '-' segments; parsed as %q (use /vendor/package/ layout if vendor name contains hyphens)",
+				uri, segment, logical,
+			)
+		}
+		return logical, true
+	}
+	return segment, true
+}
+
+// ComposerVersionFromZipFilename extracts the semver version from a Composer zip file name.
+func ComposerVersionFromZipFilename(filename string) string {
+	base := strings.TrimSuffix(filename, ".zip")
+	if m := composerSemverSuffix.FindStringSubmatch(base); len(m) == 2 {
+		return m[1]
+	}
+	// Fallback: entire base name (e.g. 3.0.0.0.zip).
+	return base
+}
+
+// ComposerZipBasename returns the file name portion of a registry-relative URI.
+func ComposerZipBasename(uri string) string {
+	return path.Base(strings.TrimPrefix(uri, "/"))
+}

--- a/modules/har/pkg/har/migrate/util/utils.go
+++ b/modules/har/pkg/har/migrate/util/utils.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/harness/cli/modules/har/pkg/har/migrate/types"
+
 	"github.com/pterm/pterm"
 )
 
@@ -35,4 +37,19 @@ func GetSkipPrinter() *pterm.PrefixPrinter {
 		},
 		Writer: os.Stdout,
 	}
+}
+
+// AddPackageErrorToStat records a package-level failure (e.g. enumeration
+// errors that never reach the per-file job loop) in the transfer stats so it
+// shows up in the migration summary instead of being silently dropped.
+func AddPackageErrorToStat(stats *types.TransferStats, pkg types.Package, srcRegistry string, err error) {
+	stat := types.FileStat{
+		Name:     pkg.Name,
+		Registry: srcRegistry,
+		Uri:      pkg.URL,
+		Size:     int64(pkg.Size),
+		Status:   types.StatusFail,
+		Error:    err.Error(),
+	}
+	stats.FileStats = append(stats.FileStats, stat)
 }


### PR DESCRIPTION
## Summary
- Fix Composer package/version enumeration so packages use `vendor/package` names and all versions migrate (not just one hardcoded path)
- Treat HAR 409 Conflict as already-migrated (skip) on re-runs
- Warn when include/exclude filters match nothing; record package-level failures in transfer stats