### PR TITLE
Fix[IAC-8072]: workspace id is required, removed no_id:true

### DIFF
--- a/pkg/registry/buildctx.go
+++ b/pkg/registry/buildctx.go
@@ -175,7 +175,7 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 		if len(args) > 0 {
 			ctx.Id = args[0]
 		}
-	} else if vspec.AllowsId {
+	} else if vspec.AllowsId || cs.AllowsId {
 		if cs.RequiresId && len(args) == 0 && !skipIdCheck {
 			return nil, fmt.Errorf("%s %s requires a positional %s argument%s", cs.Verb, cs.Noun, idLabel, cs.UsageLine())
 		}

--- a/pkg/registry/buildctx_workflow_test.go
+++ b/pkg/registry/buildctx_workflow_test.go
@@ -141,6 +141,36 @@ func TestBuildCtx_WorkflowMissingRequiredID(t *testing.T) {
 	}
 }
 
+func TestBuildCtx_ExecuteNoIdAllowsIdOptional(t *testing.T) {
+	// RequiresId verb (execute) with NoId+AllowsId: omitting the id is fine, ctx.Id stays empty.
+	r := New()
+	registerWorkflowExecute(t, r, "noidallows", &spec.CommandSpec{NoId: true, AllowsId: true})
+	cs := r.GetSpec(VerbExecute, "noidallows")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	ctx, err := buildCtx(cmd, cs, nil, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Id != "" {
+		t.Fatalf("ctx.Id = %q, want empty", ctx.Id)
+	}
+}
+
+func TestBuildCtx_ExecuteNoIdAllowsIdPopulated(t *testing.T) {
+	// RequiresId verb (execute) with NoId+AllowsId: passing a positional id still populates ctx.Id.
+	r := New()
+	registerWorkflowExecute(t, r, "noidallows2", &spec.CommandSpec{NoId: true, AllowsId: true})
+	cs := r.GetSpec(VerbExecute, "noidallows2")
+	cmd := buildWorkflowTestCmd(t, r, cs)
+	ctx, err := buildCtx(cmd, cs, []string{"foo"}, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Id != "foo" {
+		t.Fatalf("ctx.Id = %q, want %q", ctx.Id, "foo")
+	}
+}
+
 func TestBuildCtx_WorkflowRequiredFlag(t *testing.T) {
 	r := New()
 	registerWorkflowExecute(t, r, "reqflag", &spec.CommandSpec{

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -749,7 +749,7 @@ func buildUseString(cs *spec.CommandSpec, vspec VerbSpec) string {
 		if cs.HasArgs && cs.ArgsLabel != "" {
 			use += " " + cs.ArgsLabel
 		}
-	} else if vspec.AllowsId {
+	} else if vspec.AllowsId || cs.AllowsId {
 		idLabel := "id"
 		if cs.IdLabel != "" {
 			idLabel = cs.IdLabel
@@ -811,7 +811,7 @@ func (r *Registry) buildAliasCmd(cs *spec.CommandSpec, aliasNoun string) *cobra.
 		if cs.HasArgs && cs.ArgsLabel != "" {
 			use += " " + cs.ArgsLabel
 		}
-	} else if vspec.AllowsId {
+	} else if vspec.AllowsId || cs.AllowsId {
 		idLabel := "id"
 		if cs.IdLabel != "" {
 			idLabel = cs.IdLabel

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -615,6 +615,12 @@ func TestBuildUseString(t *testing.T) {
 			wantContain: "[id]",
 		},
 		{
+			name:        "no_id_with_command_allows_id_optional_bracket",
+			cs:          &spec.CommandSpec{Verb: VerbExecute, Noun: "workspace", NoId: true, AllowsId: true},
+			vs:          verbRegistry[VerbExecute],
+			wantContain: "[id]",
+		},
+		{
 			name:        "allows_parentid_optional",
 			cs:          &spec.CommandSpec{Verb: VerbList, Noun: "stage"},
 			vs:          verbRegistry[VerbList],

--- a/pkg/spec/iacm.spec.yaml
+++ b/pkg/spec/iacm.spec.yaml
@@ -224,7 +224,6 @@ commands:
         harness execute workspace --target aws_instance.web # limit plan to one resource
         harness execute workspace --force                   # skip confirmation prompt
     id_label: "<workspace-id>"
-    no_id: true
     completion_noun: workspace
     handler_type: workflow
     workflow_id: execute_workspace

--- a/pkg/spec/iacm.spec.yaml
+++ b/pkg/spec/iacm.spec.yaml
@@ -224,6 +224,8 @@ commands:
         harness execute workspace --target aws_instance.web # limit plan to one resource
         harness execute workspace --force                   # skip confirmation prompt
     id_label: "<workspace-id>"
+    no_id: true
+    allows_id: true
     completion_noun: workspace
     handler_type: workflow
     workflow_id: execute_workspace

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -444,6 +444,7 @@ type CommandSpec struct {
 	Long             string              `yaml:"long,omitempty"`
 	RequiresId       bool                `yaml:"requires_id,omitempty"`       // positional [id] is mandatory for this command
 	NoId             bool                `yaml:"no_id,omitempty"`             // opt out of the verb's default RequiresId (e.g. singleton get commands)
+	AllowsId         bool                `yaml:"allows_id,omitempty"`         // when set (with no_id), still populate ctx.Id if a positional arg is given
 	IdLabel          string              `yaml:"id_label,omitempty"`          // overrides "<id>" in the Usage line (e.g. "<registry/path>")
 	ArgsLabel        string              `yaml:"args_label,omitempty"`        // appended to Usage after the id label (e.g. "<local-file>"); only used when has_args is true
 	IdParts          int                 `yaml:"id_parts,omitempty"`          // when > 1, id must contain exactly (id_parts-1) "/" separators; parts available as {ctx:id_part:0}, {ctx:id_part:1}, ...


### PR DESCRIPTION
This PR fix the command:
`harness execute workspace <workspace_id>`
workspace_id is required but no_id:true makes the ctx.id empty while command execution.
remove no_id:true and tested the command, it is working fine now.