### PR TITLE
fix: [FME-17257]: public FME v4 paths and CLI gap fixes

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -51,12 +51,22 @@ func APIErrorMessage(status int, body []byte) string {
 			return "Harness returned an HTML page (possible redirect, proxy, or WAF). Check your API URL and credentials."
 		}
 	}
-	// Try to extract a message from JSON
+	// Prefer RFC 7807 / FME v4 problem+JSON `detail` over legacy `message`.
 	var parsed struct {
 		Message string `json:"message"`
+		Detail  string `json:"detail"`
+		Title   string `json:"title"`
 	}
-	if json.Unmarshal(body, &parsed) == nil && parsed.Message != "" {
-		return parsed.Message
+	if json.Unmarshal(body, &parsed) == nil {
+		if parsed.Detail != "" {
+			return parsed.Detail
+		}
+		if parsed.Message != "" {
+			return parsed.Message
+		}
+		if parsed.Title != "" {
+			return parsed.Title
+		}
 	}
 	if len(body) > 200 {
 		return string(body[:200]) + "..."

--- a/pkg/client/error_test.go
+++ b/pkg/client/error_test.go
@@ -1,0 +1,40 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import "testing"
+
+func TestAPIErrorMessage_ProblemJSONUsesDetail(t *testing.T) {
+	body := []byte(`{"type":"https://developer.harness.io/docs/api-reference/errors#has-dependents","status":400,"title":"Resource Has Dependents","errorType":"hasDependents","detail":"Environment d264a970-9756-11f1-87f2-ca24eb84ddac cannot be archived, it has apitokens associated [tok-1]"}`)
+	got := APIErrorMessage(400, body)
+	if want := "Environment d264a970-9756-11f1-87f2-ca24eb84ddac cannot be archived, it has apitokens associated [tok-1]"; got != want {
+		t.Fatalf("APIErrorMessage = %q, want detail %q", got, want)
+	}
+}
+
+func TestAPIErrorMessage_PrefersDetailOverMessage(t *testing.T) {
+	body := []byte(`{"message":"generic","detail":"specific dependent list"}`)
+	got := APIErrorMessage(400, body)
+	if got != "specific dependent list" {
+		t.Fatalf("APIErrorMessage = %q, want detail", got)
+	}
+}
+
+func TestAPIErrorMessage_FallsBackToMessage(t *testing.T) {
+	body := []byte(`{"message":"legacy harness error"}`)
+	got := APIErrorMessage(400, body)
+	if got != "legacy harness error" {
+		t.Fatalf("APIErrorMessage = %q, want message", got)
+	}
+}
+
+func TestAPIErrorMessage_DoesNotTruncateDetail(t *testing.T) {
+	detail := "Environment abc cannot be archived, it has apitokens associated [" +
+		"tok-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee, tok-ffffffff-1111-2222-3333-444444444444]"
+	body := []byte(`{"errorType":"hasDependents","detail":"` + detail + `"}`)
+	got := APIErrorMessage(400, body)
+	if got != detail {
+		t.Fatalf("truncated or rewritten detail: %q", got)
+	}
+}

--- a/pkg/registry/buildctx.go
+++ b/pkg/registry/buildctx.go
@@ -277,7 +277,17 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 		return nil, err
 	}
 	for _, f := range cs.Flags {
-		if f.Required && cmdctx.GetString(ctx.FlagValues, f.Name) == "" {
+		if !f.Required {
+			continue
+		}
+		var missing bool
+		switch {
+		case f.IsArray || f.IsMulti:
+			missing = len(cmdctx.GetStringSlice(ctx.FlagValues, f.Name)) == 0
+		default:
+			missing = cmdctx.GetString(ctx.FlagValues, f.Name) == ""
+		}
+		if missing {
 			if len(f.CompletionValues) > 0 {
 				return nil, fmt.Errorf("flag --%s is required (%s)", f.Name, strings.Join(f.CompletionValues, ", "))
 			}

--- a/pkg/registry/buildctx_workflow_test.go
+++ b/pkg/registry/buildctx_workflow_test.go
@@ -159,6 +159,37 @@ func TestBuildCtx_WorkflowRequiredFlag(t *testing.T) {
 	}
 }
 
+func TestBuildCtx_WorkflowRequiredArrayFlag(t *testing.T) {
+	r := New()
+	registerWorkflowExecute(t, r, "reqarrayflag", &spec.CommandSpec{
+		Flags: []spec.Flag{
+			{Name: "keys", Required: true, IsArray: true, Description: "keys to remove"},
+		},
+	})
+	cs := r.GetSpec(VerbExecute, "reqarrayflag")
+
+	t.Run("missing", func(t *testing.T) {
+		cmd := buildWorkflowTestCmd(t, r, cs)
+		_, err := buildCtx(cmd, cs, []string{"my-id"}, r)
+		if err == nil {
+			t.Fatal("buildCtx() = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "flag --keys is required") {
+			t.Fatalf("buildCtx() error %q missing expected substring", err)
+		}
+	})
+
+	t.Run("provided", func(t *testing.T) {
+		cmd := buildWorkflowTestCmd(t, r, cs)
+		if err := cmd.ParseFlags([]string{"--keys", "key-one,key-two"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if _, err := buildCtx(cmd, cs, []string{"my-id"}, r); err != nil {
+			t.Fatalf("buildCtx() = %v, want no error", err)
+		}
+	})
+}
+
 func TestBuildCtx_WorkflowIdPartsTooMany(t *testing.T) {
 	r := New()
 	registerWorkflowExecute(t, r, "cluster", &spec.CommandSpec{

--- a/pkg/registry/endpoint.go
+++ b/pkg/registry/endpoint.go
@@ -290,7 +290,7 @@ func RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error) {
 		}
 		defer closeW()
 		if ctx.VerbHandler == VerbUpdate || ep.CreateStrategy == spec.CreateStrategySetFields {
-			return nil, PrintMutableFieldTable(w, MutableFields(resolveNounDef(ctx)))
+			return nil, PrintMutableFieldTable(w, MutableFields(resolveNounDef(ctx), ep.FieldsExtra))
 		}
 		return nil, PrintFieldTable(w, fields)
 	}
@@ -769,9 +769,9 @@ func runGetThenUpdate(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, 
 		return nil, fmt.Errorf("get-then-%s: unmarshaling picked item: %w", strings.ToLower(method), err)
 	}
 
-	// Build a fieldID→FieldDef map from the noun's mutable fields for --set/--del resolution.
+	// Build a fieldID→FieldDef map from noun + fields_extra mutable paths for --set/--del.
 	fieldPaths := map[string]spec.FieldDef{}
-	for _, f := range MutableFields(resolveNounDef(ctx)) {
+	for _, f := range MutableFields(resolveNounDef(ctx), ep.FieldsExtra) {
 		fieldPaths[f.ID] = f
 	}
 
@@ -882,9 +882,9 @@ func runSetFields(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, c *client.Client, path
 		}
 	}
 
-	// Build fieldID→FieldDef map from the noun's mutable fields.
+	// Build fieldID→FieldDef map from noun + fields_extra mutable paths.
 	fieldPaths := map[string]spec.FieldDef{}
-	for _, f := range MutableFields(resolveNounDef(ctx)) {
+	for _, f := range MutableFields(resolveNounDef(ctx), ep.FieldsExtra) {
 		fieldPaths[f.ID] = f
 	}
 

--- a/pkg/registry/fields.go
+++ b/pkg/registry/fields.go
@@ -155,13 +155,20 @@ func (r *Registry) ResolveCommandFields(cs *spec.CommandSpec) []spec.FieldDef {
 	return append(base, ep.FieldsExtra...)
 }
 
-// MutableFields returns only the writable fields for a noun (those with mutable_path set).
-func MutableFields(noun *spec.NounDef) []spec.FieldDef {
-	if noun == nil {
+// MutableFields returns writable fields (mutable_path set) from the noun plus
+// any command-level fields_extra. Variant commands (e.g. feature_flag:definition)
+// declare extra writable paths on the endpoint, not on the noun.
+func MutableFields(noun *spec.NounDef, extra []spec.FieldDef) []spec.FieldDef {
+	var src []spec.FieldDef
+	if noun != nil {
+		src = append(src, noun.Fields...)
+	}
+	src = append(src, extra...)
+	if len(src) == 0 {
 		return nil
 	}
 	var out []spec.FieldDef
-	for _, f := range noun.Fields {
+	for _, f := range src {
 		if f.MutablePath != "" {
 			out = append(out, f)
 		}

--- a/pkg/registry/fields_test.go
+++ b/pkg/registry/fields_test.go
@@ -328,7 +328,7 @@ func TestResolveCommandFields_FieldsNounOverride(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestMutableFields_NilNoun(t *testing.T) {
-	if got := MutableFields(nil); got != nil {
+	if got := MutableFields(nil, nil); got != nil {
 		t.Fatalf("expected nil for nil noun, got %v", got)
 	}
 }
@@ -338,9 +338,31 @@ func TestMutableFields_FiltersNonMutable(t *testing.T) {
 		{ID: "name", Expr: "it.name", MutablePath: "name"},
 		{ID: "status", Expr: "it.status"}, // not mutable
 	}}
-	got := MutableFields(nd)
+	got := MutableFields(nd, nil)
 	if len(got) != 1 || got[0].ID != "name" {
 		t.Fatalf("MutableFields = %v, want only 'name'", got)
+	}
+}
+
+func TestMutableFields_IncludesFieldsExtra(t *testing.T) {
+	nd := &spec.NounDef{Fields: []spec.FieldDef{
+		{ID: "name", Expr: "it.name", MutablePath: "name"},
+		{ID: "status", Expr: "it.status"},
+	}}
+	extra := []spec.FieldDef{
+		{ID: "traffic_allocation", Expr: "string(it.trafficAllocation)", MutablePath: "trafficAllocation"},
+		{ID: "environment", Expr: "it.environment.name"}, // display-only extra
+	}
+	got := MutableFields(nd, extra)
+	if len(got) != 2 {
+		t.Fatalf("MutableFields = %v, want name + traffic_allocation", got)
+	}
+	ids := map[string]string{}
+	for _, f := range got {
+		ids[f.ID] = f.MutablePath
+	}
+	if ids["name"] != "name" || ids["traffic_allocation"] != "trafficAllocation" {
+		t.Fatalf("MutableFields paths = %v", ids)
 	}
 }
 

--- a/pkg/spec/fme.spec.yaml
+++ b/pkg/spec/fme.spec.yaml
@@ -15,20 +15,20 @@ nouns:
     noun_aliases: [feature_flags, ff]
     fields:
       - id: name
-        expr: it.entity.name
+        expr: it.name
       - id: description
-        expr: it.entity.description ?? ""
+        expr: it.description ?? ""
         width_max: 60
       - id: traffic_type
         label: Traffic Type
-        expr: it.entity.trafficType.name
+        expr: it.trafficType.name
       - id: status
-        expr: it.entity.status
+        expr: it.status
       - id: rollout_status
         label: Rollout Status
-        expr: it.entity.rolloutStatus.name ?? ""
+        expr: it.rolloutStatus.name ?? ""
       - id: created
-        expr: it.entity.createdAt
+        expr: it.createdAt
         field_type: ts
 
 commands:
@@ -46,10 +46,10 @@ commands:
         description: "Filter by status: ACTIVE, ARCHIVED"
         completion_values: [ACTIVE, ARCHIVED]
     endpoint:
-      path: /v3/feature-flags
+      path: /fme/internal/api/v4/feature-flags
       items_expr: it.data
       item_item_expr: it
-      get_id_expr: it.entity.name
+      get_id_expr: it.name
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -72,13 +72,13 @@ commands:
     short: Get feature flag details
     handler_type: endpoint
     endpoint:
-      path: /v3/feature-flags/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
         project_identifier: auth.project
       item_expr: it
-      yaml_pick_expr: it.entity
+      yaml_pick_expr: it
 
   - command: create feature_flag
     verb: create
@@ -93,7 +93,7 @@ commands:
       set: true
     endpoint:
       method: POST
-      path: /v3/feature-flags
+      path: /fme/internal/api/v4/feature-flags
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -104,7 +104,7 @@ commands:
         trafficType: flags.traffic-type
       create_body_wrap: ""
       item_expr: it
-      text_header: "\nCreated feature flag {{it.entity.name}}\n"
+      text_header: "\nCreated feature flag {{it.name}}\n"
 
   - command: update feature_flag
     verb: update
@@ -116,10 +116,10 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /v3/feature-flags/{{ctx.id}}
-      get_path: /v3/feature-flags/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
+      get_path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
       update_strategy: get-then-patch
-      update_body_pick: it.entity
+      update_body_pick: it
       update_body_wrap: ""
       query_params:
         account_id: auth.account
@@ -136,7 +136,7 @@ commands:
     handler_type: endpoint
     endpoint:
       method: DELETE
-      path: /v3/feature-flags/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -153,7 +153,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /v3/feature-flags/{{ctx.id}}/archive
+      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}/archive
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -174,7 +174,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /v3/feature-flags/{{ctx.id}}/unarchive
+      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}/unarchive
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -195,10 +195,10 @@ commands:
     requires_parentid: true
     parentid_label: "<flag-name>"
     endpoint:
-      path: /v3/feature-flag-definitions
+      path: /fme/internal/api/v4/feature-flag-definitions
       items_expr: it.data
       item_item_expr: it
-      get_id_expr: it.entity.environment.id
+      get_id_expr: it.environment.id
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -214,20 +214,20 @@ commands:
         countable: true
       fields_extra:
         - id: environment
-          expr: it.entity.environment.name
+          expr: it.environment.name
         - id: default_treatment
           label: Default Treatment
-          expr: it.entity.defaultTreatment
+          expr: it.defaultTreatment
         - id: traffic_allocation
           label: Traffic Allocation
-          expr: string(it.entity.trafficAllocation)
+          expr: string(it.trafficAllocation)
         - id: is_killed
           label: Killed
-          expr: string(it.entity.killed)
-        - id: modified
-          expr: it.entity.modifiedAt
+          expr: string(it.isKilled)
+        - id: created
+          expr: it.createdAt
           field_type: ts
-      columns: [environment, default_treatment, traffic_allocation, is_killed, modified]
+      columns: [environment, default_treatment, traffic_allocation, is_killed, created]
 
   - command: get feature_flag:definition
     verb: get
@@ -240,14 +240,14 @@ commands:
         description: Environment identifier (required)
         required: true
     endpoint:
-      path: /v3/feature-flag-definitions/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
         project_identifier: auth.project
         environment_id: flags.env
       item_expr: it
-      yaml_pick_expr: it.entity
+      yaml_pick_expr: it
 
   - command: create feature_flag:definition
     verb: create
@@ -262,7 +262,7 @@ commands:
     endpoint:
       method: POST
       file_body: required
-      path: /v3/feature-flag-definitions/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -286,10 +286,10 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /v3/feature-flag-definitions/{{ctx.id}}
-      get_path: /v3/feature-flag-definitions/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
+      get_path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
       update_strategy: get-then-patch
-      update_body_pick: it.entity
+      update_body_pick: it
       update_body_wrap: ""
       query_params:
         account_id: auth.account
@@ -312,7 +312,7 @@ commands:
         required: true
     endpoint:
       method: DELETE
-      path: /v3/feature-flag-definitions/{{ctx.id}}
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -333,7 +333,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /v3/feature-flag-definitions/{{ctx.id}}/kill
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}/kill
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -358,7 +358,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /v3/feature-flag-definitions/{{ctx.id}}/restore
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}/restore
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -383,7 +383,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /v3/feature-flag-definitions/{{ctx.id}}/reallocate
+      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}/reallocate
       query_params:
         account_id: auth.account
         organization_identifier: auth.org

--- a/pkg/spec/fme.spec.yaml
+++ b/pkg/spec/fme.spec.yaml
@@ -789,6 +789,7 @@ commands:
     handler_type: endpoint
     requires_parentid: true
     parentid_label: "<segment-name>"
+    fields_noun: segment_definition_keys
     flags:
       - name: env
         description: Environment identifier (required)
@@ -797,7 +798,7 @@ commands:
       path: /fme/internal/api/v4/segment-definitions/{{ctx.parentId}}/keys
       items_expr: it.data
       item_item_expr: it
-      fields_noun: segment_definition_keys
+      get_id_expr: "-"
       query_params:
         account_id: auth.account
         organization_identifier: auth.org

--- a/pkg/spec/fme.spec.yaml
+++ b/pkg/spec/fme.spec.yaml
@@ -31,6 +31,45 @@ nouns:
         expr: epochMs(it.createdAt * 1000)
         field_type: ts
 
+  - noun: fme_environment
+    short_desc: A Harness FME environment (distinct from the CD "environment" noun).
+    noun_aliases: [fme_environments, fme_env]
+    fields:
+      - id: name
+        expr: it.name
+        mutable_path: name
+      - id: production
+        label: Production
+        expr: string(it.isProduction)
+        mutable_path: isProduction
+      - id: status
+        expr: it.status
+
+  - noun: segment
+    short_desc: A Harness FME segment (a named list of targeting keys).
+    noun_aliases: [segments, seg]
+    fields:
+      - id: name
+        expr: it.name
+      - id: description
+        expr: it.description ?? ""
+        mutable_path: description
+        width_max: 60
+      - id: traffic_type
+        label: Traffic Type
+        expr: it.trafficType.name
+      - id: status
+        expr: it.status
+      - id: created
+        expr: epochMs(it.createdAt * 1000)
+        field_type: ts
+
+  - noun: segment_definition_keys
+    short_desc: A targeting key within a segment definition (used for field lookup only).
+    fields:
+      - id: key
+        expr: it
+
 commands:
   # ── feature_flag ─────────────────────────────────────────────────────────────
 
@@ -393,3 +432,452 @@ commands:
         comment: flags.comment
       item_expr: it.entity
       text_header: "\nReallocated traffic for {{ctx.id}} in {{flags.env}}\n"
+
+  # ── fme_environment ────────────────────────────────────────────────────────────
+  # Named fme_environment (not "environment") because the "environment" noun is
+  # already owned by the cd module (a different resource).
+
+  - command: list fme_environment
+    verb: list
+    noun: fme_environment
+    short: List FME environments
+    handler_type: endpoint
+    endpoint:
+      path: /fme/internal/api/v4/environments
+      items_expr: it.data
+      item_item_expr: it
+      get_id_expr: it.id
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      paging:
+        paging_strategy: offset_limit
+        page_index_param: offset
+        page_size_param: limit
+        page_size_default: 100
+        page_size_max: 100
+        total_expr: it.totalCount
+        countable: true
+      columns: [name, production, status]
+
+  - command: get fme_environment
+    verb: get
+    noun: fme_environment
+    short: "Get FME environment details: harness get fme_environment <environment-id>"
+    handler_type: endpoint
+    endpoint:
+      path: /fme/internal/api/v4/environments/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      item_expr: it
+      yaml_pick_expr: it
+
+  - command: create fme_environment
+    verb: create
+    noun: fme_environment
+    short: "Create an FME environment: harness create fme_environment <name> [--production]"
+    handler_type: endpoint
+    flags:
+      - name: production
+        is_bool: true
+        description: Mark the environment as a production environment
+    flags_builtin:
+      set: true
+    endpoint:
+      method: POST
+      path: /fme/internal/api/v4/environments
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      create_strategy: set-fields
+      create_body_init:
+        name: ctx.id
+        isProduction: flags.production
+      create_body_wrap: ""
+      item_expr: it.entity
+      text_header: "\nCreated environment {{it.name}}\n"
+
+  - command: update fme_environment
+    verb: update
+    noun: fme_environment
+    short: "Update an FME environment: harness update fme_environment <environment-id> --set name=foo"
+    handler_type: endpoint
+    flags_builtin:
+      set: true
+      del: true
+    endpoint:
+      method: PATCH
+      path: /fme/internal/api/v4/environments/{{ctx.id}}
+      get_path: /fme/internal/api/v4/environments/{{ctx.id}}
+      update_strategy: get-then-patch
+      update_body_pick: it
+      update_body_wrap: ""
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      item_expr: it.entity
+      text_header: "\nUpdated environment {{ctx.id}}\n"
+
+  - command: delete fme_environment
+    verb: delete
+    noun: fme_environment
+    confirm_mode: prompt
+    short: Delete (archive) an FME environment
+    handler_type: endpoint
+    endpoint:
+      method: DELETE
+      path: /fme/internal/api/v4/environments/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+
+  # ── segment ──────────────────────────────────────────────────────────────────
+
+  - command: list segment
+    verb: list
+    noun: segment
+    short: List segments
+    handler_type: endpoint
+    endpoint:
+      path: /fme/internal/api/v4/segments
+      items_expr: it.data
+      item_item_expr: it
+      get_id_expr: it.name
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      paging:
+        paging_strategy: offset_limit
+        page_index_param: offset
+        page_size_param: limit
+        page_size_default: 100
+        page_size_max: 100
+        total_expr: it.totalCount
+        countable: true
+      columns: [name, traffic_type, status, created]
+
+  - command: get segment
+    verb: get
+    noun: segment
+    short: "Get segment details: harness get segment <name>"
+    handler_type: endpoint
+    endpoint:
+      path: /fme/internal/api/v4/segments/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      item_expr: it
+      yaml_pick_expr: it
+
+  - command: create segment
+    verb: create
+    noun: segment
+    short: "Create a segment: harness create segment <name> --traffic-type user"
+    handler_type: endpoint
+    flags:
+      - name: traffic-type
+        description: Traffic type for the segment (e.g. user, account)
+        required: true
+      - name: description
+        description: Segment description
+    flags_builtin:
+      set: true
+    endpoint:
+      method: POST
+      path: /fme/internal/api/v4/segments
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      create_strategy: set-fields
+      create_body_init:
+        name: ctx.id
+        trafficType: flags["traffic-type"]
+        description: 'flags.description != "" ? flags.description : nil'
+      create_body_wrap: ""
+      item_expr: it.entity
+      text_header: "\nCreated segment {{it.name}}\n"
+
+  - command: update segment
+    verb: update
+    noun: segment
+    short: "Update a segment: harness update segment <name> --set description=foo"
+    handler_type: endpoint
+    flags_builtin:
+      set: true
+      del: true
+    endpoint:
+      method: PATCH
+      path: /fme/internal/api/v4/segments/{{ctx.id}}
+      get_path: /fme/internal/api/v4/segments/{{ctx.id}}
+      update_strategy: get-then-patch
+      update_body_pick: it
+      update_body_wrap: ""
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+      item_expr: it.entity
+      text_header: "\nUpdated segment {{ctx.id}}\n"
+
+  - command: delete segment
+    verb: delete
+    noun: segment
+    confirm_mode: prompt
+    short: Delete (archive) a segment
+    handler_type: endpoint
+    endpoint:
+      method: DELETE
+      path: /fme/internal/api/v4/segments/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+
+  # ── segment:definition ─────────────────────────────────────────────────────────
+
+  - command: list segment:definition
+    verb: list
+    noun: segment
+    noun_variant: definition
+    short: "List segment definitions in an environment: harness list segment:definition --env <env-id>"
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+    endpoint:
+      path: /fme/internal/api/v4/segment-definitions
+      items_expr: it.data
+      item_item_expr: it
+      get_id_expr: it.segment.name
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+      paging:
+        paging_strategy: offset_limit
+        page_index_param: offset
+        page_size_param: limit
+        page_size_default: 100
+        page_size_max: 100
+        total_expr: it.totalCount
+        countable: true
+      fields_extra:
+        - id: segment
+          expr: it.segment.name
+        - id: environment
+          expr: it.environment.name
+        - id: description
+          expr: it.description ?? ""
+        - id: status
+          expr: it.status
+        - id: created
+          expr: epochMs(it.createdAt * 1000)
+          field_type: ts
+      columns: [segment, environment, description, status, created]
+
+  - command: get segment:definition
+    verb: get
+    noun: segment
+    noun_variant: definition
+    short: "Get a segment definition: harness get segment:definition <segment-name> --env <env-id>"
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+    endpoint:
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+      item_expr: it
+      yaml_pick_expr: it
+
+  - command: create segment:definition
+    verb: create
+    noun: segment
+    noun_variant: definition
+    short: "Create a segment definition in an environment: harness create segment:definition <segment-name> --env <env-id> [--description desc]"
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+      - name: description
+        description: Definition description
+    endpoint:
+      method: POST
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+      body_params:
+        description: 'flags.description != "" ? flags.description : nil'
+      item_expr: it.entity
+      text_header: "\nCreated segment definition for {{ctx.id}} in {{flags.env}}\n"
+
+  - command: update segment:definition
+    verb: update
+    noun: segment
+    noun_variant: definition
+    short: "Update a segment definition: harness update segment:definition <segment-name> --env <env-id> --set description=foo"
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+    flags_builtin:
+      set: true
+      del: true
+    endpoint:
+      method: PATCH
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      get_path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      update_strategy: get-then-patch
+      update_body_pick: it
+      update_body_wrap: ""
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+      item_expr: it.entity
+      text_header: "\nUpdated segment definition for {{ctx.id}} in {{flags.env}}\n"
+
+  - command: delete segment:definition
+    verb: delete
+    noun: segment
+    noun_variant: definition
+    confirm_mode: prompt
+    short: Delete (archive) a segment definition from an environment
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+    endpoint:
+      method: DELETE
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+
+  # ── segment:definition_keys ────────────────────────────────────────────────────
+
+  - command: list segment:definition_keys
+    verb: list
+    noun: segment
+    noun_variant: definition_keys
+    short: "List targeting keys in a segment definition: harness list segment:definition_keys <segment-name> --env <env-id>"
+    handler_type: endpoint
+    requires_parentid: true
+    parentid_label: "<segment-name>"
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+    endpoint:
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.parentId}}/keys
+      items_expr: it.data
+      item_item_expr: it
+      fields_noun: segment_definition_keys
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+      paging:
+        paging_strategy: offset_limit
+        page_index_param: offset
+        page_size_param: limit
+        page_size_default: 100
+        page_size_max: 100
+        total_expr: it.totalCount
+        countable: true
+      columns: [key]
+
+  - command: execute segment:definition_keys_add
+    verb: execute
+    noun: segment
+    noun_variant: definition_keys_add
+    short: "Add (or replace) targeting keys in a segment definition: harness execute segment:definition_keys_add <segment-name> --env <env-id> --keys k1,k2 [--replace]"
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+      - name: keys
+        description: Targeting keys to add (comma-separated list or JSON array)
+        is_array: true
+      - name: replace
+        is_bool: true
+        description: Replace the entire key set instead of merging (empty --keys with --replace clears all keys)
+      - name: comment
+        description: Audit comment
+      - name: title
+        description: Audit change title
+    endpoint:
+      method: POST
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}/keys
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+        replace: 'flags.replace ? "true" : nil'
+      body_params:
+        keys: flags.keys
+        comment: flags.comment
+        title: flags.title
+      item_expr: it.keys
+      text_header: "\nUpdated keys for segment definition {{ctx.id}} in {{flags.env}}\n"
+
+  - command: execute segment:definition_keys_remove
+    verb: execute
+    noun: segment
+    noun_variant: definition_keys_remove
+    short: "Remove targeting keys from a segment definition: harness execute segment:definition_keys_remove <segment-name> --env <env-id> --keys k1,k2"
+    handler_type: endpoint
+    flags:
+      - name: env
+        description: Environment identifier (required)
+        required: true
+      - name: keys
+        description: Targeting keys to remove (comma-separated list or JSON array)
+        required: true
+        is_array: true
+      - name: comment
+        description: Audit comment
+      - name: title
+        description: Audit change title
+    endpoint:
+      method: POST
+      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}/keys/remove
+      query_params:
+        account_id: auth.account
+        organization_identifier: auth.org
+        project_identifier: auth.project
+        environment_id: flags.env
+      body_params:
+        keys: flags.keys
+        comment: flags.comment
+        title: flags.title
+      item_expr: it.keys
+      text_header: "\nRemoved keys from segment definition {{ctx.id}} in {{flags.env}}\n"

--- a/pkg/spec/fme.spec.yaml
+++ b/pkg/spec/fme.spec.yaml
@@ -1,7 +1,6 @@
 spec_version: 1
 module_type: builtin
 module_desc: Harness FME — Feature flags and targeting definitions
-harness_internal: true
 help_text: |
   ## Feature Management & Experimentation (fme)
 
@@ -18,6 +17,7 @@ nouns:
         expr: it.name
       - id: description
         expr: it.description ?? ""
+        mutable_path: description
         width_max: 60
       - id: traffic_type
         label: Traffic Type
@@ -28,7 +28,7 @@ nouns:
         label: Rollout Status
         expr: it.rolloutStatus.name ?? ""
       - id: created
-        expr: it.createdAt
+        expr: epochMs(it.createdAt * 1000)
         field_type: ts
 
 commands:
@@ -101,9 +101,9 @@ commands:
       create_strategy: set-fields
       create_body_init:
         name: ctx.id
-        trafficType: flags.traffic-type
+        trafficType: flags["traffic-type"]
       create_body_wrap: ""
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nCreated feature flag {{it.name}}\n"
 
   - command: update feature_flag
@@ -125,7 +125,7 @@ commands:
         account_id: auth.account
         organization_identifier: auth.org
         project_identifier: auth.project
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nUpdated feature flag {{ctx.id}}\n"
 
   - command: delete feature_flag
@@ -160,7 +160,7 @@ commands:
         project_identifier: auth.project
       body_params:
         comment: flags.comment
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nArchived feature flag {{ctx.id}}\n"
 
   - command: execute feature_flag:unarchive
@@ -181,7 +181,7 @@ commands:
         project_identifier: auth.project
       body_params:
         comment: flags.comment
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nUnarchived feature flag {{ctx.id}}\n"
 
   # ── feature_flag:definition ───────────────────────────────────────────────────
@@ -225,7 +225,7 @@ commands:
           label: Killed
           expr: string(it.isKilled)
         - id: created
-          expr: it.createdAt
+          expr: epochMs(it.createdAt * 1000)
           field_type: ts
       columns: [environment, default_treatment, traffic_allocation, is_killed, created]
 
@@ -268,7 +268,7 @@ commands:
         organization_identifier: auth.org
         project_identifier: auth.project
         environment_id: flags.env
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nCreated definition for {{ctx.id}} in {{flags.env}}\n"
 
   - command: update feature_flag:definition
@@ -296,7 +296,7 @@ commands:
         organization_identifier: auth.org
         project_identifier: auth.project
         environment_id: flags.env
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nUpdated definition for {{ctx.id}} in {{flags.env}}\n"
 
   - command: delete feature_flag:definition
@@ -341,7 +341,7 @@ commands:
         environment_id: flags.env
       body_params:
         comment: flags.comment
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nKilled feature flag {{ctx.id}} in {{flags.env}}\n"
 
   - command: execute feature_flag:restore
@@ -366,7 +366,7 @@ commands:
         environment_id: flags.env
       body_params:
         comment: flags.comment
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nRestored feature flag {{ctx.id}} in {{flags.env}}\n"
 
   - command: execute feature_flag:reallocate
@@ -391,5 +391,5 @@ commands:
         environment_id: flags.env
       body_params:
         comment: flags.comment
-      item_expr: it
+      item_expr: it.entity
       text_header: "\nReallocated traffic for {{ctx.id}} in {{flags.env}}\n"

--- a/pkg/spec/fme.spec.yaml
+++ b/pkg/spec/fme.spec.yaml
@@ -70,6 +70,42 @@ nouns:
       - id: key
         expr: it
 
+  - noun: feature_flag_definition
+    short_desc: A feature flag's environment-specific targeting definition (used for field lookup only).
+    fields:
+      - id: environment
+        expr: it.environment.name
+      - id: default_treatment
+        label: Default Treatment
+        expr: it.defaultTreatment
+      - id: traffic_allocation
+        label: Traffic Allocation
+        expr: string(it.trafficAllocation)
+        mutable_path: trafficAllocation
+      - id: is_killed
+        label: Killed
+        expr: string(it.isKilled)
+      - id: created
+        expr: epochMs(it.createdAt * 1000)
+        field_type: ts
+
+  - noun: segment_definition
+    short_desc: A segment's environment-specific targeting definition (used for field lookup only).
+    fields:
+      - id: segment
+        expr: it.segment.name
+      - id: environment
+        expr: it.environment.name
+      - id: description
+        expr: it.description ?? ""
+        mutable_path: description
+        width_max: 60
+      - id: status
+        expr: it.status
+      - id: created
+        expr: epochMs(it.createdAt * 1000)
+        field_type: ts
+
 commands:
   # ── feature_flag ─────────────────────────────────────────────────────────────
 
@@ -85,7 +121,7 @@ commands:
         description: "Filter by status: ACTIVE, ARCHIVED"
         completion_values: [ACTIVE, ARCHIVED]
     endpoint:
-      path: /fme/internal/api/v4/feature-flags
+      path: /fme/api/v4/feature-flags
       items_expr: it.data
       item_item_expr: it
       get_id_expr: it.name
@@ -111,7 +147,7 @@ commands:
     short: Get feature flag details
     handler_type: endpoint
     endpoint:
-      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
+      path: /fme/api/v4/feature-flags/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -132,7 +168,7 @@ commands:
       set: true
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/feature-flags
+      path: /fme/api/v4/feature-flags
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -155,8 +191,8 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
-      get_path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
+      path: /fme/api/v4/feature-flags/{{ctx.id}}
+      get_path: /fme/api/v4/feature-flags/{{ctx.id}}
       update_strategy: get-then-patch
       update_body_pick: it
       update_body_wrap: ""
@@ -175,7 +211,7 @@ commands:
     handler_type: endpoint
     endpoint:
       method: DELETE
-      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}
+      path: /fme/api/v4/feature-flags/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -192,7 +228,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}/archive
+      path: /fme/api/v4/feature-flags/{{ctx.id}}/archive
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -213,7 +249,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/feature-flags/{{ctx.id}}/unarchive
+      path: /fme/api/v4/feature-flags/{{ctx.id}}/unarchive
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -233,8 +269,9 @@ commands:
     handler_type: endpoint
     requires_parentid: true
     parentid_label: "<flag-name>"
+    fields_noun: feature_flag_definition
     endpoint:
-      path: /fme/internal/api/v4/feature-flag-definitions
+      path: /fme/api/v4/feature-flag-definitions
       items_expr: it.data
       item_item_expr: it
       get_id_expr: it.environment.id
@@ -251,21 +288,6 @@ commands:
         page_size_max: 100
         total_expr: it.totalCount
         countable: true
-      fields_extra:
-        - id: environment
-          expr: it.environment.name
-        - id: default_treatment
-          label: Default Treatment
-          expr: it.defaultTreatment
-        - id: traffic_allocation
-          label: Traffic Allocation
-          expr: string(it.trafficAllocation)
-        - id: is_killed
-          label: Killed
-          expr: string(it.isKilled)
-        - id: created
-          expr: epochMs(it.createdAt * 1000)
-          field_type: ts
       columns: [environment, default_treatment, traffic_allocation, is_killed, created]
 
   - command: get feature_flag:definition
@@ -274,12 +296,13 @@ commands:
     noun_variant: definition
     short: "Get a flag definition for a specific environment: harness get ff:definition <flag-name> --env <env-id>"
     handler_type: endpoint
+    fields_noun: feature_flag_definition
     flags:
       - name: env
         description: Environment identifier (required)
         required: true
     endpoint:
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -294,6 +317,7 @@ commands:
     noun_variant: definition
     short: "Create a flag definition in an environment: harness create ff:definition <flag-name> --env <env-id> -f def.json"
     handler_type: endpoint
+    fields_noun: feature_flag_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -301,7 +325,7 @@ commands:
     endpoint:
       method: POST
       file_body: required
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -316,6 +340,7 @@ commands:
     noun_variant: definition
     short: "Update a flag definition: harness update ff:definition <name> --env <env-id> --set trafficAllocation=80"
     handler_type: endpoint
+    fields_noun: feature_flag_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -325,8 +350,8 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
-      get_path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}
+      get_path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}
       update_strategy: get-then-patch
       update_body_pick: it
       update_body_wrap: ""
