### PR TITLE
Separate embedded plugin specs from builtin specs at enumeration

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"slices"
 	"strings"
 )
 
@@ -17,10 +18,25 @@ var ModuleOrder = []string{"core", "platform", "pipeline", "cd", "fme"}
 //go:embed *.spec.yaml
 var specsFS embed.FS
 
-// Files returns the names of all embedded *.spec.yaml files.
+// pluginSpecFiles lists embedded specs for modules that ship as separate plugin
+// binaries. The host never registers these as builtins — it only records their
+// noun ownership so a noun belonging to an uninstalled plugin produces a useful
+// error. A spec declaring module_type: plugin must appear here; the partition is
+// enforced by TestEmbeddedSpecPartition in pkg/specloader.
+var pluginSpecFiles = []string{"har.spec.yaml"}
+
+// Files returns the names of all embedded builtin *.spec.yaml files (everything
+// except pluginSpecFiles).
 func Files() []string {
 	entries, _ := fs.Glob(specsFS, "*.spec.yaml")
-	return entries
+	return slices.DeleteFunc(entries, func(name string) bool {
+		return slices.Contains(pluginSpecFiles, name)
+	})
+}
+
+// PluginFiles returns the names of embedded specs for plugin modules.
+func PluginFiles() []string {
+	return slices.Clone(pluginSpecFiles)
 }
 
 // Read returns the raw contents of a named spec file.

--- a/pkg/specloader/specloader.go
+++ b/pkg/specloader/specloader.go
@@ -65,12 +65,12 @@ func specParseError(name string, data []byte, parseErr error) error {
 // win: a home spec whose module name is already registered is skipped with a
 // warning.
 //
-// Embedded specs that declare module_type: plugin (e.g. har) are not registered
-// as builtins here — they are plugins, not builtins, and reach the host only
+// Embedded specs for plugin modules (spec.PluginFiles(), e.g. har) are not
+// registered here — they are plugins, not builtins, and reach the host only
 // through the home spec dir (with a binary_path to dispatch to). This lets a
 // dev-installed plugin spec in ~/.harness/spec drive the real dynamic path
-// instead of being masked by an embedded copy. loadSpecData still records their
-// noun ownership (best-effort, for "plugin not installed" error messages).
+// instead of being masked by an embedded copy. Only their noun ownership is
+// recorded (best-effort, for "plugin not installed" error messages).
 func LoadSpecs(reg *registry.Registry) error {
 	isHarnessUser := os.Getenv("HARNESS_ENABLE_BETA_MODULES") == "1" ||
 		config.AnyProfileMatchesDomain("harness.io")
@@ -83,7 +83,31 @@ func LoadSpecs(reg *registry.Registry) error {
 			return err
 		}
 	}
+	for _, name := range spec.PluginFiles() {
+		data, err := spec.Read(name)
+		if err != nil {
+			return fmt.Errorf("spec: read %s: %w", name, err)
+		}
+		if err := recordPluginNouns(reg, name, data, isHarnessUser); err != nil {
+			return err
+		}
+	}
 	return LoadHomeSpecs(reg, isHarnessUser)
+}
+
+// recordPluginNouns records which nouns an embedded plugin spec owns, without
+// registering any of its commands. A harness_internal plugin spec records
+// nothing for non-Harness users, matching how builtin specs are gated.
+func recordPluginNouns(reg *registry.Registry, name string, data []byte, isHarnessUser bool) error {
+	f, err := parseSpecFile(reg, name, data)
+	if err != nil {
+		return err
+	}
+	if f.HarnessInternal && !isHarnessUser {
+		return nil
+	}
+	reg.RecordPluginOwnedNouns(moduleNameFromFile(name), f.Nouns)
+	return nil
 }
 
 // LoadHomeSpecs loads plugin spec files from ~/.harness/spec (the sole source
@@ -189,6 +213,27 @@ func LoadSpecBytes(reg *registry.Registry, name string, data []byte, isHarnessUs
 	return data, nil
 }
 
