### PR TITLE
Support installing plugins from arbitrary GitHub repos, plus bulk plugin upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,16 @@ Do not hardcode into source files, comments, or documentation:
 
 Use placeholder text like `<accountId>`, `<token>`, `<email>` in examples.
 
+## Comments
+
+Write a comment only for a non-obvious WHY: a hidden constraint, an invariant, a gotcha ("if you change X, also update Y"), or a workaround. Don't write a comment that:
+- Restates what the code already says — in its name, its type, or (for a function that rejects/validates specific cases) the error message it returns. A comment that duplicates a value found elsewhere in the function drifts the moment one side is edited and the other isn't, leaving a reader to reconcile two sources instead of trusting one.
+- Explains a design decision or naming choice ("we did X instead of Y because...").
+- Recounts history ("this used to be Z", "added for the W feature", "changed after bug #123").
+- Walks through what the code does step by step — a good name already carries that.
+
+Default to zero comments; most functions need none. If one is warranted, keep it to 1-2 lines — reaching for 4-5 lines above a small function is a sign it needs a clearer name or shape, not a bigger comment.
+
 ## Common pitfalls
 
 - **Binary not updated**: `task build` alone isn't enough — must `cp` to `~/.local/bin/harness`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,7 @@ tasks:
       # Use the real installer path: `install plugin` runs the identity gate,
       # captures --spec, and stamps provenance into devhome/spec. Exactly what a
       # user gets from `harness install plugin <binary>`.
-      - HARNESS_CLI_HOME={{.DEVHOME}} ./bin/{{.BINARY}} install plugin {{.DEVHOME}}/bin/harness-har
+      - HARNESS_CLI_HOME={{.DEVHOME}} ./bin/{{.BINARY}} install plugin ./{{.DEVHOME}}/bin/harness-har
       - echo "Run with HARNESS_CLI_HOME={{.DEVHOME}} ./bin/harness ..."
 
   build:windows:

--- a/cmd/harness/main-harness.go
+++ b/cmd/harness/main-harness.go
@@ -32,6 +32,7 @@ var noargsText string
 func main() {
 	rootcmd.MaybeRunBackgroundUpdateCheck()
 	rootcmd.MaybeRunPostInstall()
+	rootcmd.MaybeRunPostUpgrade()
 
 	if !semver.IsValid("v" + hbase.Version) {
 		console.PrintError(fmt.Sprintf("invalid version %q: must be a valid semver (e.g. 1.2.3)", hbase.Version))

--- a/modules/core/mgmt/install.go
+++ b/modules/core/mgmt/install.go
@@ -251,12 +251,17 @@ func InstallCLIHandler(ctx *cmdctx.Ctx) error {
 	// Bring any installed plugins up to their own latest by shelling out to the
 	// binary that was just installed, not this process's own code — a change to
 	// how plugin installs work ships with the release that carries it instead
-	// of lagging one core upgrade behind. A failure here is reported but never
-	// fails the overall install: it's non-fatal today, and once install has a
-	// postinstall hook, that's the place a failure here would be retried or
-	// escalated, not here.
+	// of lagging one core upgrade behind.
 	if err := runInstalledBinary(installedBinPath, "install", "plugin", "all"); err != nil {
 		fmt.Printf("warning: could not update plugins: %v\n", err)
+	}
+
+	// Let the binary just installed finish its own upgrade — a hook for
+	// whatever migration or cleanup work a future release needs that only its
+	// own code can know how to do. Runs after plugins so that work can assume
+	// plugins are already at their final state.
+	if err := runInstalledBinary(installedBinPath, hbase.PostUpgradeFlag); err != nil {
+		fmt.Printf("warning: post-upgrade hook failed: %v\n", err)
 	}
 
 	return nil

--- a/modules/core/mgmt/install.go
+++ b/modules/core/mgmt/install.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -230,6 +231,8 @@ func InstallCLIHandler(ctx *cmdctx.Ctx) error {
 		}
 	}
 
+	installedBinPath := filepath.Join(installDir, installedBinaryName(installBinaryName))
+
 	if installCore {
 		if err := os.MkdirAll(installDir, 0755); err != nil {
 			return fmt.Errorf("creating install directory %s: %w", installDir, err)
@@ -238,22 +241,35 @@ func InstallCLIHandler(ctx *cmdctx.Ctx) error {
 		if err := downloadAndInstallBinary(rel, installBundleName, version, platform, installDir, installBinaryName, ""); err != nil {
 			return err
 		}
-		fmt.Printf("Installed harness %s to %s\n", version, filepath.Join(installDir, installedBinaryName(installBinaryName)))
+		fmt.Printf("Installed harness %s to %s\n", version, installedBinPath)
 	}
 
 	if coreOnly {
 		return nil
 	}
 
-	// Bring any installed plugins up to their own latest — each module releases
-	// independently of core, so this must not force-pin them to core's version.
-	for _, name := range installedRegistryPlugins() {
-		if err := installRegistryPlugin(name, "", "", false, force, false); err != nil {
-			fmt.Printf("warning: could not update plugin %q: %v\n", name, err)
-		}
+	// Bring any installed plugins up to their own latest by shelling out to the
+	// binary that was just installed, not this process's own code — a change to
+	// how plugin installs work ships with the release that carries it instead
+	// of lagging one core upgrade behind. A failure here is reported but never
+	// fails the overall install: it's non-fatal today, and once install has a
+	// postinstall hook, that's the place a failure here would be retried or
+	// escalated, not here.
+	if err := runInstalledBinary(installedBinPath, "install", "plugin", "all"); err != nil {
+		fmt.Printf("warning: could not update plugins: %v\n", err)
 	}
 
 	return nil
+}
+
+// runInstalledBinary execs binPath, passing args through and connecting its
+// stdout/stderr directly to this process's — the invocation should look to
+// the user like harness ran the command itself.
+func runInstalledBinary(binPath string, args ...string) error {
+	cmd := exec.Command(binPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // InstallModuleHandler installs a module that ships as a plugin. "module" is the

--- a/modules/core/mgmt/install_plugin.go
+++ b/modules/core/mgmt/install_plugin.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -26,14 +27,16 @@ import (
 	"github.com/harness/cli/pkg/specloader"
 )
 
-// registryEntry is a bare-name-installable plugin's fixed identity: its
-// release package name and the tag prefix its releases are published under.
-// Core itself has no entry — it is not a plugin — so prefix "" here always
-// means "a module release, on harness/cli, under {prefix}/vX.Y.Z" rather than
-// core's own bare "vX.Y.Z" convention.
-type registryEntry struct {
-	pkgName string
-	prefix  string
+// GithubPluginRef identifies a plugin release on GitHub: the "owner/repo" it
+// publishes to, and the tag prefix its releases are published under ("" means
+// core's own bare "vX.Y.Z" convention rather than "{TagPrefix}/vX.Y.Z").
+// PkgName is the release package name when already known — always true for a
+// registry entry, never true for a ref parsed from owner/repo[/prefix]
+// syntax, where it's discovered from the release's own assets instead.
+type GithubPluginRef struct {
+	GithubRepo string
+	TagPrefix  string
+	PkgName    string
 }
 
 // pluginRegistry is the optional name→artifact resolver behind the bare-name
@@ -43,10 +46,10 @@ type registryEntry struct {
 // cover secret/internal/third-party plugins.
 //
 // Every entry releases independently of core and of each other, each under its
-// own "{prefix}/vX.Y.Z" tag on release.Repo — a module shipping a fix does not
-// wait on core's release cadence.
-var pluginRegistry = map[string]registryEntry{
-	"har": {pkgName: "harness-plugin-har", prefix: "har"},
+// own "{TagPrefix}/vX.Y.Z" tag on release.Repo — a module shipping a fix does
+// not wait on core's release cadence.
+var pluginRegistry = map[string]GithubPluginRef{
+	"har": {GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har"},
 }
 
 func registryNames() string {
@@ -58,87 +61,191 @@ func registryNames() string {
 	return strings.Join(names, ", ")
 }
 
+// pluginRef is the parsed shape of an install-plugin <ref> argument — exactly
+// one of URL, LocalPath, or GithubRef is set.
+type pluginRef struct {
+	URL       string
+	LocalPath string
+	GithubRef *GithubPluginRef
+}
+
+// parsePluginRef classifies an install-plugin <ref> argument as a tarball URL,
+// a local path, or a GitHub plugin ref — the latter either parsed from
+// owner/repo[/prefix] syntax, or resolved from a bare registry name via
+// pluginRegistry. It touches no filesystem or network, so every branch of the
+// classification is unit-testable on its own.
+func parsePluginRef(ref string) (pluginRef, error) {
+	switch {
+	case strings.HasPrefix(ref, "http://"), strings.HasPrefix(ref, "https://"):
+		return pluginRef{URL: ref}, nil
+	case looksLikePath(ref):
+		return pluginRef{LocalPath: ref}, nil
+	case isArchive(ref):
+		// Doesn't match looksLikePath, but the extension makes the intent
+		// clear enough to give a precise fix instead of trying (and failing)
+		// a GitHub ref lookup or an "unknown plugin name" error.
+		return pluginRef{}, fmt.Errorf("%q looks like a plugin archive, but is not a path harness recognizes — local paths must be absolute, or start with \"./\" or \"~/\"", ref)
+	case strings.Contains(ref, "/"):
+		owner, repoName, prefix, ok := splitGitHubRef(ref)
+		if !ok {
+			return pluginRef{}, fmt.Errorf("%q is not a valid owner/repo or owner/repo/prefix GitHub ref", ref)
+		}
+		return pluginRef{GithubRef: &GithubPluginRef{GithubRepo: owner + "/" + repoName, TagPrefix: prefix}}, nil
+	default:
+		// Bare name → registry lookup. Same path `install module` takes.
+		if err := plugin.ValidateName(ref); err != nil {
+			return pluginRef{}, fmt.Errorf("%q is not a URL, an existing file, an owner/repo ref, or a valid plugin name — supported names: %s", ref, registryNames())
+		}
+		entry, ok := pluginRegistry[ref]
+		if !ok {
+			return pluginRef{}, fmt.Errorf("unknown plugin %q — supported: %s\n\nTo install an unregistered plugin, pass its tarball URL, path, or owner/repo ref", ref, registryNames())
+		}
+		return pluginRef{GithubRef: &entry}, nil
+	}
+}
+
 // InstallPluginHandler installs a plugin from a tarball URL, a local tarball, a
-// local binary, or a bare registry name. All four forms funnel into the same
-// routine: get a binary on disk → identity gate (--identity) → install into
-// ~/.harness/bin → capture grammar (--spec) → write <name>.spec.yaml with the
-// host-owned provenance block. Core is the only writer of spec files.
+// local binary, an owner/repo[/prefix] GitHub ref, or a bare registry name. All
+// forms funnel into the same routine: get a binary on disk → identity gate
+// (--identity) → install into ~/.harness/bin → capture grammar (--spec) →
+// write <name>.spec.yaml with the host-owned provenance block. Core is the
+// only writer of spec files.
 func InstallPluginHandler(ctx *cmdctx.Ctx) error {
 	ref := ctx.Id
 	if ref == "" {
-		return fmt.Errorf("install plugin requires a tarball URL, a local tarball or binary path, or a plugin name (%s)", registryNames())
+		return fmt.Errorf("install plugin requires a tarball URL, a local tarball or binary path, an owner/repo[/prefix] GitHub ref, or a plugin name (%s)", registryNames())
 	}
+	parsed, err := parsePluginRef(ref)
+	if err != nil {
+		return err
+	}
+
 	version := cmdctx.GetString(ctx.FlagValues, "version")
 	force := cmdctx.GetBool(ctx.FlagValues, "force")
 	check := cmdctx.GetBool(ctx.FlagValues, "check")
 	githubToken := cmdctx.GetString(ctx.FlagValues, "github-token")
 	allowDrafts := cmdctx.GetBool(ctx.FlagValues, "allow-drafts")
+	pluginName := cmdctx.GetString(ctx.FlagValues, "plugin-name")
 
 	switch {
-	case strings.HasPrefix(ref, "http://"), strings.HasPrefix(ref, "https://"):
+	case parsed.URL != "":
 		// A bare URL has no discoverable checksum file and no promised name.
-		res, err := installPluginFromURL(ref, "", ref, "")
+		res, err := installPluginFromURL(parsed.URL, "", parsed.URL, "")
 		if err != nil {
 			return err
 		}
 		res.report()
 		return nil
-	case looksLikePath(ref):
-		res, err := installPluginFromPath(ref)
+	case parsed.LocalPath != "":
+		res, err := installPluginFromPath(parsed.LocalPath)
 		if err != nil {
 			return err
 		}
 		res.report()
 		return nil
+	case parsed.GithubRef != nil:
+		gh := *parsed.GithubRef
+		// --plugin-name only disambiguates a ref whose pkgName isn't already
+		// known — a registry entry's asset is already pinned.
+		if gh.PkgName == "" && pluginName != "" {
+			gh.PkgName = plugin.BinaryPrefix + "plugin-" + pluginName
+		}
+		return installPluginFromRelease(gh.GithubRepo, gh.TagPrefix, gh.PkgName, version, githubToken, allowDrafts, force, check)
 	default:
-		// Bare name → registry lookup. Same path `install module` takes.
-		if err := plugin.ValidateName(ref); err != nil {
-			return fmt.Errorf("%q is not a URL, an existing file, or a valid plugin name — supported names: %s", ref, registryNames())
-		}
-		if _, ok := pluginRegistry[ref]; !ok {
-			return fmt.Errorf("unknown plugin %q — supported: %s\n\nTo install an unregistered plugin, pass its tarball URL or path", ref, registryNames())
-		}
-		return installRegistryPlugin(ref, version, githubToken, allowDrafts, force, check)
+		return fmt.Errorf("internal error: parsePluginRef(%q) returned no variant", ref)
 	}
 }
 
 // looksLikePath reports whether ref should be treated as a filesystem path
-// rather than a registry name. A ref containing a separator is always a path
-// (so a typo'd path errors as a missing file, not an unknown plugin); a bare
-// word is a path only if a file by that name actually exists.
+// rather than a registry name or a GitHub ref. Only these three forms count —
+// there is no filesystem probing here, so a bareword or a relative path
+// without "./" is never silently treated as a path.
 func looksLikePath(ref string) bool {
-	if strings.ContainsAny(ref, `/\`) || strings.HasPrefix(ref, "~") || strings.HasPrefix(ref, ".") {
-		return true
-	}
-	_, err := os.Stat(ref)
-	return err == nil
+	return filepath.IsAbs(ref) || strings.HasPrefix(ref, "~/") || strings.HasPrefix(ref, "./")
 }
 
-// installRegistryPlugin installs a plugin named in pluginRegistry from the
-// Harness GitHub release tagged {prefix}/vX.Y.Z ("" / "latest" resolves to
-// that module's own latest release — independent of core's version and of
-// every other module's). check reports availability and drift without
-// installing.
-//
-// This is the only ref form that does an up-to-date check: a name means "get me
-// the current one", so reinstalling an identical version is wasted work. An
-// explicit URL or path names a specific artifact and is always installed.
-//
-// githubToken, when set, is forwarded to release resolution and asset download
-// so this can also install from a draft release or a private repo; allowDrafts
-// additionally includes drafts when resolving "latest" (meaningless without a
-// token, since an unauthenticated request never sees a draft to begin with).
+// splitGitHubRef parses ref as "owner/repo" or "owner/repo/prefix". Any other
+// slash count is rejected outright rather than falling through to be treated
+// as a bare plugin name.
+func splitGitHubRef(ref string) (owner, repoName, prefix string, ok bool) {
+	parts := strings.Split(ref, "/")
+	switch len(parts) {
+	case 2:
+		owner, repoName = parts[0], parts[1]
+	case 3:
+		owner, repoName, prefix = parts[0], parts[1], parts[2]
+	default:
+		return "", "", "", false
+	}
+	if owner == "" || repoName == "" || (len(parts) == 3 && prefix == "") {
+		return "", "", "", false
+	}
+	return owner, repoName, prefix, true
+}
+
+// installRegistryPlugin installs a plugin named in pluginRegistry. Its repo is
+// always release.Repo and its pkgName is always known, so it's a thin wrapper
+// over installPluginFromRelease, which also serves the generic
+// owner/repo[/prefix] ref form where the repo is user-supplied and pkgName may
+// have to be discovered from the release's own assets.
 func installRegistryPlugin(name, version, githubToken string, allowDrafts, force, check bool) error {
 	entry, ok := pluginRegistry[name]
 	if !ok {
 		return fmt.Errorf("unknown plugin %q — supported: %s", name, registryNames())
 	}
+	return installPluginFromRelease(entry.GithubRepo, entry.TagPrefix, entry.PkgName, version, githubToken, allowDrafts, force, check)
+}
 
+// installPluginFromRelease resolves a release tagged {prefix}/vX.Y.Z ("" /
+// "latest" resolves to that prefix's own latest release) in repo, finds the
+// plugin asset in it, and installs it — checking drift against any existing
+// install first. check reports availability and drift without installing.
+//
+// pkgName, when known (the registry form), selects the asset directly.
+// When empty (a generic owner/repo[/prefix] ref, where no pkgName is known
+// ahead of time), the asset — and the plugin's name — is discovered by
+// pattern-matching the release's own assets.
+//
+// This is the only ref form that does an up-to-date check: naming a release
+// this way means "get me the current one", so reinstalling an identical
+// version is wasted work. An explicit URL or path names a specific artifact
+// and is always installed.
+//
+// githubToken, when set, is forwarded to release resolution and asset download
+// so this can also install from a draft release or a private repo; allowDrafts
+// additionally includes drafts when resolving "latest" (meaningless without a
+// token, since an unauthenticated request never sees a draft to begin with).
+func installPluginFromRelease(repo, prefix, pkgName, version, githubToken string, allowDrafts, force, check bool) error {
 	platform, err := detectPlatform()
 	if err != nil {
 		return err
 	}
 	hlog.Debug("platform detected", "platform", platform)
+
+	rel, resolvedVersion, err := resolveReleaseForPrefix(repo, prefix, version, githubToken, allowDrafts)
+	if err != nil {
+		if check {
+			fmt.Printf("Version %s not found in %s: %v\n", versionLabel(version), repo, err)
+			os.Exit(1)
+		}
+		return err
+	}
+
+	var asset *release.Asset
+	var name string
+	if pkgName != "" {
+		name = strings.TrimPrefix(pkgName, plugin.BinaryPrefix+"plugin-")
+		asset, err = archiveAsset(rel, pkgName, resolvedVersion, platform)
+	} else {
+		asset, name, err = discoverPluginAsset(rel, resolvedVersion, platform)
+	}
+	if err != nil {
+		if check {
+			fmt.Printf("%s %s not available for platform %s: %v\n", repo, resolvedVersion, platform, err)
+			os.Exit(1)
+		}
+		return err
+	}
 
 	installed := installedPluginVersion(name)
 	// A spec whose binary is gone is not an install, whatever version it
@@ -154,15 +261,6 @@ func installRegistryPlugin(name, version, githubToken string, allowDrafts, force
 	}
 
 	if check {
-		rel, resolvedVersion, err := resolveReleaseForPrefix(release.Repo, entry.prefix, version, githubToken, allowDrafts)
-		if err != nil {
-			fmt.Printf("Plugin %q version %s not found: %v\n", name, versionLabel(version), err)
-			os.Exit(1)
-		}
-		if _, err := archiveAssetURL(rel, entry.pkgName, resolvedVersion, platform); err != nil {
-			fmt.Printf("Plugin %q %s not available for platform %s\n", name, resolvedVersion, platform)
-			os.Exit(1)
-		}
 		if installed == "" {
 			fmt.Printf("Plugin %q %s is available to install\n", name, resolvedVersion)
 			return nil
@@ -181,11 +279,6 @@ func installRegistryPlugin(name, version, githubToken string, allowDrafts, force
 		return nil
 	}
 
-	rel, resolvedVersion, err := resolveReleaseForPrefix(release.Repo, entry.prefix, version, githubToken, allowDrafts)
-	if err != nil {
-		return err
-	}
-
 	if !force && installed != "" {
 		if cmp, ok := cmpVersion(resolvedVersion, installed); ok && cmp <= 0 {
 			if cmp < 0 {
@@ -197,25 +290,70 @@ func installRegistryPlugin(name, version, githubToken string, allowDrafts, force
 		}
 	}
 
-	archiveAsset, err := archiveAsset(rel, entry.pkgName, resolvedVersion, platform)
-	if err != nil {
-		return err
-	}
 	checksumAsset, err := checksumAsset(rel)
 	if err != nil {
 		return err
 	}
 	hlog.Info("downloading plugin", "plugin", name, "version", resolvedVersion, "platform", platform)
-	// expectName: the registry promised us this plugin, so a tarball that
-	// identifies as something else is a bad registry entry, not a new plugin —
-	// and must be rejected before it lands anywhere on disk.
-	res, err := installPluginFromAsset(archiveAsset, checksumAsset, githubToken, name)
+	// expectName: the release promised us this plugin (by registry entry or by
+	// asset-name discovery), so a tarball that identifies as something else is
+	// a bad release, not a new plugin — and must be rejected before it lands
+	// anywhere on disk.
+	res, err := installPluginFromAsset(asset, checksumAsset, githubToken, name)
 	if err != nil {
 		return err
 	}
 	res.report()
 	return nil
 }
+
+// discoverPluginAsset finds the sole plugin asset in rel for version and
+// platform when pkgName isn't known ahead of time (the generic
+// owner/repo[/prefix] ref form). It pattern-matches every asset against
+// harness-plugin-<name>_<version>_<platform>{.tar.gz,.tgz,.zip} and returns
+// the one match together with the <name> it captured — that name becomes both
+// the identity-gate expectation and the plugin's spec/version-tracking key.
+//
+// Zero matches means the release has no plugin for this platform; two or more
+// means the release ships more than one plugin and --plugin-name is needed to
+// pick one.
+func discoverPluginAsset(rel *release.Release, version, platform string) (*release.Asset, string, error) {
+	ver := strings.TrimPrefix(version, "v")
+	suffix := fmt.Sprintf("_%s_%s%s", ver, platform, archiveExtensionForPlatform(platform))
+
+	type candidate struct {
+		asset *release.Asset
+		name  string
+	}
+	var matches []candidate
+	for i := range rel.Assets {
+		a := &rel.Assets[i]
+		m := pluginAssetNamePattern.FindStringSubmatch(a.Name)
+		if m == nil || !strings.HasSuffix(a.Name, suffix) {
+			continue
+		}
+		matches = append(matches, candidate{asset: a, name: m[1]})
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0].asset, matches[0].name, nil
+	case 0:
+		return nil, "", fmt.Errorf("no plugin asset for platform %s in release %s", platform, rel.TagName)
+	}
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.name
+	}
+	sort.Strings(names)
+	return nil, "", fmt.Errorf("release %s has %d plugin candidates for platform %s (%s) — pass --plugin-name to pick one",
+		rel.TagName, len(matches), platform, strings.Join(names, ", "))
+}
+
+// pluginAssetNamePattern captures <name> out of a harness-plugin-<name>_...
+// release asset name — the naming convention every plugin release, registered
+// or not, is expected to follow.
+var pluginAssetNamePattern = regexp.MustCompile(`^` + regexp.QuoteMeta(plugin.BinaryPrefix+"plugin-") + `([a-z0-9]+(?:-[a-z0-9]+)*)_`)
 
 // installedPlugin is what a successful install produces: the gated identity and
 // the path the binary actually landed at.

--- a/modules/core/mgmt/install_plugin.go
+++ b/modules/core/mgmt/install_plugin.go
@@ -115,10 +115,6 @@ func InstallPluginHandler(ctx *cmdctx.Ctx) error {
 	if ref == "" {
 		return fmt.Errorf("install plugin requires a tarball URL, a local tarball or binary path, an owner/repo[/prefix] GitHub ref, or a plugin name (%s)", registryNames())
 	}
-	parsed, err := parsePluginRef(ref)
-	if err != nil {
-		return err
-	}
 
 	version := cmdctx.GetString(ctx.FlagValues, "version")
 	force := cmdctx.GetBool(ctx.FlagValues, "force")
@@ -126,6 +122,15 @@ func InstallPluginHandler(ctx *cmdctx.Ctx) error {
 	githubToken := cmdctx.GetString(ctx.FlagValues, "github-token")
 	allowDrafts := cmdctx.GetBool(ctx.FlagValues, "allow-drafts")
 	pluginName := cmdctx.GetString(ctx.FlagValues, "plugin-name")
+
+	if ref == "all" {
+		return installAllRegistryPlugins(version, githubToken, allowDrafts, force, check)
+	}
+
+	parsed, err := parsePluginRef(ref)
+	if err != nil {
+		return err
+	}
 
 	switch {
 	case parsed.URL != "":
@@ -196,6 +201,47 @@ func installRegistryPlugin(name, version, githubToken string, allowDrafts, force
 	return installPluginFromRelease(entry.GithubRepo, entry.TagPrefix, entry.PkgName, version, githubToken, allowDrafts, force, check)
 }
 
+// installAllRegistryPlugins updates every registry-known plugin that is
+// currently installed to its own latest release. "all" has no single version
+// to install — each plugin releases independently of core and of every other
+// plugin — so a caller-supplied --version is rejected rather than silently
+// ignored or applied to every plugin. --force is rejected too: forcing a
+// reinstall of every plugin regardless of its own up-to-date state is a
+// per-plugin decision, made by naming that plugin directly. --github-token
+// and --allow-drafts are rejected as well — every registry plugin releases
+// from release.Repo under core's own visible, non-draft release process, so
+// neither flag has anything to do for a registry name.
+func installAllRegistryPlugins(version, githubToken string, allowDrafts, force, check bool) error {
+	if version != "" && version != "latest" {
+		return fmt.Errorf(`--version is not valid with "all" — each plugin releases independently, so there is no single version to install`)
+	}
+	if force {
+		return fmt.Errorf(`--force is not valid with "all" — install a plugin by name to force its reinstall`)
+	}
+	if githubToken != "" {
+		return fmt.Errorf(`--github-token is not valid with "all" — registry plugins are never behind a private or draft release`)
+	}
+	if allowDrafts {
+		return fmt.Errorf(`--allow-drafts is not valid with "all" — registry plugins are never behind a private or draft release`)
+	}
+	names := installedRegistryPlugins()
+	if len(names) == 0 {
+		fmt.Println("no registry plugins installed")
+		return nil
+	}
+	var failed []string
+	for _, name := range names {
+		if err := installRegistryPlugin(name, "", "", false, false, check); err != nil {
+			fmt.Printf("warning: could not install plugin %q: %v\n", name, err)
+			failed = append(failed, name)
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to install %d of %d plugin(s): %s", len(failed), len(names), strings.Join(failed, ", "))
+	}
+	return nil
+}
+
 // installPluginFromRelease resolves a release tagged {prefix}/vX.Y.Z ("" /
 // "latest" resolves to that prefix's own latest release) in repo, finds the
 // plugin asset in it, and installs it — checking drift against any existing
@@ -224,11 +270,7 @@ func installPluginFromRelease(repo, prefix, pkgName, version, githubToken string
 
 	rel, resolvedVersion, err := resolveReleaseForPrefix(repo, prefix, version, githubToken, allowDrafts)
 	if err != nil {
-		if check {
-			fmt.Printf("Version %s not found in %s: %v\n", versionLabel(version), repo, err)
-			os.Exit(1)
-		}
-		return err
+		return fmt.Errorf("version %s not found in %s: %w", versionLabel(version), repo, err)
 	}
 
 	var asset *release.Asset
@@ -240,11 +282,7 @@ func installPluginFromRelease(repo, prefix, pkgName, version, githubToken string
 		asset, name, err = discoverPluginAsset(rel, resolvedVersion, platform)
 	}
 	if err != nil {
-		if check {
-			fmt.Printf("%s %s not available for platform %s: %v\n", repo, resolvedVersion, platform, err)
-			os.Exit(1)
-		}
-		return err
+		return fmt.Errorf("%s %s not available for platform %s: %w", repo, resolvedVersion, platform, err)
 	}
 
 	installed := installedPluginVersion(name)

--- a/modules/core/mgmt/install_plugin.go
+++ b/modules/core/mgmt/install_plugin.go
@@ -154,7 +154,10 @@ func InstallPluginHandler(ctx *cmdctx.Ctx) error {
 		if pluginName != "" {
 			gh.PkgName = plugin.BinaryPrefix + "plugin-" + pluginName
 		}
-		return installPluginFromRelease(gh.GithubRepo, gh.TagPrefix, gh.PkgName, version, githubToken, allowDrafts, force, check)
+		if err := installPluginFromRelease(gh.GithubRepo, gh.TagPrefix, gh.PkgName, version, githubToken, allowDrafts, force, check); err != nil {
+			return withLocalPathHint(ref, err)
+		}
+		return nil
 	case parsed.PluginName != "":
 		// A registry entry's asset is already pinned, so --plugin-name has
 		// nothing to disambiguate.
@@ -167,10 +170,8 @@ func InstallPluginHandler(ctx *cmdctx.Ctx) error {
 	}
 }
 
-// looksLikePath reports whether ref should be treated as a filesystem path
-// rather than a registry name or a GitHub ref. Only these three forms count —
-// there is no filesystem probing here, so a bareword or a relative path
-// without "./" is never silently treated as a path.
+// looksLikePath deliberately excludes bare relative paths (e.g. "foo/bar") —
+// those are parsed as GitHub owner/repo refs instead.
 func looksLikePath(ref string) bool {
 	return filepath.IsAbs(ref) || strings.HasPrefix(ref, "~/") || strings.HasPrefix(ref, "./")
 }
@@ -194,6 +195,15 @@ func splitGitHubRef(ref string) (owner, repoName, prefix string, ok bool) {
 	return owner, repoName, prefix, true
 }
 
+// withLocalPathHint covers a relative path like "devhome/bin/harness-har",
+// indistinguishable from an owner/repo ref to parsePluginRef.
+func withLocalPathHint(ref string, err error) error {
+	if _, statErr := os.Stat(ref); statErr != nil {
+		return err
+	}
+	return fmt.Errorf("%w\n\n%q exists on disk — to install from a local path, prefix it with \"./\" (e.g. %q)", err, ref, "./"+ref)
+}
+
 // installRegistryPlugin installs a plugin named in pluginRegistry. Its repo is
 // always release.Repo and its pkgName is always known, so it's a thin wrapper
 // over installPluginFromRelease, which also serves the generic
@@ -207,16 +217,6 @@ func installRegistryPlugin(name, version, githubToken string, allowDrafts, force
 	return installPluginFromRelease(entry.GithubRepo, entry.TagPrefix, entry.PkgName, version, githubToken, allowDrafts, force, check)
 }
 
-// installAllRegistryPlugins updates every registry-known plugin that is
-// currently installed to its own latest release. "all" has no single version
-// to install — each plugin releases independently of core and of every other
-// plugin — so a caller-supplied --version is rejected rather than silently
-// ignored or applied to every plugin. --force is rejected too: forcing a
-// reinstall of every plugin regardless of its own up-to-date state is a
-// per-plugin decision, made by naming that plugin directly. --github-token
-// and --allow-drafts are rejected as well — every registry plugin releases
-// from release.Repo under core's own visible, non-draft release process, so
-// neither flag has anything to do for a registry name.
 func installAllRegistryPlugins(version, githubToken string, allowDrafts, force, check bool) error {
 	if version != "" && version != "latest" {
 		return fmt.Errorf(`--version is not valid with "all" — each plugin releases independently, so there is no single version to install`)
@@ -276,7 +276,7 @@ func installPluginFromRelease(repo, prefix, pkgName, version, githubToken string
 
 	rel, resolvedVersion, err := resolveReleaseForPrefix(repo, prefix, version, githubToken, allowDrafts)
 	if err != nil {
-		return fmt.Errorf("version %s not found in %s: %w", versionLabel(version), repo, err)
+		return fmt.Errorf("version %s not found in github.com/%s: %w", versionLabel(version), repo, err)
 	}
 
 	var asset *release.Asset

--- a/modules/core/mgmt/install_plugin.go
+++ b/modules/core/mgmt/install_plugin.go
@@ -31,8 +31,9 @@ import (
 // publishes to, and the tag prefix its releases are published under ("" means
 // core's own bare "vX.Y.Z" convention rather than "{TagPrefix}/vX.Y.Z").
 // PkgName is the release package name when already known — always true for a
-// registry entry, never true for a ref parsed from owner/repo[/prefix]
-// syntax, where it's discovered from the release's own assets instead.
+// registry entry. For a ref parsed from owner/repo[/prefix] syntax it starts
+// empty and is either discovered from the release's own assets, or supplied
+// via --plugin-name.
 type GithubPluginRef struct {
 	GithubRepo string
 	TagPrefix  string
@@ -62,18 +63,21 @@ func registryNames() string {
 }
 
 // pluginRef is the parsed shape of an install-plugin <ref> argument — exactly
-// one of URL, LocalPath, or GithubRef is set.
+// one of URL, LocalPath, PluginName, or GithubRef is set.
 type pluginRef struct {
-	URL       string
-	LocalPath string
-	GithubRef *GithubPluginRef
+	URL        string
+	LocalPath  string
+	PluginName string
+	GithubRef  *GithubPluginRef
 }
 
 // parsePluginRef classifies an install-plugin <ref> argument as a tarball URL,
-// a local path, or a GitHub plugin ref — the latter either parsed from
-// owner/repo[/prefix] syntax, or resolved from a bare registry name via
-// pluginRegistry. It touches no filesystem or network, so every branch of the
-// classification is unit-testable on its own.
+// a local path, a GitHub plugin ref parsed from owner/repo[/prefix] syntax, or
+// a bare plugin name — the latter left for the caller to resolve against
+// pluginRegistry, since a registry name and a raw GitHub ref are resolved
+// differently (e.g. --plugin-name is meaningless for the former). It touches
+// no filesystem or network, so every branch of the classification is
+// unit-testable on its own.
 func parsePluginRef(ref string) (pluginRef, error) {
 	switch {
 	case strings.HasPrefix(ref, "http://"), strings.HasPrefix(ref, "https://"):
@@ -91,16 +95,11 @@ func parsePluginRef(ref string) (pluginRef, error) {
 			return pluginRef{}, fmt.Errorf("%q is not a valid owner/repo or owner/repo/prefix GitHub ref", ref)
 		}
 		return pluginRef{GithubRef: &GithubPluginRef{GithubRepo: owner + "/" + repoName, TagPrefix: prefix}}, nil
-	default:
+	case plugin.ValidateName(ref) == nil:
 		// Bare name → registry lookup. Same path `install module` takes.
-		if err := plugin.ValidateName(ref); err != nil {
-			return pluginRef{}, fmt.Errorf("%q is not a URL, an existing file, an owner/repo ref, or a valid plugin name — supported names: %s", ref, registryNames())
-		}
-		entry, ok := pluginRegistry[ref]
-		if !ok {
-			return pluginRef{}, fmt.Errorf("unknown plugin %q — supported: %s\n\nTo install an unregistered plugin, pass its tarball URL, path, or owner/repo ref", ref, registryNames())
-		}
-		return pluginRef{GithubRef: &entry}, nil
+		return pluginRef{PluginName: ref}, nil
+	default:
+		return pluginRef{}, fmt.Errorf("%q is not a URL, an existing file, an owner/repo ref, or a valid plugin name — supported names: %s", ref, registryNames())
 	}
 }
 
@@ -150,12 +149,19 @@ func InstallPluginHandler(ctx *cmdctx.Ctx) error {
 		return nil
 	case parsed.GithubRef != nil:
 		gh := *parsed.GithubRef
-		// --plugin-name only disambiguates a ref whose pkgName isn't already
-		// known — a registry entry's asset is already pinned.
-		if gh.PkgName == "" && pluginName != "" {
+		// --plugin-name disambiguates a release with more than one plugin
+		// asset, since the pkgName here is never known ahead of time.
+		if pluginName != "" {
 			gh.PkgName = plugin.BinaryPrefix + "plugin-" + pluginName
 		}
 		return installPluginFromRelease(gh.GithubRepo, gh.TagPrefix, gh.PkgName, version, githubToken, allowDrafts, force, check)
+	case parsed.PluginName != "":
+		// A registry entry's asset is already pinned, so --plugin-name has
+		// nothing to disambiguate.
+		if pluginName != "" {
+			return fmt.Errorf("--plugin-name is not valid with %q — its release asset name is already known", parsed.PluginName)
+		}
+		return installRegistryPlugin(parsed.PluginName, version, githubToken, allowDrafts, force, check)
 	default:
 		return fmt.Errorf("internal error: parsePluginRef(%q) returned no variant", ref)
 	}
@@ -196,7 +202,7 @@ func splitGitHubRef(ref string) (owner, repoName, prefix string, ok bool) {
 func installRegistryPlugin(name, version, githubToken string, allowDrafts, force, check bool) error {
 	entry, ok := pluginRegistry[name]
 	if !ok {
-		return fmt.Errorf("unknown plugin %q — supported: %s", name, registryNames())
+		return fmt.Errorf("unknown plugin %q — supported: %s\n\nTo install an unregistered plugin, pass its tarball URL, path, or owner/repo ref", name, registryNames())
 	}
 	return installPluginFromRelease(entry.GithubRepo, entry.TagPrefix, entry.PkgName, version, githubToken, allowDrafts, force, check)
 }

--- a/modules/core/mgmt/install_plugin_test.go
+++ b/modules/core/mgmt/install_plugin_test.go
@@ -10,7 +10,158 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/harness/cli/pkg/release"
 )
+
+func TestLooksLikePath(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"/abs/path/foo.tar.gz", true},
+		{"~/foo.tar.gz", true},
+		{"./foo.tar.gz", true},
+		{"./bin/harness-har", true},
+		{"foo.tar.gz", false},          // bareword, no marker — not a path
+		{"dist/foo.tar.gz", false},     // relative with a slash but no "./" — not a path
+		{"harness-har", false},         // bareword, even if a same-named file exists in cwd
+		{"someorg/some-plugin", false}, // owner/repo shape
+		{"~foo/bar", false},            // "~" not followed by "/" doesn't count
+	}
+	for _, tt := range tests {
+		if got := looksLikePath(tt.ref); got != tt.want {
+			t.Errorf("looksLikePath(%q) = %v, want %v", tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestSplitGitHubRef(t *testing.T) {
+	tests := []struct {
+		ref                             string
+		wantOwner, wantRepo, wantPrefix string
+		wantOK                          bool
+	}{
+		{"someorg/some-plugin", "someorg", "some-plugin", "", true},
+		{"someorg/some-plugin/myplugin", "someorg", "some-plugin", "myplugin", true},
+		{"a/b/c/d", "", "", "", false},
+		{"onlyoneword", "", "", "", false},
+		{"owner/", "", "", "", false},
+		{"/repo", "", "", "", false},
+		{"owner/repo/", "", "", "", false},
+	}
+	for _, tt := range tests {
+		owner, repoName, prefix, ok := splitGitHubRef(tt.ref)
+		if ok != tt.wantOK || owner != tt.wantOwner || repoName != tt.wantRepo || prefix != tt.wantPrefix {
+			t.Errorf("splitGitHubRef(%q) = (%q, %q, %q, %v), want (%q, %q, %q, %v)",
+				tt.ref, owner, repoName, prefix, ok, tt.wantOwner, tt.wantRepo, tt.wantPrefix, tt.wantOK)
+		}
+	}
+}
+
+func TestParsePluginRef(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want pluginRef
+	}{
+		{"url", "https://example.com/foo.tar.gz", pluginRef{URL: "https://example.com/foo.tar.gz"}},
+		{"http url", "http://example.com/foo.tar.gz", pluginRef{URL: "http://example.com/foo.tar.gz"}},
+		{"absolute path", "/abs/path/foo.tar.gz", pluginRef{LocalPath: "/abs/path/foo.tar.gz"}},
+		{"home path", "~/foo.tar.gz", pluginRef{LocalPath: "~/foo.tar.gz"}},
+		{"dot path", "./foo.tar.gz", pluginRef{LocalPath: "./foo.tar.gz"}},
+		{
+			"owner/repo", "someorg/some-plugin",
+			pluginRef{GithubRef: &GithubPluginRef{GithubRepo: "someorg/some-plugin"}},
+		},
+		{
+			"owner/repo/prefix", "someorg/some-plugin/myplugin",
+			pluginRef{GithubRef: &GithubPluginRef{GithubRepo: "someorg/some-plugin", TagPrefix: "myplugin"}},
+		},
+		{
+			"registry name", "har",
+			pluginRef{GithubRef: &GithubPluginRef{GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePluginRef(tt.ref)
+			if err != nil {
+				t.Fatalf("parsePluginRef(%q): %v", tt.ref, err)
+			}
+			if got.URL != tt.want.URL || got.LocalPath != tt.want.LocalPath {
+				t.Fatalf("parsePluginRef(%q) = %+v, want %+v", tt.ref, got, tt.want)
+			}
+			switch {
+			case tt.want.GithubRef == nil && got.GithubRef != nil:
+				t.Fatalf("parsePluginRef(%q).GithubRef = %+v, want nil", tt.ref, got.GithubRef)
+			case tt.want.GithubRef != nil && got.GithubRef == nil:
+				t.Fatalf("parsePluginRef(%q).GithubRef = nil, want %+v", tt.ref, tt.want.GithubRef)
+			case tt.want.GithubRef != nil && *got.GithubRef != *tt.want.GithubRef:
+				t.Fatalf("parsePluginRef(%q).GithubRef = %+v, want %+v", tt.ref, got.GithubRef, tt.want.GithubRef)
+			}
+		})
+	}
+
+	errTests := []struct {
+		name, ref, wantSubstr string
+	}{
+		{"bad archive ref", "dist/foo.tar.gz", "not a path harness recognizes"},
+		{"bad github ref shape", "a/b/c/d", "not a valid owner/repo"},
+		{"unknown registry name", "notaplugin", "unknown plugin"},
+		{"invalid plugin name syntax", "Not_Valid", "not a URL, an existing file"},
+	}
+	for _, tt := range errTests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parsePluginRef(tt.ref)
+			if err == nil {
+				t.Fatalf("parsePluginRef(%q): expected an error", tt.ref)
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("parsePluginRef(%q) error = %v, want it to contain %q", tt.ref, err, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestDiscoverPluginAsset(t *testing.T) {
+	rel := &release.Release{
+		TagName: "v1.2.3",
+		Assets: []release.Asset{
+			{Name: "harness-core_1.2.3_darwin_amd64.tar.gz"},
+			{Name: "harness-plugin-har_1.2.3_darwin_amd64.tar.gz"},
+			{Name: "harness-plugin-har_1.2.3_linux_amd64.tar.gz"},
+			{Name: "harness_1.2.3_checksums.txt"},
+		},
+	}
+	asset, name, err := discoverPluginAsset(rel, "v1.2.3", "darwin_amd64")
+	if err != nil {
+		t.Fatalf("discoverPluginAsset: %v", err)
+	}
+	if name != "har" {
+		t.Errorf("name = %q, want %q", name, "har")
+	}
+	if asset.Name != "harness-plugin-har_1.2.3_darwin_amd64.tar.gz" {
+		t.Errorf("asset = %q, want the darwin_amd64 asset", asset.Name)
+	}
+
+	if _, _, err := discoverPluginAsset(rel, "v1.2.3", "windows_amd64"); err == nil {
+		t.Fatal("expected an error for a platform with no plugin asset")
+	}
+
+	multi := &release.Release{
+		TagName: "v1.2.3",
+		Assets: []release.Asset{
+			{Name: "harness-plugin-har_1.2.3_darwin_amd64.tar.gz"},
+			{Name: "harness-plugin-foo_1.2.3_darwin_amd64.tar.gz"},
+		},
+	}
+	if _, _, err := discoverPluginAsset(multi, "v1.2.3", "darwin_amd64"); err == nil {
+		t.Fatal("expected an error when more than one plugin asset matches")
+	} else if !strings.Contains(err.Error(), "--plugin-name") {
+		t.Fatalf("error = %v, want it to mention --plugin-name", err)
+	}
+}
 
 func TestIsArchive(t *testing.T) {
 	tests := []struct {

--- a/modules/core/mgmt/install_plugin_test.go
+++ b/modules/core/mgmt/install_plugin_test.go
@@ -80,7 +80,11 @@ func TestParsePluginRef(t *testing.T) {
 		},
 		{
 			"registry name", "har",
-			pluginRef{GithubRef: &GithubPluginRef{GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har"}},
+			pluginRef{PluginName: "har"},
+		},
+		{
+			"unregistered but valid name", "notaplugin",
+			pluginRef{PluginName: "notaplugin"},
 		},
 	}
 	for _, tt := range tests {
@@ -89,7 +93,7 @@ func TestParsePluginRef(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parsePluginRef(%q): %v", tt.ref, err)
 			}
-			if got.URL != tt.want.URL || got.LocalPath != tt.want.LocalPath {
+			if got.URL != tt.want.URL || got.LocalPath != tt.want.LocalPath || got.PluginName != tt.want.PluginName {
 				t.Fatalf("parsePluginRef(%q) = %+v, want %+v", tt.ref, got, tt.want)
 			}
 			switch {
@@ -108,7 +112,6 @@ func TestParsePluginRef(t *testing.T) {
 	}{
 		{"bad archive ref", "dist/foo.tar.gz", "not a path harness recognizes"},
 		{"bad github ref shape", "a/b/c/d", "not a valid owner/repo"},
-		{"unknown registry name", "notaplugin", "unknown plugin"},
 		{"invalid plugin name syntax", "Not_Valid", "not a URL, an existing file"},
 	}
 	for _, tt := range errTests {
@@ -121,6 +124,16 @@ func TestParsePluginRef(t *testing.T) {
 				t.Fatalf("parsePluginRef(%q) error = %v, want it to contain %q", tt.ref, err, tt.wantSubstr)
 			}
 		})
+	}
+}
+
+func TestInstallRegistryPluginUnknownName(t *testing.T) {
+	err := installRegistryPlugin("notaplugin", "", "", false, false, false)
+	if err == nil {
+		t.Fatal("installRegistryPlugin(\"notaplugin\"): expected an error")
+	}
+	if !strings.Contains(err.Error(), "unknown plugin") {
+		t.Fatalf("installRegistryPlugin(\"notaplugin\") error = %v, want it to contain %q", err, "unknown plugin")
 	}
 }
 

--- a/pkg/hbase/hbase.go
+++ b/pkg/hbase/hbase.go
@@ -27,8 +27,12 @@ var BuildTime = ""
 // TimeoutExitCode is the exit code used when a command is killed by --timeout.
 const TimeoutExitCode = 124
 
-// PostUpgradeFlag is the hidden flag `install cli` passes to the binary it just installed. See rootcmd.MaybeRunPostUpgrade.
-const PostUpgradeFlag = "--post-upgrade"
+// Hidden flags. See the corresponding rootcmd.MaybeRun* function for each.
+const (
+	PostUpgradeFlag           = "--post-upgrade"
+	PostInstallFlag           = "--post-install"
+	BackgroundUpdateCheckFlag = "--background-update-check"
+)
 
 const (
 	HarnessHome         = "~/.harness"

--- a/pkg/hbase/hbase.go
+++ b/pkg/hbase/hbase.go
@@ -27,6 +27,9 @@ var BuildTime = ""
 // TimeoutExitCode is the exit code used when a command is killed by --timeout.
 const TimeoutExitCode = 124
 
+// PostUpgradeFlag is the hidden flag `install cli` passes to the binary it just installed. See rootcmd.MaybeRunPostUpgrade.
+const PostUpgradeFlag = "--post-upgrade"
+
 const (
 	HarnessHome         = "~/.harness"
 	ConfigFileName      = "config.yaml"

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -57,9 +57,6 @@ type Release struct {
 }
 
 const (
-	// FlagName is the hidden flag that triggers the background subprocess behavior.
-	FlagName = "--background-update-check"
-
 	cacheFile = "update-check.json"
 	// Repo is the GitHub repo for Harness CLI releases.
 	Repo          = "harness/cli"
@@ -109,7 +106,7 @@ func MaybeSpawn() {
 		return
 	}
 	hlog.Debug("spawning background update check", "exe", exe)
-	cmd := exec.Command(exe, FlagName)
+	cmd := exec.Command(exe, hbase.BackgroundUpdateCheckFlag)
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil

--- a/pkg/rootcmd/rootcmd.go
+++ b/pkg/rootcmd/rootcmd.go
@@ -21,36 +21,39 @@ import (
 	"github.com/harness/cli/pkg/telemetry"
 )
 
-// MaybeRunBackgroundUpdateCheck exits if this invocation is the background update subprocess.
-func MaybeRunBackgroundUpdateCheck() {
-	for _, arg := range os.Args[1:] {
-		if arg == release.FlagName {
-			release.RunBackgroundCheck()
-			os.Exit(0)
-		}
+// firstArg returns os.Args[1], or "" if no argument was passed.
+func firstArg() string {
+	if len(os.Args) > 1 {
+		return os.Args[1]
 	}
+	return ""
 }
 
-// postInstallFlag is the hidden flag the installers (install.sh, install.ps1,
-// the Homebrew cask's postflight hook) invoke right after placing a fresh
-// binary on disk, purely to fire a cli_installed telemetry event.
-const postInstallFlag = "--post-install"
+// MaybeRunBackgroundUpdateCheck exits if this invocation is the background update subprocess.
+// The flag is always passed as the sole argument (see release.MaybeSpawn), so only os.Args[1] is checked.
+func MaybeRunBackgroundUpdateCheck() {
+	if firstArg() != hbase.BackgroundUpdateCheckFlag {
+		return
+	}
+	release.RunBackgroundCheck()
+	os.Exit(0)
+}
 
 // MaybeRunPostInstall exits if this invocation is an installer's post-install
 // telemetry ping. Respects the same opt-out as every other event.
+// The flag is always passed as the sole argument (see install.sh/install.ps1), so only os.Args[1] is checked.
 func MaybeRunPostInstall() {
-	for _, arg := range os.Args[1:] {
-		if arg == postInstallFlag {
-			flush := telemetry.Init()
-			telemetry.RecordInstall(telemetry.InstallEvent{
-				RunID:       hbase.RunID,
-				InstallType: telemetry.ResolveInstallType(),
-				Env:         telemetry.NewEnv(),
-			})
-			flush()
-			os.Exit(0)
-		}
+	if firstArg() != hbase.PostInstallFlag {
+		return
 	}
+	flush := telemetry.Init()
+	telemetry.RecordInstall(telemetry.InstallEvent{
+		RunID:       hbase.RunID,
+		InstallType: telemetry.ResolveInstallType(),
+		Env:         telemetry.NewEnv(),
+	})
+	flush()
+	os.Exit(0)
 }
 
 // MaybeRunPostUpgrade exits if this invocation is install cli's post-upgrade
@@ -63,12 +66,12 @@ func MaybeRunPostInstall() {
 // only the new binary's code knows how to do, without the old binary needing
 // to know about it. The flag itself lives in hbase, not here, since
 // modules/core/mgmt invokes it and can't depend on rootcmd. No-op today.
+// The flag is always passed as the sole argument (see runInstalledBinary), so only os.Args[1] is checked.
 func MaybeRunPostUpgrade() {
-	for _, arg := range os.Args[1:] {
-		if arg == hbase.PostUpgradeFlag {
-			os.Exit(0)
-		}
+	if firstArg() != hbase.PostUpgradeFlag {
+		return
 	}
+	os.Exit(0)
 }
 
 // MaybeCheckSpecs runs spec validation and exits if HARNESS_CHECKSPECS=1, otherwise returns immediately.

--- a/pkg/rootcmd/rootcmd.go
+++ b/pkg/rootcmd/rootcmd.go
@@ -57,16 +57,10 @@ func MaybeRunPostInstall() {
 }
 
 // MaybeRunPostUpgrade exits if this invocation is install cli's post-upgrade
-// hook (hbase.PostUpgradeFlag), run against the binary it just installed (or
-// confirmed already up to date) right after that binary's own
-// "install plugin all" has brought plugins to their own latest. Unlike
-// postInstallFlag — fired by external installer scripts that have no context
-// on what changed — this is invoked by our own upgrade code specifically so a
-// future release can do upgrade-finishing work (migrations, cleanup) that
-// only the new binary's code knows how to do, without the old binary needing
-// to know about it. The flag itself lives in hbase, not here, since
-// modules/core/mgmt invokes it and can't depend on rootcmd. No-op today.
-// The flag is always passed as the sole argument (see runInstalledBinary), so only os.Args[1] is checked.
+// hook (hbase.PostUpgradeFlag), run against the newly installed binary right
+// after "install plugin all" has brought plugins to their own latest. No-op
+// today. The flag is always passed as the sole argument (see
+// runInstalledBinary), so only os.Args[1] is checked.
 func MaybeRunPostUpgrade() {
 	if firstArg() != hbase.PostUpgradeFlag {
 		return

--- a/pkg/rootcmd/rootcmd.go
+++ b/pkg/rootcmd/rootcmd.go
@@ -53,6 +53,24 @@ func MaybeRunPostInstall() {
 	}
 }
 
+// MaybeRunPostUpgrade exits if this invocation is install cli's post-upgrade
+// hook (hbase.PostUpgradeFlag), run against the binary it just installed (or
+// confirmed already up to date) right after that binary's own
+// "install plugin all" has brought plugins to their own latest. Unlike
+// postInstallFlag — fired by external installer scripts that have no context
+// on what changed — this is invoked by our own upgrade code specifically so a
+// future release can do upgrade-finishing work (migrations, cleanup) that
+// only the new binary's code knows how to do, without the old binary needing
+// to know about it. The flag itself lives in hbase, not here, since
+// modules/core/mgmt invokes it and can't depend on rootcmd. No-op today.
+func MaybeRunPostUpgrade() {
+	for _, arg := range os.Args[1:] {
+		if arg == hbase.PostUpgradeFlag {
+			os.Exit(0)
+		}
+	}
+}
+
 // MaybeCheckSpecs runs spec validation and exits if HARNESS_CHECKSPECS=1, otherwise returns immediately.
 func MaybeCheckSpecs(reg *registry.Registry) {
 	if os.Getenv(hbase.EnvCheckSpecs) != "1" {

--- a/pkg/spec/core.spec.yaml
+++ b/pkg/spec/core.spec.yaml
@@ -357,8 +357,6 @@ commands:
       Install a plugin into the harness home directory (~/.harness).
 
       <ref> may be:
-        - "all", to update every registry plugin that is currently installed
-          to its own latest release
         - a plugin name, resolved to a Harness release (currently: har)
         - an owner/repo GitHub ref, resolved to that repo's latest release
         - an owner/repo/prefix GitHub ref, for a repo whose releases are tagged
@@ -366,33 +364,19 @@ commands:
         - a tarball URL
         - a local tarball
         - a local plugin binary
+        - "all", to update every installed registry plugin to its own latest release
 
       A local path must be absolute, or start with "./" or "~/" — anything else
       with a slash is parsed as a GitHub ref instead.
 
       --version, --force, and --check apply to the plugin-name and GitHub-ref
-      forms; a URL or path already names a specific artifact and is always
-      installed. Version defaults to "latest".
-
-      --plugin-name disambiguates a GitHub-ref install when the release ships
-      more than one plugin asset for the platform; it has no effect on the
-      plugin-name form, where the asset is already known.
-
-      "all" installs each currently-installed registry plugin at its own
-      latest — it does not install plugins that were never installed.
-      --version and --force are rejected: there is no single version across
-      plugins that release independently, and forcing every plugin to
-      reinstall regardless of its own state is a per-plugin decision made by
-      naming that plugin directly. --github-token and --allow-drafts are
-      rejected too, since registry plugins are never behind a private or
-      draft release. --check applies to every plugin; a failure on one
-      plugin is reported and skipped rather than aborting the rest.
+      forms only; a URL or path installs directly. "all" only accepts --check.
 
       Examples:
         harness install plugin har                             # install by name
-        harness install plugin all                              # update every installed registry plugin
-        harness install plugin someorg/some-plugin              # install from a GitHub repo's latest release
-        harness install plugin someorg/some-plugin/myplugin     # install from a repo tagged myplugin/vX.Y.Z
+        harness install plugin all                             # update every installed registry plugin
+        harness install plugin someorg/some-plugin             # install from a GitHub repo's latest release
+        harness install plugin someorg/some-plugin/myplugin    # install from a repo tagged myplugin/vX.Y.Z
         harness install plugin https://example.com/foo.tar.gz  # install from a tarball URL
         harness install plugin ./foo.tar.gz                    # install from a local tarball
         harness install plugin ./bin/harness-har               # install from a local binary
@@ -417,7 +401,7 @@ commands:
         hidden: true
         description: Include draft releases when resolving "latest" (requires --github-token)
       - name: plugin-name
-        description: Plugin to pick when a GitHub-ref release ships more than one plugin asset for the platform
+        description: Plugin to pick when a GitHub-ref release ships more than one plugin asset for the platform (uncommon)
 
   - command: list module
     verb: list

--- a/pkg/spec/core.spec.yaml
+++ b/pkg/spec/core.spec.yaml
@@ -357,6 +357,8 @@ commands:
       Install a plugin into the harness home directory (~/.harness).
 
       <ref> may be:
+        - "all", to update every registry plugin that is currently installed
+          to its own latest release
         - a plugin name, resolved to a Harness release (currently: har)
         - an owner/repo GitHub ref, resolved to that repo's latest release
         - an owner/repo/prefix GitHub ref, for a repo whose releases are tagged
@@ -376,8 +378,19 @@ commands:
       more than one plugin asset for the platform; it has no effect on the
       plugin-name form, where the asset is already known.
 
+      "all" installs each currently-installed registry plugin at its own
+      latest — it does not install plugins that were never installed.
+      --version and --force are rejected: there is no single version across
+      plugins that release independently, and forcing every plugin to
+      reinstall regardless of its own state is a per-plugin decision made by
+      naming that plugin directly. --github-token and --allow-drafts are
+      rejected too, since registry plugins are never behind a private or
+      draft release. --check applies to every plugin; a failure on one
+      plugin is reported and skipped rather than aborting the rest.
+
       Examples:
         harness install plugin har                             # install by name
+        harness install plugin all                              # update every installed registry plugin
         harness install plugin someorg/some-plugin              # install from a GitHub repo's latest release
         harness install plugin someorg/some-plugin/myplugin     # install from a repo tagged myplugin/vX.Y.Z
         harness install plugin https://example.com/foo.tar.gz  # install from a tarball URL

--- a/pkg/spec/core.spec.yaml
+++ b/pkg/spec/core.spec.yaml
@@ -358,16 +358,28 @@ commands:
 
       <ref> may be:
         - a plugin name, resolved to a Harness release (currently: har)
+        - an owner/repo GitHub ref, resolved to that repo's latest release
+        - an owner/repo/prefix GitHub ref, for a repo whose releases are tagged
+          "{prefix}/vX.Y.Z" rather than a bare "vX.Y.Z"
         - a tarball URL
         - a local tarball
         - a local plugin binary
 
-      --version, --force, and --check apply only to the plugin-name form; a URL or
-      path already names a specific artifact and is always installed. Version
-      defaults to "latest".
+      A local path must be absolute, or start with "./" or "~/" — anything else
+      with a slash is parsed as a GitHub ref instead.
+
+      --version, --force, and --check apply to the plugin-name and GitHub-ref
+      forms; a URL or path already names a specific artifact and is always
+      installed. Version defaults to "latest".
+
+      --plugin-name disambiguates a GitHub-ref install when the release ships
+      more than one plugin asset for the platform; it has no effect on the
+      plugin-name form, where the asset is already known.
 
       Examples:
         harness install plugin har                             # install by name
+        harness install plugin someorg/some-plugin              # install from a GitHub repo's latest release
+        harness install plugin someorg/some-plugin/myplugin     # install from a repo tagged myplugin/vX.Y.Z
         harness install plugin https://example.com/foo.tar.gz  # install from a tarball URL
         harness install plugin ./foo.tar.gz                    # install from a local tarball
         harness install plugin ./bin/harness-har               # install from a local binary
@@ -391,6 +403,8 @@ commands:
         is_bool: true
         hidden: true
         description: Include draft releases when resolving "latest" (requires --github-token)
+      - name: plugin-name
+        description: Plugin to pick when a GitHub-ref release ships more than one plugin asset for the platform
 
   - command: list module
     verb: list


### PR DESCRIPTION
- `install plugin` now accepts an `owner/repo` or `owner/repo/prefix` GitHub ref, not just a registered bare name — the asset and plugin name are discovered from the release itself (`--plugin-name` disambiguates if a release ships more than one plugin for the platform).
- `install plugin all` upgrades every currently-installed registry plugin to its own latest release in one call; a failure on one plugin is reported and skipped rather than aborting the rest.
- `install cli` now upgrades plugins by shelling out to the *newly installed* binary's own `install plugin all` instead of running the old process's plugin-install code, so plugin-install changes ship with the release that introduces them. It also runs a new `--post-upgrade` hook on the new binary afterward, for future upgrade-finishing work (no-op today).
- Internal cleanup: hidden CLI flags (`--post-install`, `--post-upgrade`, `--background-update-check`) are consolidated as constants in `pkg/hbase`, and the registry/GitHub-ref plugin install paths are unified behind a single `installPluginFromRelease`.