### PR TITLE
Add repo-level label management and PR label assign/unassign

### DIFF
--- a/pkg/exprenv/exprenv.go
+++ b/pkg/exprenv/exprenv.go
@@ -90,7 +90,7 @@ func Make(ctx *cmdctx.Ctx) map[string]any {
 		"formatMetadata":        exprfuncs.FormatMetadata,
 		"pipelineSparkline":     exprfuncs.NewPipelineSparkline(ctx.IsPty && !isMachineFormat(flags)),
 		"statusIcon":            exprfuncs.NewStatusIcon(ctx.IsPty && !isMachineFormat(flags)),
-		"prLabelColor":            exprfuncs.NewPrLabelColor(ctx.IsPty && !isMachineFormat(flags)),
+		"prLabelColor":          exprfuncs.NewPrLabelColor(ctx.IsPty && !isMachineFormat(flags)),
 		"spaceAfter":            exprfuncs.SpaceAfter,
 		"duration":              exprfuncs.Duration,
 		"harScopeUrl":           exprfuncs.HarScopeUrl,

--- a/pkg/exprenv/exprenv.go
+++ b/pkg/exprenv/exprenv.go
@@ -90,6 +90,7 @@ func Make(ctx *cmdctx.Ctx) map[string]any {
 		"formatMetadata":        exprfuncs.FormatMetadata,
 		"pipelineSparkline":     exprfuncs.NewPipelineSparkline(ctx.IsPty && !isMachineFormat(flags)),
 		"statusIcon":            exprfuncs.NewStatusIcon(ctx.IsPty && !isMachineFormat(flags)),
+		"prLabelColor":            exprfuncs.NewPrLabelColor(ctx.IsPty && !isMachineFormat(flags)),
 		"spaceAfter":            exprfuncs.SpaceAfter,
 		"duration":              exprfuncs.Duration,
 		"harScopeUrl":           exprfuncs.HarScopeUrl,

--- a/pkg/exprenv/exprfuncs/exprfuncs.go
+++ b/pkg/exprenv/exprfuncs/exprfuncs.go
@@ -71,6 +71,40 @@ func NewStatusIcon(enabled bool) func(string) string {
 	}
 }
 
+// labelColorMap maps a Harness Code label color (EnumLabelColor) to the nearest
+// basic ANSI color, since terminals only give us 8 basic colors for the API's 13.
+var pr_labelColorMap = map[string]console.Color{
+	"blue":   console.ColorBlue,
+	"brown":  console.ColorYellow,
+	"cyan":   console.ColorCyan,
+	"green":  console.ColorGreen,
+	"indigo": console.ColorBlue,
+	"lime":   console.ColorGreen,
+	"mint":   console.ColorCyan,
+	"orange": console.ColorYellow,
+	"pink":   console.ColorMagenta,
+	"purple": console.ColorMagenta,
+	"red":    console.ColorRed,
+	"violet": console.ColorMagenta,
+	"yellow": console.ColorYellow,
+}
+
+// NewLabelColor returns a function that colorizes text using the nearest basic ANSI
+// color for a Harness Code label color. When enabled is false (non-PTY or machine
+// format), the returned function always returns text unchanged.
+func NewPrLabelColor(enabled bool) func(color, text string) string {
+	return func(color, text string) string {
+		if !enabled {
+			return text
+		}
+		c, ok := pr_labelColorMap[color]
+		if !ok {
+			return text
+		}
+		return console.WithColor(c, text)
+	}
+}
+
 // Duration formats the elapsed time between two epoch-millisecond timestamps as
 // a human-readable string ("5m20s" or "42s"). Returns "" when either value is zero.
 // Accepts any numeric type since JSON numbers arrive as float64 in untyped maps.

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -430,6 +430,31 @@ nouns:
       - id: color
         expr: it.color
 
+  - noun: repo_label
+    short_desc: A label defined at the repo level, assignable to pull requests (Harness Code).
+    noun_aliases: [repo_labels]
+    fields:
+      - id: id
+        expr: it.id
+      - id: key
+        expr: prLabelColor(it.color, it.key)
+      - id: type
+        expr: it.type
+      - id: description
+        expr: it.description
+      - id: value_count
+        label: Values
+        expr: it.value_count
+        align: right
+      - id: pullreq_count
+        label: PRs Using
+        expr: it.pullreq_count
+        align: right
+      - id: created
+        expr: epochMs(it.created)
+      - id: updated
+        expr: epochMs(it.updated)
+
   - noun: code_principal
     short_desc: A person or service account in the current account/org/project scope (Harness Code).
     noun_aliases: [code_principals]
@@ -1074,6 +1099,115 @@ commands:
         page_size_max: 100
         page_base: 1
       columns: [id, key, type, assigned]
+
+  - command: list repo_label
+    verb: list
+    noun: repo_label
+    short: "List labels defined for a repo: harness list repo_label <repo_id>"
+    handler_type: endpoint
+    requires_parentid: true
+    parentid_label: "<repo_id>"
+    id_parts: 1
+    completion_seq:
+      - completion_noun: repository
+    flags:
+      - name: search
+        description: Filter by substring match on label key
+    endpoint:
+      path: /code/api/v1/repos/{{ctx.parentIdParts[0]}}/labels
+      items_expr: it
+      query_params:
+        query: flags.search
+        page: flags.page
+        limit: flags.limit
+      paging:
+        paging_strategy: page_header
+        countable: false
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+      columns: [id, key, type, description, value_count, pullreq_count, created, updated]
+
+  - command: create repo_label
+    verb: create
+    noun: repo_label
+    short: "Define a new label at the repo level: harness create repo_label <repo_id> --key <key> [--color <color>] [--type static|dynamic] [--description <text>]"
+    handler_type: endpoint
+    requires_id: true
+    id_parts: 1
+    id_label: "<repo_id>"
+    completion_seq:
+      - completion_noun: repository
+    flags:
+      - name: key
+        description: Label key/name
+        required: true
+      - name: color
+        description: "Label color"
+        default: blue
+        completion_values: [blue, brown, cyan, green, indigo, lime, mint, orange, pink, purple, red, violet, yellow]
+      - name: type
+        description: "Label type: static or dynamic"
+        default: static
+        completion_values: [static, dynamic]
+      - name: description
+        description: Label description
+    endpoint:
+      method: POST
+      path: /code/api/v1/repos/{{ctx.idParts[0]}}/labels
+      body_params:
+        key: flags.key
+        color: flags.color
+        type: flags.type
+        description: flags.description
+      no_fields: true
+      text_header: "\nCreated label {{flags.key}} on repo {{ctx.idParts[0]}}\n"
+
+  - command: execute pr:label
+    verb: execute
+    noun: pr
+    noun_variant: label
+    short: "Assign a label to a pull request: harness execute pr:label <repo_id>/<pr_number> --label <label_id>"
+    handler_type: endpoint
+    id_parts: 2
+    completion_seq:
+      - completion_noun: repository
+      - completion_noun: pr
+        keep_order: true
+    flags:
+      - name: label
+        description: "Numeric label ID to assign (see list pr_label / list repo_label)"
+        required: true
+    endpoint:
+      method: PUT
+      path: /code/api/v1/repos/{{ctx.idParts[0]}}/pullreq/{{ctx.idParts[1]}}/labels
+      body_params:
+        label_id: int(flags.label)
+      no_fields: true
+      text_header: "\nAssigned label to PR #{{ctx.idParts[1]}}\n"
+
+  - command: execute pr:unlabel
+    verb: execute
+    noun: pr
+    noun_variant: unlabel
+    short: "Remove a label from a pull request: harness execute pr:unlabel <repo_id>/<pr_number> --label <label_id>"
+    handler_type: endpoint
+    id_parts: 2
+    completion_seq:
+      - completion_noun: repository
+      - completion_noun: pr
+        keep_order: true
+    flags:
+      - name: label
+        description: "Numeric label ID to remove"
+        required: true
+    endpoint:
+      method: DELETE
+      path: /code/api/v1/repos/{{ctx.idParts[0]}}/pullreq/{{ctx.idParts[1]}}/labels/{{flags.label}}
+      no_fields: true
+      text_header: "\nRemoved label from PR #{{ctx.idParts[1]}}\n"
 
   # ── pr_suggested_reviewer (Harness Code review insights) ───────────────────────
 

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -415,6 +415,21 @@ nouns:
       - id: decision
         expr: it.review_decision
 
+  - noun: pr_label
+    short_desc: A label assignable to a pull request (Harness Code).
+    noun_aliases: [pr_labels]
+    fields:
+      - id: id
+        expr: it.id
+      - id: key
+        expr: it.key
+      - id: color
+        expr: it.color
+      - id: type
+        expr: it.type
+      - id: assigned
+        expr: it.assigned
+
   - noun: code_principal
     short_desc: A person or service account in the current account/org/project scope (Harness Code).
     noun_aliases: [code_principals]
@@ -1021,6 +1036,44 @@ commands:
       paging:
         paging_strategy: flat_list
       columns: [pattern, owner_type, display_name, email, group_name, decision]
+
+  # ── pr_label ─────────────────────────────────────────────────────────────────────
+
+  - command: list pr_label
+    verb: list
+    noun: pr_label
+    short: "List labels assignable to a pull request: harness list pr_label <repo_id>/<pr_number>"
+    handler_type: endpoint
+    requires_parentid: true
+    parentid_label: "<repo_id>/<pr_number>"
+    id_parts: 2
+    completion_seq:
+      - completion_noun: repository
+      - completion_noun: pr
+        keep_order: true
+    flags:
+      - name: assignable
+        description: "Only show labels assignable to this PR (default true); set --assignable=false to see all repo/space labels"
+        default: "true"
+      - name: search
+        description: Filter by substring match on label key
+    endpoint:
+      path: /code/api/v1/repos/{{ctx.parentIdParts[0]}}/pullreq/{{ctx.parentIdParts[1]}}/labels
+      items_expr: it.label_data
+      query_params:
+        assignable: flags.assignable
+        query: flags.search
+        page: flags.page
+        limit: flags.limit
+      paging:
+        paging_strategy: page_header
+        countable: false
+        page_index_param: page
+        page_size_param: limit
+        page_size_default: 30
+        page_size_max: 100
+        page_base: 1
+      columns: [id, key, color, type, assigned]
 
   # ── pr_suggested_reviewer (Harness Code review insights) ───────────────────────
 

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -1165,6 +1165,52 @@ commands:
       no_fields: true
       text_header: "\nCreated label {{flags.key}} on repo {{ctx.idParts[0]}}\n"
 
+  - command: update repo_label
+    verb: update
+    noun: repo_label
+    short: "Update a repo-level label: harness update repo_label <repo_id>/<key> [--new-key <key>] [--color <color>] [--type static|dynamic] [--description <text>]"
+    handler_type: endpoint
+    id_parts: 2
+    id_label: "<repo_id>/<key>"
+    completion_seq:
+      - completion_noun: repository
+    flags:
+      - name: new-key
+        description: New label key/name (renames the label)
+      - name: color
+        description: "Label color"
+        completion_values: [blue, brown, cyan, green, indigo, lime, mint, orange, pink, purple, red, violet, yellow]
+      - name: type
+        description: "Label type: static or dynamic"
+        completion_values: [static, dynamic]
+      - name: description
+        description: Label description
+    endpoint:
+      method: PATCH
+      path: /code/api/v1/repos/{{ctx.idParts[0]}}/labels/{{ctx.idParts[1]}}
+      body_params:
+        key: flags.new-key
+        color: flags.color
+        type: flags.type
+        description: flags.description
+      no_fields: true
+      text_header: "\nUpdated label {{ctx.idParts[1]}} on repo {{ctx.idParts[0]}}\n"
+
+  - command: delete repo_label
+    verb: delete
+    noun: repo_label
+    confirm_mode: prompt
+    short: "Delete a label from a repo: harness delete repo_label <repo_id>/<key>"
+    handler_type: endpoint
+    id_parts: 2
+    id_label: "<repo_id>/<key>"
+    completion_seq:
+      - completion_noun: repository
+    endpoint:
+      method: DELETE
+      path: /code/api/v1/repos/{{ctx.idParts[0]}}/labels/{{ctx.idParts[1]}}
+      item_expr: it
+
   - command: execute pr:label
     verb: execute
     noun: pr

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -422,13 +422,13 @@ nouns:
       - id: id
         expr: it.id
       - id: key
-        expr: it.key
-      - id: color
-        expr: it.color
+        expr: prLabelColor(it.color, it.key)
       - id: type
         expr: it.type
       - id: assigned
         expr: it.assigned
+      - id: color
+        expr: it.color
 
   - noun: code_principal
     short_desc: A person or service account in the current account/org/project scope (Harness Code).
@@ -1073,7 +1073,7 @@ commands:
         page_size_default: 30
         page_size_max: 100
         page_base: 1
-      columns: [id, key, color, type, assigned]
+      columns: [id, key, type, assigned]
 
   # ── pr_suggested_reviewer (Harness Code review insights) ───────────────────────
 


### PR DESCRIPTION
 ## Summary
   1 - Add `list repo_label` / `create repo_label`/  `update repo_label` / `delete repo_label` to define and browse labels at the repo level (key, color, type, description).
   2 - Add `execute pr:label` / `execute pr:unlabel` to attach/detach an existing label to a specific PR by numeric label ID.
   3 - Builds on the already-shipped `list pr_label` (which shows labels assignable to a PR) — these commands close the gap by letting you actually create a label and assign it, using the `execute` verb (not `create`/`delete`) since attaching a label isn't creating one.