### PR TITLE
allow overriding of id_label for migrate commands

### DIFF
--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -296,8 +296,11 @@ neither owns the positional slot. Taking no positional is not an exception — `
 active profile.
 
 A spec entry controls each flag's registration and label via `migrate_from`/`migrate_to` blocks
-(`presence: required|optional|none`, `label: "..."`). `presence: none` drops the flag entirely —
-use it when one side of the pair is fixed and has no id to take, not a boolean toggle on the verb.
+(`presence: required|optional|none`, `label: "..."`, `id_label: "<...>"`). `presence: none` drops the
+flag entirely — use it when one side of the pair is fixed and has no id to take, not a boolean toggle
+on the verb; `label` is the `--help` text and `id_label` is the value placeholder shown in usage lines
+(defaults to `<id>`). `get noun <x>` renders each flag from these: `--from <label>` when required,
+`[--from <label>]` when optional, omitted when `none`.
 A command must declare `handler_type: workflow` and `noun_to` (not `noun_variant`); this is
 enforced by `validateNounPairConstraints` in `pkg/registry/checks.go`.
 

--- a/modules/core/mgmt/nouns_verbs.go
+++ b/modules/core/mgmt/nouns_verbs.go
@@ -149,7 +149,7 @@ func GetNounHandler(ctx *cmdctx.Ctx) error {
 		usage := "harness " + cs.Verb + " " + cs.FullNoun()
 		switch {
 		case cs.NounTo != "":
-			usage += " --from <id> --to <id>"
+			usage += cs.MigrateFrom.UsageFragment("from") + cs.MigrateTo.UsageFragment("to")
 		case cs.RequiresParentId && cs.ParentIdLabel != "":
 			usage += " " + cs.ParentIdLabel
 		case cs.IdLabel != "":

--- a/pkg/registry/checks.go
+++ b/pkg/registry/checks.go
@@ -203,7 +203,11 @@ func validateNounPairConstraints(cs *spec.CommandSpec, vs VerbSpec) error {
 		spec *spec.MigrateFlag
 	}{{"migrate_from", cs.MigrateFrom}, {"migrate_to", cs.MigrateTo}} {
 		switch mf.spec.EffectivePresence() {
-		case spec.MigratePresenceRequired, spec.MigratePresenceOptional, spec.MigratePresenceNone:
+		case spec.MigratePresenceRequired, spec.MigratePresenceOptional:
+		case spec.MigratePresenceNone:
+			if mf.spec.Label != "" || mf.spec.IdLabel != "" {
+				return fmt.Errorf("command %q: %s declares label/id_label with presence: none (the flag is not registered)", cs.Command, mf.name)
+			}
 		default:
 			return fmt.Errorf("command %q: %s presence %q must be one of required, optional, none", cs.Command, mf.name, mf.spec.Presence)
 		}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -680,6 +680,10 @@ func buildUseString(cs *spec.CommandSpec, vspec VerbSpec) string {
 	if cs.Noun != "" {
 		use = cs.FullNoun()
 	}
+	// pair verbs take no positional: both endpoints are named by --from/--to
+	if vspec.NounPair {
+		return use + cs.MigrateFrom.UsageFragment("from") + cs.MigrateTo.UsageFragment("to")
+	}
 	if vspec.RequiresId && !cs.NoId {
 		idLabel := "<id>"
 		if cs.IdLabel != "" {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -101,6 +101,9 @@ const (
 type MigrateFlag struct {
 	// Label overrides the flag's --help text (e.g. "GitHub organization to migrate").
 	Label string `yaml:"label,omitempty"`
+	// IdLabel overrides the "<id>" value placeholder shown after the flag in usage
+	// lines (e.g. "<bundle-folder-or-zip>", "<folder>").
+	IdLabel string `yaml:"id_label,omitempty"`
 	// Presence controls flag registration. See MigratePresence* consts.
 	Presence string `yaml:"presence,omitempty"`
 }
@@ -120,6 +123,28 @@ func (m *MigrateFlag) EffectiveLabel(fallback string) string {
 		return fallback
 	}
 	return m.Label
+}
+
+// EffectiveIdLabel returns the declared value placeholder, defaulting to "<id>".
+func (m *MigrateFlag) EffectiveIdLabel() string {
+	if m == nil || m.IdLabel == "" {
+		return "<id>"
+	}
+	return m.IdLabel
+}
+
+// UsageFragment renders this flag for a usage line: " --name <label>" when required,
+// " [--name <label>]" when optional, "" when the flag is not registered. name is the
+// flag name ("from" or "to").
+func (m *MigrateFlag) UsageFragment(name string) string {
+	switch m.EffectivePresence() {
+	case MigratePresenceNone:
+		return ""
+	case MigratePresenceRequired:
+		return " --" + name + " " + m.EffectiveIdLabel()
+	default:
+		return " [--" + name + " " + m.EffectiveIdLabel() + "]"
+	}
 }
 
 // BuiltinFlags enables predefined system flags that have fixed registration and dispatch behavior.


### PR DESCRIPTION
makes better usage text and better help text for migrate commands for nouns/help