+// parseSpecFile unmarshals spec bytes and checks the spec version. name is used
+// only for error messages.
+func parseSpecFile(reg *registry.Registry, name string, data []byte) (*specFile, error) {
+	var f specFile
+	if reg.StrictYAML {
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(&f); err != nil {
+			return nil, specParseError(name, data, err)
+		}
+	} else {
+		if err := yaml.Unmarshal(data, &f); err != nil {
+			return nil, specParseError(name, data, err)
+		}
+	}
+	if f.SpecVersion < MinSpecVersion || f.SpecVersion > MaxSpecVersion {
+		return nil, fmt.Errorf("spec: %s: spec_version %d out of supported range [%d, %d]", name, f.SpecVersion, MinSpecVersion, MaxSpecVersion)
+	}
+	return &f, nil
+}
+
 // loadSpecData parses spec bytes and registers the module, nouns, and commands.
 // name is used only for module-name derivation and error messages; the bytes
 // may come from the embedded FS or from a ~/.harness/spec file.
@@ -204,27 +249,11 @@ func LoadSpecBytes(reg *registry.Registry, name string, data []byte, isHarnessUs
 // by check:specs, so a duplicate there is a build bug we surface loudly.
 func loadSpecData(reg *registry.Registry, name string, data []byte, isHarnessUser, fromSpecDir bool) error {
 	module := moduleNameFromFile(name)
-	var f specFile
-	if reg.StrictYAML {
-		dec := yaml.NewDecoder(bytes.NewReader(data))
-		dec.KnownFields(true)
-		if err := dec.Decode(&f); err != nil {
-			return specParseError(name, data, err)
-		}
-	} else {
-		if err := yaml.Unmarshal(data, &f); err != nil {
-			return specParseError(name, data, err)
-		}
-	}
-	if f.SpecVersion < MinSpecVersion || f.SpecVersion > MaxSpecVersion {
-		return fmt.Errorf("spec: %s: spec_version %d out of supported range [%d, %d]", name, f.SpecVersion, MinSpecVersion, MaxSpecVersion)
+	f, err := parseSpecFile(reg, name, data)
+	if err != nil {
+		return err
 	}
 	if f.HarnessInternal && !isHarnessUser {
-		return nil
-	}
-	// Embedded plugin specs (e.g. har) aren't builtins; only record noun ownership.
-	if !fromSpecDir && f.ModuleType == "plugin" {
-		reg.RecordPluginOwnedNouns(module, f.Nouns)
 		return nil
 	}
 	if fromSpecDir {

--- a/pkg/specloader/specloader_test.go
+++ b/pkg/specloader/specloader_test.go
@@ -24,6 +24,41 @@ func TestLoadAllEmbeddedSpecs(t *testing.T) {
 	}
 }
 
+// TestEmbeddedSpecPartition verifies that spec.Files() and spec.PluginFiles()
+// partition the embedded specs by module_type. A plugin spec that leaks into
+// Files() would be registered as a builtin, masking the installed plugin's
+// binary_path; a builtin spec listed in PluginFiles() would never register at
+// all.
+func TestEmbeddedSpecPartition(t *testing.T) {
+	check := func(name string, wantPlugin bool) {
+		data, err := spec.Read(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		var f specFile
+		if err := yaml.Unmarshal(data, &f); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		if gotPlugin := f.ModuleType == "plugin"; gotPlugin != wantPlugin {
+			if wantPlugin {
+				t.Errorf("%s is in spec.PluginFiles() but declares module_type: %q — remove it from pluginSpecFiles", name, f.ModuleType)
+			} else {
+				t.Errorf("%s declares module_type: plugin but is not in spec.PluginFiles() — add it to pluginSpecFiles in pkg/spec/spec.go", name)
+			}
+		}
+	}
+	for _, name := range spec.Files() {
+		check(name, false)
+	}
+	plugins := spec.PluginFiles()
+	if len(plugins) == 0 {
+		t.Fatal("spec.PluginFiles() is empty — expected at least har.spec.yaml")
+	}
+	for _, name := range plugins {
+		check(name, true)
+	}
+}
+
 // TestDuplicateNoun ensures that loading two specs that declare the same noun
 // produces a clear error rather than a silent override.
 func TestDuplicateNoun(t *testing.T) {


### PR DESCRIPTION
spec.Files() now returns only builtin specs; spec.PluginFiles() returns the embedded plugin specs (har). LoadSpecs registers the former and records only noun ownership for the latter, replacing the module_type check inside loadSpecData — so a plugin binary loading its own spec registers normally.

Adds a test asserting the two lists partition the embedded specs by module_type.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

AI-Session-Id: 28a7e429-75d4-4581-884e-22900deccaa0
AI-Tool: claude-code
AI-Model: unknown