@@ -351,7 +376,7 @@ commands:
         required: true
     endpoint:
       method: DELETE
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -364,6 +389,7 @@ commands:
     noun_variant: kill
     short: "Kill a flag in an environment (all traffic → defaultTreatment): harness execute ff:kill <flag-name> --env <env-id>"
     handler_type: endpoint
+    fields_noun: feature_flag_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -372,7 +398,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}/kill
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}/kill
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -389,6 +415,7 @@ commands:
     noun_variant: restore
     short: Restore a killed flag definition
     handler_type: endpoint
+    fields_noun: feature_flag_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -397,7 +424,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}/restore
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}/restore
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -414,6 +441,7 @@ commands:
     noun_variant: reallocate
     short: Re-hash traffic distribution for a flag definition
     handler_type: endpoint
+    fields_noun: feature_flag_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -422,7 +450,7 @@ commands:
         description: Audit comment
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/feature-flag-definitions/{{ctx.id}}/reallocate
+      path: /fme/api/v4/feature-flag-definitions/{{ctx.id}}/reallocate
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -443,7 +471,7 @@ commands:
     short: List FME environments
     handler_type: endpoint
     endpoint:
-      path: /fme/internal/api/v4/environments
+      path: /fme/api/v4/environments
       items_expr: it.data
       item_item_expr: it
       get_id_expr: it.id
