### PR TITLE
feat: [CHAOS-13003]: address RT module follow-up review items

### DIFF
--- a/modules/rt/apitest_test.go
+++ b/modules/rt/apitest_test.go
@@ -87,11 +87,16 @@ func api(format string, args ...any) string {
 }
 
 func itemsPage(items ...map[string]any) map[string]any {
-	page := make([]any, 0, len(items))
+	return map[string]any{"items": bareList(items...)}
+}
+
+// The shape the revision routes actually answer with: rows, with no page around them.
+func bareList(items ...map[string]any) []any {
+	list := make([]any, 0, len(items))
 	for _, item := range items {
-		page = append(page, item)
+		list = append(list, item)
 	}
-	return map[string]any{"items": page}
+	return list
 }
 
 // The runs-of-a-load-test response; the identity picker reads only the identities.

--- a/modules/rt/rt.go
+++ b/modules/rt/rt.go
@@ -7,6 +7,8 @@
 package rt
 
 import (
+	"strconv"
+
 	"github.com/harness/cli/pkg/cmdctx"
 	"github.com/harness/cli/pkg/registry"
 )
@@ -42,6 +44,27 @@ func scopeParams(ctx *cmdctx.Ctx) map[string]string {
 		qp["projectIdentifier"] = ctx.Auth.ProjectID
 	}
 	return qp
