### PR TITLE
Add migrate as a registered plugin module

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -131,12 +131,14 @@ function Install-HarnessBinaries {
 
         # A failure here still leaves a working core, so note it instead of aborting.
         if (-not $CoreOnly) {
-            Write-Info "Installing har module..."
-            & $coreTarget install module har 2>$null | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-                Write-Ok "Installed har module to ~\.harness\bin"
-            } else {
-                Write-Note "Could not install the har module - run 'harness install module har' to retry"
+            foreach ($module in @("har", "migrate")) {
+                Write-Info "Installing $module module..."
+                & $coreTarget install module $module 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Ok "Installed $module module to ~\.harness\bin"
+                } else {
+                    Write-Note "Could not install the $module module - run 'harness install module $module' to retry"
+                }
             }
         }
     } finally {

--- a/install.sh
+++ b/install.sh
@@ -131,12 +131,15 @@ download_and_install() {
 
     # A failure here still leaves a working core, so warn instead of aborting.
     if [ -z "$CORE_ONLY" ]; then
-        info "Installing har module..."
-        if "$dest/harness" install module har >/dev/null 2>&1; then
-            success "Installed har module to ~/.harness/bin"
-        else
-            warn "Could not install the har module — run 'harness install module har' to retry"
-        fi
+        local module
+        for module in har migrate; do
+            info "Installing $module module..."
+            if "$dest/harness" install module "$module" >/dev/null 2>&1; then
+                success "Installed $module module to ~/.harness/bin"
+            else
+                warn "Could not install the $module module — run 'harness install module $module' to retry"
+            fi
+        done
     fi
 
     rm -rf "$tmp"

--- a/modules/core/mgmt/install_plugin.go
+++ b/modules/core/mgmt/install_plugin.go
@@ -50,7 +50,8 @@ type GithubPluginRef struct {
 // own "{TagPrefix}/vX.Y.Z" tag on release.Repo — a module shipping a fix does
 // not wait on core's release cadence.
 var pluginRegistry = map[string]GithubPluginRef{
-	"har": {GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har"},
+	"har":     {GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har"},
+	"migrate": {GithubRepo: release.Repo, TagPrefix: "migrate", PkgName: "harness-plugin-migrate"},
 }
 
 func registryNames() string {

--- a/pkg/spec/core.spec.yaml
+++ b/pkg/spec/core.spec.yaml
@@ -357,7 +357,7 @@ commands:
       Install a plugin into the harness home directory (~/.harness).
 
       <ref> may be:
-        - a plugin name, resolved to a Harness release (currently: har)
+        - a plugin name, resolved to a Harness release (currently: har, migrate)
         - an owner/repo GitHub ref, resolved to that repo's latest release
         - an owner/repo/prefix GitHub ref, for a repo whose releases are tagged
           "{prefix}/vX.Y.Z" rather than a bare "vX.Y.Z"


### PR DESCRIPTION
## Summary
- Registers `migrate` in `pluginRegistry` alongside `har` — releases posted to
  `harness/cli` under the `migrate/vX.Y.Z` tag prefix — so `harness install
  module migrate` and `harness install plugin migrate` resolve it as a bare
  word, same as `har`.
- `migrate` now participates in `install plugin all` and `install cli`'s
  module-refresh loop automatically, since both iterate the registry map.
- `install.sh` / `install.ps1` now install `migrate` by default alongside
  `har` (skipped by `--core`/`-Core`, same as `har`).
- Updated the `install plugin` help text's registry-name list.

## Test plan
- [x] `go build ./...`
- [x] `go test ./modules/core/...`
- [x] `task check:specs:main`
- [x] `harness install plugin migrate --check` / `harness install module
      migrate --check` resolve as a known registry plugin (fails only on the
      missing `migrate/vX.Y.Z` release tag, expected until a release is cut)