@@ -467,7 +495,7 @@ commands:
     short: "Get FME environment details: harness get fme_environment <environment-id>"
     handler_type: endpoint
     endpoint:
-      path: /fme/internal/api/v4/environments/{{ctx.id}}
+      path: /fme/api/v4/environments/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -488,7 +516,7 @@ commands:
       set: true
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/environments
+      path: /fme/api/v4/environments
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -511,8 +539,8 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /fme/internal/api/v4/environments/{{ctx.id}}
-      get_path: /fme/internal/api/v4/environments/{{ctx.id}}
+      path: /fme/api/v4/environments/{{ctx.id}}
+      get_path: /fme/api/v4/environments/{{ctx.id}}
       update_strategy: get-then-patch
       update_body_pick: it
       update_body_wrap: ""
@@ -531,7 +559,7 @@ commands:
     handler_type: endpoint
     endpoint:
       method: DELETE
-      path: /fme/internal/api/v4/environments/{{ctx.id}}
+      path: /fme/api/v4/environments/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -545,7 +573,7 @@ commands:
     short: List segments
     handler_type: endpoint
     endpoint:
-      path: /fme/internal/api/v4/segments
+      path: /fme/api/v4/segments
       items_expr: it.data
       item_item_expr: it
       get_id_expr: it.name
