### PR TITLE
Fix: Decouple plugin --spec dump from core's embedded spec FS

### DIFF
--- a/modules/har/cmd/harness-har/main-harness-har.go
+++ b/modules/har/cmd/harness-har/main-harness-har.go
@@ -17,7 +17,8 @@ import (
 
 func main() {
 	reg := registry.New()
-	if err := specloader.LoadSpec(reg, "har.spec.yaml", true); err != nil {
+	specBytes, err := specloader.LoadSpec(reg, "har.spec.yaml", true)
+	if err != nil {
 		console.PrintError(err.Error())
 		os.Exit(1)
 	}
@@ -27,5 +28,5 @@ func main() {
 		Use:   "harness-har",
 		Short: "Harness Artifact Registry CLI",
 	}
-	rootcmd.SetupAndExecutePluginRootCmd(root, reg, "har")
+	rootcmd.SetupAndExecutePluginRootCmd(root, reg, "har", specBytes)
 }

--- a/pkg/rootcmd/rootcmd.go
+++ b/pkg/rootcmd/rootcmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/harness/cli/pkg/plugin"
 	"github.com/harness/cli/pkg/registry"
 	"github.com/harness/cli/pkg/release"
-	"github.com/harness/cli/pkg/specloader"
 	"github.com/harness/cli/pkg/telemetry"
 )
 
@@ -75,7 +74,11 @@ func MaybeCheckSpecs(reg *registry.Registry) {
 
 // SetupAndExecutePluginRootCmd is like SetupAndExecuteRootCmd but adds hidden
 // --spec and --modulehelp flags for use by the plugin host.
-func SetupAndExecutePluginRootCmd(root *cobra.Command, reg *registry.Registry, moduleName string) {
+//
+// specBytes is the exact spec YAML this plugin was loaded from (whatever the
+// caller passed to specloader.LoadSpec or specloader.LoadSpecBytes) — dumped
+// verbatim on --spec so the host can capture it at install time
+func SetupAndExecutePluginRootCmd(root *cobra.Command, reg *registry.Registry, moduleName string, specBytes []byte) {
 	if os.Getenv(hbase.EnvDebugCompletion) == "1" && isCompletionInvocation() {
 		hlog.SetDebugFile(hbase.CompletionDebugLogFile())
 	}
@@ -108,7 +111,8 @@ func SetupAndExecutePluginRootCmd(root *cobra.Command, reg *registry.Registry, m
 			return dumpIdentity(moduleName)
 		}
 		if ok, _ := cmd.Flags().GetBool("spec"); ok {
-			return dumpSpec(moduleName)
+			fmt.Print(string(specBytes))
+			return nil
 		}
 		if origRun != nil {
 			return origRun(cmd, args)
@@ -125,15 +129,6 @@ func SetupAndExecutePluginRootCmd(root *cobra.Command, reg *registry.Registry, m
 		defaultHelp(cmd, args)
 	})
 	SetupAndExecuteRootCmd(root, reg)
-}
-
-func dumpSpec(moduleName string) error {
-	data, err := specloader.ReadSpecFile(moduleName)
-	if err != nil {
-		return err
-	}
-	fmt.Print(string(data))
-	return nil
 }
 
 // dumpIdentity emits the sentinel-gated identity object the host checks before

--- a/pkg/specloader/specloader.go
+++ b/pkg/specloader/specloader.go
@@ -181,14 +181,27 @@ func ReadSpecFile(moduleName string) ([]byte, error) {
 	return spec.Read(moduleName + ".spec.yaml")
 }
 
-// LoadSpec loads a single embedded spec file (e.g. "har.spec.yaml") into reg.
-// isHarnessUser gates modules marked harness_internal: true.
-func LoadSpec(reg *registry.Registry, name string, isHarnessUser bool) error {
+// Returns the raw bytes it read so a plugin main() can also hand them to
+// rootcmd.SetupAndExecutePluginRootCmd for its own --spec dump, without a
+// second read of the same file.
+func LoadSpec(reg *registry.Registry, name string, isHarnessUser bool) ([]byte, error) {
 	data, err := spec.Read(name)
 	if err != nil {
-		return fmt.Errorf("spec: read %s: %w", name, err)
+		return nil, fmt.Errorf("spec: read %s: %w", name, err)
 	}
-	return loadSpecData(reg, name, data, isHarnessUser, false)
+	if err := loadSpecData(reg, name, data, isHarnessUser, false); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// LoadSpecBytes is LoadSpec's counterpart for a plugin whose spec file lives in
+// its own repo rather than core's pkg/spec.
+func LoadSpecBytes(reg *registry.Registry, name string, data []byte, isHarnessUser bool) ([]byte, error) {
+	if err := loadSpecData(reg, name, data, isHarnessUser, false); err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
 // loadSpecData parses spec bytes and registers the module, nouns, and commands.


### PR DESCRIPTION
## Summary
  - `rootcmd.SetupAndExecutePluginRootCmd` now takes `specBytes []byte`
    and prints them verbatim on `--spec`, instead of calling
    `specloader.ReadSpecFile(moduleName)` (which only reads names baked
    into core's `pkg/spec` embed.FS at compile time).
  - `specloader.LoadSpec` now returns the bytes it read, in addition to
    registering the spec — no behavior change for existing callers
    beyond the new return value.
  - Added `specloader.LoadSpecBytes(reg, name, data, isHarnessUser)` —
    same registration logic as `LoadSpec`, but the caller supplies the
    bytes directly instead of going through `spec.Read`.
  - Updated `har`'s `main-harness-har.go` to the new `LoadSpec` signature.

  ## Why
  `go:embed` globs are resolved at compile time of the *declaring*
  package's own source directory — `pkg/spec`'s embed can only ever see
  `.spec.yaml` files physically committed inside
  `harness-unified-cli/pkg/spec/`. `har` works today only because
  `har.spec.yaml` happens to be checked into that directory. A plugin
  that lives in a genuinely separate repo (e.g. an upcoming `hcli`
  plugin) has no way to get its spec file into that embed, so the old
  `dumpSpec`/`ReadSpecFile` path would fail for it with "file not
  found." This change lets each plugin supply its own spec bytes from
  wherever it likes (its own `go:embed`, typically), while
  `rootcmd`/`specloader` stay generic.