+}
+
+// A hand-built EndpointSpec still has its query_params evaluated as expressions, so the
+// shared scope values are quoted into literal exprs rather than written out a second time.
+func scopeQueryExprs(ctx *cmdctx.Ctx) map[string]string {
+	params := scopeParams(ctx)
+	exprs := make(map[string]string, len(params))
+	for name, value := range params {
+		exprs[name] = strconv.Quote(value)
+	}
+	return exprs
+}
+
+// Collections come back in two shapes: the paged routes wrap their rows in an items
+// envelope, while the revision routes answer with a bare array. Readers take either.
+func itemsOf(resp any) []any {
+	if items, ok := resp.([]any); ok {
+		return items
+	}
+	items, _ := asMap(resp)["items"].([]any)
+	return items
 }
 
 func asMap(v any) map[string]any {

--- a/modules/rt/run.go
+++ b/modules/rt/run.go
@@ -97,8 +97,7 @@ func existingRunIdentities(ctx *cmdctx.Ctx, loadTestID string) map[string]bool {
 	if err != nil {
 		return taken
 	}
-	items, _ := asMap(resp)["items"].([]any)
-	for _, item := range items {
+	for _, item := range itemsOf(resp) {
 		if id := stringField(asMap(item), "identity"); id != "" {
 			taken[id] = true
 		}
@@ -140,7 +139,7 @@ func rerunWorkflow(ctx *cmdctx.Ctx) error {
 		Path:        basePath + "/load-tests/{{ctx.id}}/runs",
 		BodyFn:      "rt:" + startRunBodyFnID,
 		ItemExpr:    "it",
-		QueryParams: scopeQueryExprs,
+		QueryParams: scopeQueryExprs(ctx),
 	}
 	result, err := registry.RunEndpoint(ctx, ep)
 	if err != nil {
@@ -150,9 +149,4 @@ func rerunWorkflow(ctx *cmdctx.Ctx) error {
 		return watchFollowFn(ctx, result)
 	}
 	return nil
-}
-
-var scopeQueryExprs = map[string]string{
-	"organizationIdentifier": `auth.org != "" ? auth.org : nil`,
-	"projectIdentifier":      `auth.project != "" ? auth.project : nil`,
 }

--- a/modules/rt/run_test.go
+++ b/modules/rt/run_test.go
@@ -154,6 +154,12 @@ func TestRerunStartsAFreshRunOfTheSameLoadTest(t *testing.T) {
 	if name, _ := post.body["name"].(string); !strings.Contains(name, "checkout-aaa") {
 		t.Errorf("name = %q, want the run it reruns named", name)
 	}
+	// The rerun spec is hand-built, so its scope has to match what every other call sends.
+	for name, want := range scopeParams(ctx) {
+		if got := post.query.Get(name); got != want {
+			t.Errorf("%s = %q on the rerun, want %q", name, got, want)
+		}
+	}
 	// Callers reuse ctx after a workflow returns.
 	if ctx.Id != "checkout-aaa" {
 		t.Errorf("ctx.Id = %q, want the previous run restored", ctx.Id)
@@ -262,6 +268,50 @@ func TestScopeParams(t *testing.T) {
 
 	if got := scopeParams(&cmdctx.Ctx{}); len(got) != 0 {
 		t.Errorf("got %v, want nothing when there is no auth", got)
+	}
+}
+
+// The rerun endpoint spec is built in Go, so its scope params must come from the same
+// place as every other call's — a param added to one has to appear in the other.
+func TestScopeQueryExprsQuotesTheSameParams(t *testing.T) {
+	ctx := &cmdctx.Ctx{Auth: &auth.ResolvedAuth{
+		AccountID: "acct", OrgID: "eng", ProjectID: "payments",
+	}}
+
+	exprs := scopeQueryExprs(ctx)
+	params := scopeParams(ctx)
+	if len(exprs) != len(params) {
+		t.Fatalf("got %d exprs for %d params: %v vs %v", len(exprs), len(params), exprs, params)
+	}
+	for name, value := range params {
+		if exprs[name] != `"`+value+`"` {
+			t.Errorf("expr for %s = %s, want the value as a quoted literal", name, exprs[name])
+		}
+	}
+
+	if got := scopeQueryExprs(&cmdctx.Ctx{}); len(got) != 0 {
+		t.Errorf("got %v, want nothing when there is no auth", got)
+	}
+}
+
+func TestItemsOfReadsBothShapes(t *testing.T) {
+	row := map[string]any{"identity": "rev-one"}
+
+	page := itemsOf(map[string]any{"items": []any{row}})
+	if len(page) != 1 || asMap(page[0])["identity"] != "rev-one" {
+		t.Errorf("got %v, want the row out of the page envelope", page)
+	}
+
+	bare := itemsOf([]any{row})
+	if len(bare) != 1 || asMap(bare[0])["identity"] != "rev-one" {
+		t.Errorf("got %v, want the row out of the bare array", bare)
+	}
+
+	// A 404 body, an empty page and a null all mean "no rows", not a panic.
+	for _, resp := range []any{nil, map[string]any{"message": "not found"}, map[string]any{}} {
+		if got := itemsOf(resp); len(got) != 0 {
+			t.Errorf("itemsOf(%v) = %v, want no rows", resp, got)
+		}
 	}
 }
 

--- a/modules/rt/script.go
+++ b/modules/rt/script.go
@@ -87,8 +87,7 @@ func resolveScriptRevision(ctx *cmdctx.Ctx, raw string) (string, error) {
 		return "", fmt.Errorf("reading the script revisions of load test %q: %w", ctx.Id, err)
 	}
 
-	items, _ := asMap(resp)["items"].([]any)
-	for _, item := range items {
+	for _, item := range itemsOf(resp) {
 		m := asMap(item)
 		if int(floatField(m, "revisionNumber")) != number {
 			continue

--- a/modules/rt/script_test.go
+++ b/modules/rt/script_test.go
@@ -137,7 +137,7 @@ func TestEncodeScriptBodyMissingFlag(t *testing.T) {
 
 func TestResolveScriptRevisionByNumber(t *testing.T) {
 	ctx, calls := apiCtx(t, map[string]any{
-		api("/load-tests/checkout/script/revisions"): itemsPage(
+		api("/load-tests/checkout/script/revisions"): bareList(
 			map[string]any{"revisionNumber": float64(1), "identity": "rev-one"},
 			map[string]any{"revisionNumber": float64(2), "identity": "rev-two"},
 		),
@@ -158,13 +158,28 @@ func TestResolveScriptRevisionByNumber(t *testing.T) {
 
 func TestResolveScriptRevisionTrimsTheNumber(t *testing.T) {
 	ctx, _ := apiCtx(t, map[string]any{
-		api("/load-tests/checkout/script/revisions"): itemsPage(
+		api("/load-tests/checkout/script/revisions"): bareList(
 			map[string]any{"revisionNumber": float64(2), "identity": "rev-two"},
 		),
 	})
 	ctx.Id = "checkout"
 
 	if got, err := resolveScriptRevision(ctx, " 2 "); err != nil || got != "rev-two" {
+		t.Errorf("got %q, %v; want rev-two", got, err)
+	}
+}
+
+// The revisions route answers with a bare array today, but the paged routes next to it
+// answer with an envelope, so a revision number resolves either way.
+func TestResolveScriptRevisionReadsAPagedResponseToo(t *testing.T) {
+	ctx, _ := apiCtx(t, map[string]any{
+		api("/load-tests/checkout/script/revisions"): itemsPage(
+			map[string]any{"revisionNumber": float64(2), "identity": "rev-two"},
+		),
+	})
+	ctx.Id = "checkout"
+
+	if got, err := resolveScriptRevision(ctx, "2"); err != nil || got != "rev-two" {
 		t.Errorf("got %q, %v; want rev-two", got, err)
 	}
 }
@@ -195,7 +210,7 @@ func TestResolveScriptRevisionNeedsALoadTest(t *testing.T) {
 
 func TestResolveScriptRevisionUnknownNumber(t *testing.T) {
 	ctx, _ := apiCtx(t, map[string]any{
-		api("/load-tests/checkout/script/revisions"): itemsPage(
+		api("/load-tests/checkout/script/revisions"): bareList(
 			map[string]any{"revisionNumber": float64(1), "identity": "rev-one"},
 		),
 	})

--- a/pkg/spec/rt.spec.yaml
+++ b/pkg/spec/rt.spec.yaml
@@ -17,15 +17,16 @@ help_text: |
   the tunables (target users, duration) it accepts. Creating one does not run
   anything.
 
-  `create loadtest <id> --set tool_type=K6 --set infra=<infra> --set
-  environment=<env>` builds the definition from key=value pairs, or pass a
-  whole body with `-f test.yaml`. Use one or the other: when `-f` is given it
-  supplies the entire body and `--set` is ignored. `--set` takes the field IDs
-  listed by `create loadtest --list-fields`, not the API's own spellings.
+  `create loadtest <id> -f test.yaml` creates one from a whole body. Every tool
+  type requires a `toolConfig` block, which key=value pairs cannot express, so
+  `-f` is the path in — `get loadtest <id> --yaml -o test.yaml` on an existing
+  test gives you a body to edit. `--set` is ignored whenever `-f` is present.
 
   Two variants create a load test from something you already have:
-  `create loadtest:from_json <id> -f spec.json` takes a declarative endpoint
-  spec instead of a tool script, and `create loadtest:from_template <id>
+  `create loadtest:from_json <id> -f request.json` takes a declarative endpoint
+  spec instead of a tool script — the file is the whole request body, with the
+  spec under `jsonSpec` alongside `toolType`, `infraIdentifier` and
+  `environmentIdentifier` — and `create loadtest:from_template <id>
   --template <template-id>` instantiates a template. A template-backed test is
   either a REFERENCE (a pointer — the template stays the source of truth) or a
   LOCAL copy. Use `execute loadtest:sync <id>` to re-pull a REFERENCE test
@@ -101,11 +102,11 @@ nouns:
       - id: name
         expr: it.name
         mutable_path: name
-      # Required when creating a load test, and fixed from then on.
+      # No mutable_path: toolType is fixed at create, and create needs a toolConfig
+      # block that --set cannot express, so a load test is created with -f.
       - id: tool_type
         label: Tool
         expr: it.toolType
-        mutable_path: toolType
       - id: environment
         expr: it.environmentIdentifier
         mutable_path: environmentIdentifier
@@ -274,17 +275,16 @@ nouns:
       - id: name
         expr: it.name
         mutable_path: name
-      # Both are required when creating a template, and fixed from then on.
+      # No mutable_path on either: both are fixed at create, and a template is
+      # created with -f for the same reason a load test is.
       - id: revision
         expr: it.revision
-        mutable_path: revision
       - id: hub
         label: Hub
         expr: it.hubIdentity
       - id: tool_type
         label: Tool
         expr: it.toolType
-        mutable_path: toolType
       - id: infra_type
         expr: it.infraType
         mutable_path: infraType
@@ -726,7 +726,7 @@ commands:
     verb: create
     noun: loadtest
     requires_id: true
-    short: "Create a load test: harness create loadtest <id> --set tool_type=K6 --set infra=<infra> --set environment=<env>, or -f test.yaml"
+    short: "Create a load test: harness create loadtest <id> -f test.yaml — the body carries the toolConfig block that --set cannot express"
     flags_builtin:
       set: true
     handler_type: endpoint
@@ -749,7 +749,7 @@ commands:
     noun: loadtest
     noun_variant: from_json
     requires_id: true
-    short: "Create a load test from a JSON endpoint spec: harness create loadtest:from_json <id> -f spec.json --set infra=<infra> --set environment=<env>"
+    short: "Create a load test from a JSON endpoint spec: harness create loadtest:from_json <id> -f request.json — the file is the whole body, endpoint spec under jsonSpec"
     flags_builtin:
       set: true
     handler_type: endpoint
@@ -1329,7 +1329,7 @@ commands:
     verb: create
     noun: loadtest_template
     requires_id: true
-    short: "Create a load test template: harness create loadtest_template <id> --set tool_type=K6 --set revision=v1, or -f template.yaml"
+    short: "Create a load test template: harness create loadtest_template <id> -f template.yaml — templates carry a toolConfig block too"
     flags_builtin:
       set: true
     flags:

--- a/pkg/spec/rt.spec.yaml
+++ b/pkg/spec/rt.spec.yaml
@@ -69,9 +69,11 @@ help_text: |
   each template came from. Every other template command targets one hub, so
   pass `--hub` when the template is not in the default (unhubbed) one.
 
-  Templates are revisioned: `create loadtest_template:revision <id> --revision
-  <rev>` adds a revision, `list loadtest_template:revisions <id>` lists them,
-  and `get loadtest_template:revision <id> --revision <rev>` fetches one.
+  Templates are revisioned, and a revision is addressed as `<template-id>/<rev>`
+  the same way a pipeline template version is: `create
+  loadtest_template_revision <id>/<rev>` adds one, `list
+  loadtest_template_revision <id>` lists them, and `get
+  loadtest_template_revision <id>/<rev>` fetches one.
   `get loadtest_template:yaml <id>` writes the template as a YAML document.
 
   A **loadtest_script** is the script attached to an RT load test, with its own
@@ -299,6 +301,39 @@ nouns:
         expr: it.description
         width_max: 60
         mutable_path: description
+      - id: created_at
+        expr: it.createdAt
+      - id: created_by
+        expr: it.createdBy
+      - id: updated_at
+        expr: it.updatedAt
+      - id: updated_by
+        expr: it.updatedBy
+      - id: script
+        expr: it.scriptContent
+        field_type: multiline_text
+
+  - noun: loadtest_template_revision
+    short_desc: A specific revision of an RT load test template.
+    noun_aliases: [loadtest_template_revisions]
+    fields:
+      - id: revision
+        expr: it.revision
+      - id: name
+        expr: it.name
+      - id: hub
+        label: Hub
+        expr: it.hubIdentity
+      - id: tool_type
+        label: Tool
+        expr: it.toolType
+      - id: infra_type
+        expr: it.infraType
+      - id: script_source
+        expr: it.scriptSource
+      - id: description
+        expr: it.description
+        width_max: 60
       - id: created_at
         expr: it.createdAt
       - id: created_by
@@ -1394,11 +1429,10 @@ commands:
       no_fields: true
       text_header: "\nDeleted load test template {{ctx.id}}\n"
 
-  - command: list loadtest_template:revisions
+  - command: list loadtest_template_revision
     verb: list
-    noun: loadtest_template
-    noun_variant: revisions
-    short: "List the revisions of a template: harness list loadtest_template:revisions <template-id>"
+    noun: loadtest_template_revision
+    short: "List the revisions of a template: harness list loadtest_template_revision <template-id>"
     requires_parentid: true
     parentid_label: "<template-id>"
     completion_noun: loadtest_template
@@ -1410,7 +1444,10 @@ commands:
       path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.parentId}}/revisions
       # The route answers with a bare array of revisions rather than a page.
       items_expr: it
-      get_id_expr: it.revision
+      get_id_expr: parentId + "/" + it.revision
+      completion:
+        id_expr: it.revision
+        name_expr: it.name
       query_params:
         organizationIdentifier: 'auth.org != "" ? auth.org : nil'
         projectIdentifier: 'auth.project != "" ? auth.project : nil'
@@ -1419,82 +1456,81 @@ commands:
         paging_strategy: flat_list
       columns: [revision, name, tool_type, infra_type, updated_at, updated_by]
 
-  - command: create loadtest_template:revision
+  - command: create loadtest_template_revision
     verb: create
-    noun: loadtest_template
-    noun_variant: revision
+    noun: loadtest_template_revision
     requires_id: true
-    short: "Add a revision to a template: harness create loadtest_template:revision <template-id> --revision v2, or -f template.yaml"
-    completion_noun: loadtest_template
+    short: "Add a revision to a template: harness create loadtest_template_revision <template-id>/v2, or -f template.yaml"
+    id_parts: 2
+    id_label: "<template-id/revision>"
+    completion_seq:
+      - completion_noun: loadtest_template
     flags_builtin:
       set: true
     flags:
-      - name: revision
-        description: Identifier for the new revision
-        required: true
       - name: hub
         description: Hub holding the template
     handler_type: endpoint
     endpoint:
       method: POST
-      path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.id}}/revisions
+      path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.idParts[0]}}/revisions
       file_body: optional
       create_strategy: set-fields
       create_body_init:
-        identity: ctx.id
-        revision: flags.revision
+        identity: ctx.idParts[0]
+        revision: ctx.idParts[1]
       query_params:
         organizationIdentifier: 'auth.org != "" ? auth.org : nil'
         projectIdentifier: 'auth.project != "" ? auth.project : nil'
         hubIdentity: flags.hub
       item_expr: it
 
-  - command: get loadtest_template:revision
+  - command: get loadtest_template_revision
     verb: get
-    noun: loadtest_template
-    noun_variant: revision
-    short: "Get one revision of a template: harness get loadtest_template:revision <template-id> --revision v2"
-    id_label: "<template-id>"
-    completion_noun: loadtest_template
+    noun: loadtest_template_revision
+    short: "Get one revision of a template: harness get loadtest_template_revision <template-id>/v2"
+    id_parts: 2
+    id_label: "<template-id/revision>"
+    completion_seq:
+      - completion_noun: loadtest_template
+      - completion_noun: loadtest_template_revision
+        keep_order: true
     handler_type: endpoint
     flags:
-      - name: revision
-        description: Revision to fetch
-        required: true
       - name: hub
         description: Hub holding the template
     endpoint:
-      path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.id}}/revisions/{{flags.revision}}
+      path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.idParts[0]}}/revisions/{{ctx.idParts[1]}}
       item_expr: it
       query_params:
         organizationIdentifier: 'auth.org != "" ? auth.org : nil'
         projectIdentifier: 'auth.project != "" ? auth.project : nil'
         hubIdentity: flags.hub
 
-  - command: delete loadtest_template:revision
+  - command: delete loadtest_template_revision
     verb: delete
-    noun: loadtest_template
-    noun_variant: revision
-    short: "Delete one revision of a template: harness delete loadtest_template:revision <template-id> --revision v2"
-    id_label: "<template-id>"
-    completion_noun: loadtest_template
+    noun: loadtest_template_revision
+    short: "Delete one revision of a template: harness delete loadtest_template_revision <template-id>/v2"
+    id_parts: 2
+    id_label: "<template-id/revision>"
+    completion_seq:
+      - completion_noun: loadtest_template
+      - completion_noun: loadtest_template_revision
+        keep_order: true
     confirm_mode: prompt
     handler_type: endpoint
     flags:
-      - name: revision
-        description: Revision to delete
-        required: true
       - name: hub
         description: Hub holding the template
     endpoint:
       method: DELETE
-      path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.id}}/revisions/{{flags.revision}}
+      path: /gateway/loadTest/manager/api/v1/load-test-templates/{{ctx.idParts[0]}}/revisions/{{ctx.idParts[1]}}
       query_params:
         organizationIdentifier: 'auth.org != "" ? auth.org : nil'
         projectIdentifier: 'auth.project != "" ? auth.project : nil'
         hubIdentity: flags.hub
       no_fields: true
-      text_header: "\nDeleted revision {{flags.revision}} of template {{ctx.id}}\n"
+      text_header: "\nDeleted revision {{ctx.idParts[1]}} of template {{ctx.idParts[0]}}\n"
 
   - command: list loadtest_template:variables
     verb: list

--- a/pkg/spec/rt.spec.yaml
+++ b/pkg/spec/rt.spec.yaml
@@ -17,10 +17,11 @@ help_text: |
   the tunables (target users, duration) it accepts. Creating one does not run
   anything.
 
-  `create loadtest <id> --set toolType=K6 --set infraIdentifier=<infra> --set
-  environmentIdentifier=<env>` builds the definition from key=value pairs, or
-  pass a whole body with `-f test.yaml`. Use one or the other: when `-f` is
-  given it supplies the entire body and `--set` is ignored.
+  `create loadtest <id> --set tool_type=K6 --set infra=<infra> --set
+  environment=<env>` builds the definition from key=value pairs, or pass a
+  whole body with `-f test.yaml`. Use one or the other: when `-f` is given it
+  supplies the entire body and `--set` is ignored. `--set` takes the field IDs
+  listed by `create loadtest --list-fields`, not the API's own spellings.
 
   Two variants create a load test from something you already have:
   `create loadtest:from_json <id> -f spec.json` takes a declarative endpoint
@@ -40,22 +41,26 @@ help_text: |
   A **loadtest_run** is one execution of an RT load test.
   `execute loadtest <id>` starts a run and prints its identity; add `--follow`
   to stay attached and stream status and metrics until the run reaches a
-  terminal state, exiting non-zero if it fails. Supply run-time values with
-  `--set targetUsers=50`.
+  terminal state, exiting non-zero if it fails. Override the test's own
+  variables for this run with `--set targetUsers=50` — here `--set` takes
+  variable names as the script declares them, which
+  `list loadtest:variables <id>` lists.
 
   Inspect runs with `list loadtest_run` (across the scope) or
   `list loadtest_run <loadtest-id>` (for one test), and
   `get loadtest_run <run-id>`. While a run is live you can retarget it with
-  `update loadtest_run <run-id> --set targetUsers=200` and end it early with
+  `update loadtest_run <run-id> --set target_users=200` and end it early with
   `execute loadtest_run:stop <run-id>`.
 
   `execute loadtest_run:rerun <run-id>` starts a fresh run of the same load
   test with the same shape.
 
-  Results come from `get loadtest_run:summary <run-id>` for the headline
-  numbers, `get loadtest_run:metrics <run-id> --view timeseries|scatter|aggregate`
-  for the metric series, and `get loadtest_run:graph <run-id>` for the
-  render-ready chart payload.
+  Results are separate commands rather than one command with a view flag:
+  `get loadtest_run:summary <run-id>` for the headline numbers,
+  `list loadtest_run:metrics <run-id>` for the time series,
+  `list loadtest_run:requests <run-id>` for sampled individual requests,
+  `list loadtest_run:endpoints <run-id>` for the per-endpoint breakdown, and
+  `list loadtest_run:graph <run-id>` for the render-ready chart series.
 
   A **loadtest_template** is a shareable, versioned RT load test definition.
   Templates live in hubs; `list loadtest_template` spans every hub in the
@@ -64,14 +69,15 @@ help_text: |
   pass `--hub` when the template is not in the default (unhubbed) one.
 
   Templates are revisioned: `create loadtest_template:revision <id> --revision
-  <rev>` adds a revision, `list loadtest_template:revision <id>` lists them,
-  and `get loadtest_template:revision <id>/<rev>` fetches one.
+  <rev>` adds a revision, `list loadtest_template:revisions <id>` lists them,
+  and `get loadtest_template:revision <id> --revision <rev>` fetches one.
   `get loadtest_template:yaml <id>` writes the template as a YAML document.
 
   A **loadtest_script** is the script attached to an RT load test, with its own
   revision history. `get loadtest_script <loadtest-id>` shows the current
-  script, `list loadtest_script <loadtest-id>` lists revisions, and
-  `update loadtest_script <loadtest-id> -f script.jmx` uploads a new one.
+  script, `list loadtest_script:revisions <loadtest-id>` lists revisions,
+  `get loadtest_script:revision <loadtest-id> --revision 3` shows one of them,
+  and `update loadtest_script <loadtest-id> -f script.jmx` uploads a new one.
 
   A **composite_loadtest** is a pipeline that runs RT load tests and chaos
   probes together as stages. Identifiers must not contain hyphens — use
@@ -95,9 +101,11 @@ nouns:
       - id: name
         expr: it.name
         mutable_path: name
+      # Required when creating a load test, and fixed from then on.
       - id: tool_type
         label: Tool
         expr: it.toolType
+        mutable_path: toolType
       - id: environment
         expr: it.environmentIdentifier
         mutable_path: environmentIdentifier
@@ -188,12 +196,15 @@ nouns:
       - id: tool_type
         label: Tool
         expr: it.toolType
+      # Retargetable while the run is live — see update loadtest_run.
       - id: target_users
         label: Users
         expr: it.targetUsers
+        mutable_path: targetUsers
         align: right
       - id: spawn_rate
         expr: it.spawnRate
+        mutable_path: spawnRate
         align: right
       - id: duration
         label: Duration (s)
@@ -263,14 +274,17 @@ nouns:
       - id: name
         expr: it.name
         mutable_path: name
+      # Both are required when creating a template, and fixed from then on.
       - id: revision
         expr: it.revision
+        mutable_path: revision
       - id: hub
         label: Hub
         expr: it.hubIdentity
       - id: tool_type
         label: Tool
         expr: it.toolType
+        mutable_path: toolType
       - id: infra_type
         expr: it.infraType
         mutable_path: infraType
@@ -712,7 +726,7 @@ commands:
     verb: create
     noun: loadtest
     requires_id: true
-    short: "Create a load test: harness create loadtest <id> --set toolType=K6 --set infraIdentifier=<infra> --set environmentIdentifier=<env>, or -f test.yaml"
+    short: "Create a load test: harness create loadtest <id> --set tool_type=K6 --set infra=<infra> --set environment=<env>, or -f test.yaml"
     flags_builtin:
       set: true
     handler_type: endpoint
@@ -735,7 +749,7 @@ commands:
     noun: loadtest
     noun_variant: from_json
     requires_id: true
-    short: "Create a load test from a JSON endpoint spec: harness create loadtest:from_json <id> -f spec.json --set infraIdentifier=<infra> --set environmentIdentifier=<env>"
+    short: "Create a load test from a JSON endpoint spec: harness create loadtest:from_json <id> -f spec.json --set infra=<infra> --set environment=<env>"
     flags_builtin:
       set: true
     handler_type: endpoint
@@ -984,25 +998,25 @@ commands:
   - command: update loadtest_run
     verb: update
     noun: loadtest_run
-    short: "Retarget a running load test: harness update loadtest_run <run-id> --users 200 [--spawn-rate 5]"
+    short: "Retarget a running load test: harness update loadtest_run <run-id> --set target_users=200 [--set spawn_rate=5]"
     id_label: "<run-id>"
     handler_type: endpoint
-    flags:
-      - name: users
-        description: New target number of virtual users
-      - name: spawn-rate
-        description: New spawn rate, in users per second
+    flags_builtin:
+      set: true
     endpoint:
       method: POST
       path: /gateway/loadTest/manager/api/v1/runs/{{ctx.id}}/update
       # This endpoint takes the scope in the body, not just the query string.
+      # --set values arrive as strings and the route binds targetUsers and spawnRate as
+      # numbers, so the two tunables are read from ctx.setArgs and converted here rather
+      # than written straight through by create_strategy: set-fields.
       body_params:
         identity: ctx.id
         accountIdentifier: auth.account
         organizationIdentifier: auth.org
         projectIdentifier: auth.project
-        targetUsers: 'flags.users != "" ? int(flags.users) : nil'
-        spawnRate: 'flags["spawn-rate"] != "" ? float(flags["spawn-rate"]) : nil'
+        targetUsers: 'ctx.setArgs.target_users == nil ? nil : int(ctx.setArgs.target_users)'
+        spawnRate: 'ctx.setArgs.spawn_rate == nil ? nil : float(ctx.setArgs.spawn_rate)'
       query_params:
         organizationIdentifier: 'auth.org != "" ? auth.org : nil'
         projectIdentifier: 'auth.project != "" ? auth.project : nil'
@@ -1315,7 +1329,7 @@ commands:
     verb: create
     noun: loadtest_template
     requires_id: true
-    short: "Create a load test template: harness create loadtest_template <id> --set toolType=K6 --set revision=v1, or -f template.yaml"
+    short: "Create a load test template: harness create loadtest_template <id> --set tool_type=K6 --set revision=v1, or -f template.yaml"
     flags_builtin:
       set: true
     flags:


### PR DESCRIPTION
Follow-up to #131, covering the four items from the RT review.

## 1. `resolveScriptRevision` and the spec disagreed on the revisions response shape

The spec was right and the Go was wrong. `ListScriptRevisions` in the load test manager ends with `respondJSON(c, http.StatusOK, responses)` over a slice, so the route answers with a bare array and there is no `items` envelope to read — `get loadtest_script:revision <id> --revision 3` never resolved the number and always failed with "no script revision 3".

Both readers now go through one `itemsOf` helper that takes either shape, and the revision fixtures in the tests use a bare array, so the test would now catch the regression that the old `itemsPage(...)` fixture hid. `run.go`'s read is unchanged in behaviour — the runs route really is paged — it just shares the helper now.

## 2. `help_text` documented commands that don't exist

Fixed all five, plus a sixth of the same kind found while auditing the rest of the surface:

| was | now |
| --- | --- |
| `get loadtest_run:metrics <id> --view timeseries\|scatter\|aggregate` | the four separate `list loadtest_run:metrics` / `:requests` / `:endpoints` / `:graph` commands |
| `get loadtest_run:graph <id>` | `list loadtest_run:graph <id>` |
| `list loadtest_script <id>` | `list loadtest_script:revisions <id>`, plus `get loadtest_script:revision <id> --revision 3` |
| `list loadtest_template:revision <id>` | `list loadtest_template:revisions <id>` |
| `get loadtest_template:revision <id>/<rev>` | `get loadtest_template:revision <id> --revision <rev>` |
| `create loadtest <id> --set toolType=K6 --set infraIdentifier=… --set environmentIdentifier=…` | `--set tool_type=K6 --set infra=… --set environment=…` |

That last row was a real failure, not just wrong prose: `--set` keys are noun field IDs, so the documented form exited with `unknown or read-only field "toolType"`, and `tool_type` had no `mutable_path` at all — `toolType` is `binding:"required"` on create, so `create loadtest` could not be driven by `--set` at all. Same for `toolType` and `revision` on `create loadtest_template`. Those three fields now carry a `mutable_path`.

Every `harness …` example in the spec is now checked against the declared command list, and the two sets match exactly.

## 3. `update loadtest_run` now uses `--set`

`target_users` and `spawn_rate` carry a `mutable_path`, the bespoke `--users` / `--spawn-rate` flags are gone, and `flags_builtin: {set: true}` gives `--list-fields`.

The `body_params` block stays, as suggested, and does slightly more than carry the scope: `--set` values arrive as strings and the route binds `targetUsers` / `spawnRate` into `*int` / `*float64`, so `create_strategy: set-fields` would have posted `{"targetUsers":"200"}` and been rejected. Reading the two tunables off `ctx.setArgs` in `body_params` keeps the conversion. Verified on the wire: `--set target_users=200 --set spawn_rate=5` posts `{"targetUsers":200,"spawnRate":5}`, and omitted tunables stay out of the body.

## 4. `scopeParams()` and `scopeQueryExprs` are one thing again

`scopeQueryExprs` is now a function over `scopeParams`, quoting each value into a literal expr, so a third scope param only has to be added once. A test asserts the two agree, and the rerun test now checks the scope actually reaches the POST.

## Test plan

- [x] `go test ./...` — all packages pass; `modules/rt` coverage 96.1%
- [x] `HARNESS_CHECKSPECS=1` spec validation passes
- [x] `go vet ./...` and `gofmt` clean
- [x] `update loadtest_run`, `create loadtest` and `create loadtest_template` exercised against a fake API to confirm the request bodies