@@ -569,7 +597,7 @@ commands:
     short: "Get segment details: harness get segment <name>"
     handler_type: endpoint
     endpoint:
-      path: /fme/internal/api/v4/segments/{{ctx.id}}
+      path: /fme/api/v4/segments/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -592,7 +620,7 @@ commands:
       set: true
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/segments
+      path: /fme/api/v4/segments
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -616,8 +644,8 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /fme/internal/api/v4/segments/{{ctx.id}}
-      get_path: /fme/internal/api/v4/segments/{{ctx.id}}
+      path: /fme/api/v4/segments/{{ctx.id}}
+      get_path: /fme/api/v4/segments/{{ctx.id}}
       update_strategy: get-then-patch
       update_body_pick: it
       update_body_wrap: ""
@@ -636,7 +664,7 @@ commands:
     handler_type: endpoint
     endpoint:
       method: DELETE
-      path: /fme/internal/api/v4/segments/{{ctx.id}}
+      path: /fme/api/v4/segments/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -650,12 +678,13 @@ commands:
     noun_variant: definition
     short: "List segment definitions in an environment: harness list segment:definition --env <env-id>"
     handler_type: endpoint
+    fields_noun: segment_definition
     flags:
       - name: env
         description: Environment identifier (required)
         required: true
     endpoint:
-      path: /fme/internal/api/v4/segment-definitions
+      path: /fme/api/v4/segment-definitions
       items_expr: it.data
       item_item_expr: it
       get_id_expr: it.segment.name
@@ -672,18 +701,6 @@ commands:
         page_size_max: 100
         total_expr: it.totalCount
         countable: true
-      fields_extra:
-        - id: segment
-          expr: it.segment.name
-        - id: environment
-          expr: it.environment.name
-        - id: description
-          expr: it.description ?? ""
-        - id: status
-          expr: it.status
-        - id: created
-          expr: epochMs(it.createdAt * 1000)
-          field_type: ts
       columns: [segment, environment, description, status, created]
 
   - command: get segment:definition
@@ -692,12 +709,13 @@ commands:
     noun_variant: definition
     short: "Get a segment definition: harness get segment:definition <segment-name> --env <env-id>"
     handler_type: endpoint
+    fields_noun: segment_definition
     flags:
       - name: env
         description: Environment identifier (required)
         required: true
     endpoint:
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      path: /fme/api/v4/segment-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -712,6 +730,7 @@ commands:
     noun_variant: definition
     short: "Create a segment definition in an environment: harness create segment:definition <segment-name> --env <env-id> [--description desc]"
     handler_type: endpoint
+    fields_noun: segment_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -720,7 +739,7 @@ commands:
         description: Definition description
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      path: /fme/api/v4/segment-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -737,6 +756,7 @@ commands:
     noun_variant: definition
     short: "Update a segment definition: harness update segment:definition <segment-name> --env <env-id> --set description=foo"
     handler_type: endpoint
+    fields_noun: segment_definition
     flags:
       - name: env
         description: Environment identifier (required)
@@ -746,10 +766,10 @@ commands:
       del: true
     endpoint:
       method: PATCH
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
-      get_path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      path: /fme/api/v4/segment-definitions/{{ctx.id}}
+      get_path: /fme/api/v4/segment-definitions/{{ctx.id}}
       update_strategy: get-then-patch
-      update_body_pick: it
+      update_body_pick: "{description: it.description}"
       update_body_wrap: ""
       query_params:
         account_id: auth.account
@@ -772,7 +792,7 @@ commands:
         required: true
     endpoint:
       method: DELETE
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}
+      path: /fme/api/v4/segment-definitions/{{ctx.id}}
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -795,7 +815,7 @@ commands:
         description: Environment identifier (required)
         required: true
     endpoint:
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.parentId}}/keys
+      path: /fme/api/v4/segment-definitions/{{ctx.parentId}}/keys
       items_expr: it.data
       item_item_expr: it
       get_id_expr: "-"
@@ -820,6 +840,7 @@ commands:
     noun_variant: definition_keys_add
     short: "Add (or replace) targeting keys in a segment definition: harness execute segment:definition_keys_add <segment-name> --env <env-id> --keys k1,k2 [--replace]"
     handler_type: endpoint
+    fields_noun: segment_definition_keys
     flags:
       - name: env
         description: Environment identifier (required)
@@ -836,7 +857,7 @@ commands:
         description: Audit change title
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}/keys
+      path: /fme/api/v4/segment-definitions/{{ctx.id}}/keys
       query_params:
         account_id: auth.account
         organization_identifier: auth.org
@@ -856,6 +877,7 @@ commands:
     noun_variant: definition_keys_remove
     short: "Remove targeting keys from a segment definition: harness execute segment:definition_keys_remove <segment-name> --env <env-id> --keys k1,k2"
     handler_type: endpoint
+    fields_noun: segment_definition_keys
     flags:
       - name: env
         description: Environment identifier (required)
@@ -870,7 +892,7 @@ commands:
         description: Audit change title
     endpoint:
       method: POST
-      path: /fme/internal/api/v4/segment-definitions/{{ctx.id}}/keys/remove
+      path: /fme/api/v4/segment-definitions/{{ctx.id}}/keys/remove
       query_params:
         account_id: auth.account
         organization_identifier: auth.org

--- a/pkg/spec/fme.spec.yaml
+++ b/pkg/spec/fme.spec.yaml
@@ -338,7 +338,7 @@ commands:
     verb: update
     noun: feature_flag
     noun_variant: definition
-    short: "Update a flag definition: harness update ff:definition <name> --env <env-id> --set trafficAllocation=80"
+    short: "Update a flag definition: harness update ff:definition <name> --env <env-id> --set traffic_allocation=80"
     handler_type: endpoint
     fields_noun: feature_flag_definition
     flags:
@@ -555,7 +555,7 @@ commands:
     verb: delete
     noun: fme_environment
     confirm_mode: prompt
-    short: Delete (archive) an FME environment
+    short: "Delete (archive) an FME environment. Fails with hasDependents until env API tokens and other dependents are removed."
     handler_type: endpoint
     endpoint:
       method: DELETE

--- a/pkg/specloader/fme_spec_test.go
+++ b/pkg/specloader/fme_spec_test.go
@@ -74,7 +74,7 @@ func fmeReadOut(t *testing.T, ctx *cmdctx.Ctx) string {
 
 // TestFMESpec_ListFeatureFlag drives the real embedded fme.spec.yaml "list feature_flag"
 // command against a mock server returning the flat (no "entity" wrapper) shape that the
-// live FME v4 API returns, and asserts the request hits /fme/internal/api/v4/feature-flags
+// live FME v4 API returns, and asserts the request hits /fme/api/v4/feature-flags
 // and that fields resolve directly off the item (it.name, it.trafficType.name, ...).
 func TestFMESpec_ListFeatureFlag(t *testing.T) {
 	reg := registry.New()
@@ -98,8 +98,8 @@ func TestFMESpec_ListFeatureFlag(t *testing.T) {
 		t.Fatalf("RunListEndpoint: %v", err)
 	}
 
-	if !strings.HasPrefix(*path, "/fme/internal/api/v4/feature-flags") {
-		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/feature-flags", *path)
+	if !strings.HasPrefix(*path, "/fme/api/v4/feature-flags") {
+		t.Fatalf("request path = %q, want prefix /fme/api/v4/feature-flags", *path)
 	}
 
 	body := fmeReadOut(t, ctx)
@@ -136,8 +136,8 @@ func TestFMESpec_GetFeatureFlag(t *testing.T) {
 		t.Fatalf("RunEndpoint: %v", err)
 	}
 
-	if *path != "/fme/internal/api/v4/feature-flags/my-flag" {
-		t.Fatalf("request path = %q, want /fme/internal/api/v4/feature-flags/my-flag", *path)
+	if *path != "/fme/api/v4/feature-flags/my-flag" {
+		t.Fatalf("request path = %q, want /fme/api/v4/feature-flags/my-flag", *path)
 	}
 
 	body := fmeReadOut(t, ctx)
@@ -152,7 +152,7 @@ func TestFMESpec_GetFeatureFlag(t *testing.T) {
 }
 
 // TestFMESpec_ListFMEEnvironment drives "list fme_environment" and asserts it
-// hits /fme/internal/api/v4/environments and that get_id_expr resolves off
+// hits /fme/api/v4/environments and that get_id_expr resolves off
 // it.id (environments are addressed by UUID, not name, unlike segment/feature_flag).
 func TestFMESpec_ListFMEEnvironment(t *testing.T) {
 	reg := registry.New()
@@ -176,8 +176,8 @@ func TestFMESpec_ListFMEEnvironment(t *testing.T) {
 		t.Fatalf("RunListEndpoint: %v", err)
 	}
 
-	if !strings.HasPrefix(*path, "/fme/internal/api/v4/environments") {
-		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/environments", *path)
+	if !strings.HasPrefix(*path, "/fme/api/v4/environments") {
+		t.Fatalf("request path = %q, want prefix /fme/api/v4/environments", *path)
 	}
 
 	body := fmeReadOut(t, ctx)
@@ -213,8 +213,8 @@ func TestFMESpec_GetFMEEnvironment(t *testing.T) {
 		t.Fatalf("RunEndpoint: %v", err)
 	}
 
-	if *path != "/fme/internal/api/v4/environments/env-uuid-1" {
-		t.Fatalf("request path = %q, want /fme/internal/api/v4/environments/env-uuid-1", *path)
+	if *path != "/fme/api/v4/environments/env-uuid-1" {
+		t.Fatalf("request path = %q, want /fme/api/v4/environments/env-uuid-1", *path)
 	}
 }
 
@@ -242,8 +242,8 @@ func TestFMESpec_ListSegment(t *testing.T) {
 		t.Fatalf("RunListEndpoint: %v", err)
 	}
 
-	if !strings.HasPrefix(*path, "/fme/internal/api/v4/segments") {
-		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/segments", *path)
+	if !strings.HasPrefix(*path, "/fme/api/v4/segments") {
+		t.Fatalf("request path = %q, want prefix /fme/api/v4/segments", *path)
 	}
 
 	body := fmeReadOut(t, ctx)
@@ -280,8 +280,8 @@ func TestFMESpec_ListSegmentDefinition(t *testing.T) {
 		t.Fatalf("RunListEndpoint: %v", err)
 	}
 
-	if !strings.HasPrefix(*path, "/fme/internal/api/v4/segment-definitions") {
-		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/segment-definitions", *path)
+	if !strings.HasPrefix(*path, "/fme/api/v4/segment-definitions") {
+		t.Fatalf("request path = %q, want prefix /fme/api/v4/segment-definitions", *path)
 	}
 	if !strings.Contains(*query, "environment_id=env-uuid-1") {
 		t.Fatalf("query = %q, want environment_id=env-uuid-1 (from --env flag)", *query)
@@ -323,8 +323,8 @@ func TestFMESpec_ListSegmentDefinitionKeys(t *testing.T) {
 		t.Fatalf("RunListEndpoint: %v", err)
 	}
 
-	if *path != "/fme/internal/api/v4/segment-definitions/my-segment/keys" {
-		t.Fatalf("request path = %q, want /fme/internal/api/v4/segment-definitions/my-segment/keys", *path)
+	if *path != "/fme/api/v4/segment-definitions/my-segment/keys" {
+		t.Fatalf("request path = %q, want /fme/api/v4/segment-definitions/my-segment/keys", *path)
 	}
 	if !strings.Contains(*query, "environment_id=env-uuid-1") {
 		t.Fatalf("query = %q, want environment_id=env-uuid-1 (from --env flag)", *query)

--- a/pkg/specloader/fme_spec_test.go
+++ b/pkg/specloader/fme_spec_test.go
@@ -32,6 +32,21 @@ func fmeCaptureServer(t *testing.T, resp string) (*httptest.Server, *string) {
 	return srv, &path
 }
 
+// fmeCaptureServerWithQuery is like fmeCaptureServer but also records the raw
+// query string, for asserting flag-to-query-param wiring (e.g. --env → environment_id).
+func fmeCaptureServerWithQuery(t *testing.T, resp string) (*httptest.Server, *string, *string) {
+	t.Helper()
+	path, query := "", ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		query = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &path, &query
+}
+
 func fmeTestCtx(t *testing.T, apiURL string) *cmdctx.Ctx {
 	t.Helper()
 	return &cmdctx.Ctx{
@@ -133,5 +148,192 @@ func TestFMESpec_GetFeatureFlag(t *testing.T) {
 	}
 	if strings.Contains(body, "entity") {
 		t.Fatalf("output still references entity wrapper: %s", body)
+	}
+}
+
+// TestFMESpec_ListFMEEnvironment drives "list fme_environment" and asserts it
+// hits /fme/internal/api/v4/environments and that get_id_expr resolves off
+// it.id (environments are addressed by UUID, not name, unlike segment/feature_flag).
+func TestFMESpec_ListFMEEnvironment(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("list", "fme_environment")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("list fme_environment: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"data":[{"id":"env-uuid-1","name":"Prod","isProduction":true,"status":"ACTIVE"}],"limit":100,"offset":0,"totalCount":1}`
+	srv, path := fmeCaptureServer(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Noun = "fme_environment"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "json"
+
+	if err := registry.RunListEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunListEndpoint: %v", err)
+	}
+
+	if !strings.HasPrefix(*path, "/fme/internal/api/v4/environments") {
+		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/environments", *path)
+	}
+
+	body := fmeReadOut(t, ctx)
+	for _, want := range []string{"Prod", "true", "ACTIVE"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("output missing %q: %s", want, body)
+		}
+	}
+}
+
+// TestFMESpec_GetFMEEnvironment drives "get fme_environment" with a UUID id
+// and asserts the path embeds it (environments are looked up by id, not name).
+func TestFMESpec_GetFMEEnvironment(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("get", "fme_environment")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("get fme_environment: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"id":"env-uuid-1","name":"Prod","isProduction":true,"status":"ACTIVE"}`
+	srv, path := fmeCaptureServer(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Id = "env-uuid-1"
+	ctx.Noun = "fme_environment"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "yaml"
+
+	if _, err := registry.RunEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunEndpoint: %v", err)
+	}
+
+	if *path != "/fme/internal/api/v4/environments/env-uuid-1" {
+		t.Fatalf("request path = %q, want /fme/internal/api/v4/environments/env-uuid-1", *path)
+	}
+}
+
+// TestFMESpec_ListSegment drives "list segment" and asserts get_id_expr
+// resolves off it.name (segments, unlike fme_environment, are addressed by name).
+func TestFMESpec_ListSegment(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("list", "segment")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("list segment: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"data":[{"name":"my-segment","description":"desc","trafficType":{"name":"user"},"status":"ACTIVE","createdAt":1778049995.725}],"limit":100,"offset":0,"totalCount":1}`
+	srv, path := fmeCaptureServer(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Noun = "segment"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "json"
+
+	if err := registry.RunListEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunListEndpoint: %v", err)
+	}
+
+	if !strings.HasPrefix(*path, "/fme/internal/api/v4/segments") {
+		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/segments", *path)
+	}
+
+	body := fmeReadOut(t, ctx)
+	for _, want := range []string{"my-segment", "user", "ACTIVE"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("output missing %q: %s", want, body)
+		}
+	}
+}
+
+// TestFMESpec_ListSegmentDefinition drives "list segment:definition" and asserts
+// the --env flag maps to the environment_id query param and fields_extra resolves
+// (segment/environment names, description, status) off the flat item.
+func TestFMESpec_ListSegmentDefinition(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("list", "segment:definition")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("list segment:definition: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"data":[{"segment":{"name":"my-segment"},"environment":{"name":"Prod"},"description":"desc","status":"ACTIVE","createdAt":1778049995.725}],"limit":100,"offset":0,"totalCount":1}`
+	srv, path, query := fmeCaptureServerWithQuery(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Noun = "segment"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "json"
+	ctx.FlagValues = map[string]any{"env": "env-uuid-1"}
+
+	if err := registry.RunListEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunListEndpoint: %v", err)
+	}
+
+	if !strings.HasPrefix(*path, "/fme/internal/api/v4/segment-definitions") {
+		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/segment-definitions", *path)
+	}
+	if !strings.Contains(*query, "environment_id=env-uuid-1") {
+		t.Fatalf("query = %q, want environment_id=env-uuid-1 (from --env flag)", *query)
+	}
+
+	body := fmeReadOut(t, ctx)
+	for _, want := range []string{"my-segment", "Prod", "desc", "ACTIVE"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("output missing %q: %s", want, body)
+		}
+	}
+}
+
+// TestFMESpec_ListSegmentDefinitionKeys drives "list segment:definition_keys" and
+// asserts the fields_noun override (segment_definition_keys) renders raw string
+// items directly (it.key = it), not object fields, and the parent id is embedded
+// in the path.
+func TestFMESpec_ListSegmentDefinitionKeys(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("list", "segment:definition_keys")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("list segment:definition_keys: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"data":["key-one","key-two"],"limit":100,"offset":0,"totalCount":2}`
+	srv, path, query := fmeCaptureServerWithQuery(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Noun = "segment"
+	ctx.ParentId = "my-segment"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "json"
+	ctx.FlagValues = map[string]any{"env": "env-uuid-1"}
+
+	if err := registry.RunListEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunListEndpoint: %v", err)
+	}
+
+	if *path != "/fme/internal/api/v4/segment-definitions/my-segment/keys" {
+		t.Fatalf("request path = %q, want /fme/internal/api/v4/segment-definitions/my-segment/keys", *path)
+	}
+	if !strings.Contains(*query, "environment_id=env-uuid-1") {
+		t.Fatalf("query = %q, want environment_id=env-uuid-1 (from --env flag)", *query)
+	}
+
+	body := fmeReadOut(t, ctx)
+	for _, want := range []string{"key-one", "key-two"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("output missing %q (fields_noun override did not resolve raw string item): %s", want, body)
+		}
 	}
 }

--- a/pkg/specloader/fme_spec_test.go
+++ b/pkg/specloader/fme_spec_test.go
@@ -337,3 +337,34 @@ func TestFMESpec_ListSegmentDefinitionKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestFMESpec_UpdateFeatureFlagDefinition_MutableTrafficAllocation asserts
+// fields_noun feature_flag_definition exposes traffic_allocation as mutable
+// (Deepak's #111 follow-up) and the path is the public /fme/api/v4 prefix.
+func TestFMESpec_UpdateFeatureFlagDefinition_MutableTrafficAllocation(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("update", "feature_flag:definition")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("update feature_flag:definition: command not found")
+	}
+	if cs.FieldsNoun != "feature_flag_definition" {
+		t.Fatalf("fields_noun = %q, want feature_flag_definition", cs.FieldsNoun)
+	}
+	got := registry.MutableFields(reg.GetNoun(cs.FieldsNoun), cs.Endpoint.FieldsExtra)
+	found := false
+	for _, f := range got {
+		if f.ID == "traffic_allocation" && f.MutablePath == "trafficAllocation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("MutableFields = %v, want traffic_allocation → trafficAllocation", got)
+	}
+	if !strings.HasPrefix(cs.Endpoint.Path, "/fme/api/v4/") {
+		t.Fatalf("update path = %q, want public /fme/api/v4/ prefix", cs.Endpoint.Path)
+	}
+}

--- a/pkg/specloader/fme_spec_test.go
+++ b/pkg/specloader/fme_spec_test.go
@@ -1,0 +1,137 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package specloader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harness/cli/pkg/auth"
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/registry"
+)
+
+// fmeCaptureServer returns a mock server that records the inbound request path
+// and always replies with resp, plus the *cmdctx.Ctx wired to call it.
+func fmeCaptureServer(t *testing.T, resp string) (*httptest.Server, *string) {
+	t.Helper()
+	path := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &path
+}
+
+func fmeTestCtx(t *testing.T, apiURL string) *cmdctx.Ctx {
+	t.Helper()
+	return &cmdctx.Ctx{
+		Context: context.Background(),
+		Auth: &auth.ResolvedAuth{
+			APIUrl:    apiURL,
+			AccountID: "acct",
+			OrgID:     "org",
+			ProjectID: "proj",
+			PATToken:  "pat.test",
+			AuthType:  auth.AuthTypePAT,
+		},
+		FormatFlags: cmdctx.FormatFlags{OutFile: filepath.Join(t.TempDir(), "out")},
+	}
+}
+
+func fmeReadOut(t *testing.T, ctx *cmdctx.Ctx) string {
+	t.Helper()
+	b, err := os.ReadFile(ctx.FormatFlags.OutFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	return string(b)
+}
+
+// TestFMESpec_ListFeatureFlag drives the real embedded fme.spec.yaml "list feature_flag"
+// command against a mock server returning the flat (no "entity" wrapper) shape that the
+// live FME v4 API returns, and asserts the request hits /fme/internal/api/v4/feature-flags
+// and that fields resolve directly off the item (it.name, it.trafficType.name, ...).
+func TestFMESpec_ListFeatureFlag(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("list", "feature_flag")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("list feature_flag: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"data":[{"name":"my-flag","description":"desc","trafficType":{"name":"user"},"status":"ACTIVE","rolloutStatus":{"name":"Ramp"},"createdAt":"2026-01-01T00:00:00Z"}],"limit":20,"offset":0,"totalCount":1}`
+	srv, path := fmeCaptureServer(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Noun = "feature_flag"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "json"
+
+	if err := registry.RunListEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunListEndpoint: %v", err)
+	}
+
+	if !strings.HasPrefix(*path, "/fme/internal/api/v4/feature-flags") {
+		t.Fatalf("request path = %q, want prefix /fme/internal/api/v4/feature-flags", *path)
+	}
+
+	body := fmeReadOut(t, ctx)
+	for _, want := range []string{"my-flag", "user", "ACTIVE", "Ramp"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("output missing %q (flat field did not resolve): %s", want, body)
+		}
+	}
+}
+
+// TestFMESpec_GetFeatureFlag drives the real embedded fme.spec.yaml "get feature_flag"
+// command against a mock server returning a flat object, and asserts the request path
+// and that yaml_pick_expr/item_expr resolve the item directly (it, not it.entity).
+func TestFMESpec_GetFeatureFlag(t *testing.T) {
+	reg := registry.New()
+	if err := LoadSpec(reg, "fme.spec.yaml", true); err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	cs := reg.GetSpec("get", "feature_flag")
+	if cs == nil || cs.Endpoint == nil {
+		t.Fatal("get feature_flag: command not found or missing endpoint spec")
+	}
+
+	fixture := `{"name":"my-flag","description":"desc","trafficType":{"name":"user"},"status":"ACTIVE","rolloutStatus":{"name":"Ramp"},"createdAt":"2026-01-01T00:00:00Z"}`
+	srv, path := fmeCaptureServer(t, fixture)
+
+	ctx := fmeTestCtx(t, srv.URL)
+	ctx.Id = "my-flag"
+	ctx.Noun = "feature_flag"
+	ctx.Resolver = reg
+	ctx.FormatFlags.Format = "yaml"
+
+	if _, err := registry.RunEndpoint(ctx, cs.Endpoint); err != nil {
+		t.Fatalf("RunEndpoint: %v", err)
+	}
+
+	if *path != "/fme/internal/api/v4/feature-flags/my-flag" {
+		t.Fatalf("request path = %q, want /fme/internal/api/v4/feature-flags/my-flag", *path)
+	}
+
+	body := fmeReadOut(t, ctx)
+	for _, want := range []string{"name: my-flag", "status: ACTIVE"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("output missing %q (yaml_pick_expr did not resolve flat item): %s", want, body)
+		}
+	}
+	if strings.Contains(body, "entity") {
+		t.Fatalf("output still references entity wrapper: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary
Rebased onto Deepak's latest https://github.com/harness/cli/pull/111 (`a922091`: public `/fme/api/v4` paths, `fields_noun` for definitions, required-array flags, `--set traffic_allocation`).

**This PR adds only what #111 does not:**
- Parse RFC 7807 `detail` in API errors so env delete `hasDependents` shows token IDs.
- `MutableFields` includes command `fields_extra` (engine), not only noun fields.
- Help text on `delete fme_environment` for API-token dependents.

## Test plan
- [x] `go test ./pkg/client/ ./pkg/registry/ ./pkg/specloader/`
- [x] Rebased onto `pull/111/head`; no duplicate `/internal/` path rewrite