### PR TITLE
populate uninstalled module descriptions

### DIFF
--- a/cmd/harness/main-harness.go
+++ b/cmd/harness/main-harness.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/harness/cli/modules/code"
 	"github.com/harness/cli/modules/core"
+	"github.com/harness/cli/modules/core/mgmt"
 	"github.com/harness/cli/modules/gitops"
 	"github.com/harness/cli/modules/iacm"
 	"github.com/harness/cli/modules/pipeline"
@@ -74,12 +75,15 @@ func main() {
 }
 
 func renderModules(metas []spec.ModuleMeta) string {
+	seen := map[string]bool{}
 	var visible []spec.ModuleMeta
 	for _, m := range metas {
+		seen[m.Name] = true
 		if !m.Core {
 			visible = append(visible, m)
 		}
 	}
+	visible = append(visible, mgmt.UninstalledRegistryPlugins(seen)...)
 
 	// find longest name for alignment
 	maxLen := 0

--- a/modules/core/mgmt/install_plugin.go
+++ b/modules/core/mgmt/install_plugin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/harness/cli/pkg/hlog"
 	"github.com/harness/cli/pkg/plugin"
 	"github.com/harness/cli/pkg/release"
+	"github.com/harness/cli/pkg/spec"
 	"github.com/harness/cli/pkg/specloader"
 )
 
@@ -38,6 +39,11 @@ type GithubPluginRef struct {
 	GithubRepo string
 	TagPrefix  string
 	PkgName    string
+	// Desc is a one-line summary shown in `list module`/`list plugin` for
+	// registry plugins that aren't installed — the module's own spec (and its
+	// module_desc) isn't loaded until install, so this is the only
+	// description available before then.
+	Desc string
 }
 
 // pluginRegistry is the optional name→artifact resolver behind the bare-name
@@ -50,8 +56,28 @@ type GithubPluginRef struct {
 // own "{TagPrefix}/vX.Y.Z" tag on release.Repo — a module shipping a fix does
 // not wait on core's release cadence.
 var pluginRegistry = map[string]GithubPluginRef{
-	"har":     {GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har"},
-	"migrate": {GithubRepo: release.Repo, TagPrefix: "migrate", PkgName: "harness-plugin-migrate"},
+	"har":     {GithubRepo: release.Repo, TagPrefix: "har", PkgName: "harness-plugin-har", Desc: "Harness Artifact Registry (push and pull artifacts)"},
+	"migrate": {GithubRepo: release.Repo, TagPrefix: "migrate", PkgName: "harness-plugin-migrate", Desc: "Migrate repos, pull requests and pipelines into Harness from another SCM"},
+}
+
+// UninstalledRegistryPlugins returns registry-known plugins that aren't in
+// seen (keyed by module name), as ModuleMeta stubs carrying only Name/Type/Desc.
+// Registry plugins aren't loaded until installed, so they're otherwise absent
+// from GetModuleMetas() — this is how callers like `list module` and the
+// no-args `harness` summary surface them as available-but-not-installed.
+func UninstalledRegistryPlugins(seen map[string]bool) []spec.ModuleMeta {
+	names := make([]string, 0, len(pluginRegistry))
+	for name := range pluginRegistry {
+		if !seen[name] {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	metas := make([]spec.ModuleMeta, 0, len(names))
+	for _, name := range names {
+		metas = append(metas, spec.ModuleMeta{Name: name, Type: "plugin", Desc: pluginRegistry[name].Desc})
+	}
+	return metas
 }
 
 func registryNames() string {

--- a/modules/core/mgmt/modules.go
+++ b/modules/core/mgmt/modules.go
@@ -49,6 +49,9 @@ func getModuleOrPluginHandler(ctx *cmdctx.Ctx, kind string, match func(spec.Modu
 			// name exists but isn't a plugin — the caller almost certainly meant `get module`.
 			return fmt.Errorf("%s %q not found (it's a builtin module — did you mean %q?)", kind, ctx.Id, "harness get module "+ctx.Id)
 		}
+		if _, ok := pluginRegistry[strings.ToLower(ctx.Id)]; ok {
+			return fmt.Errorf("%s %q is not installed — to install run %q", kind, ctx.Id, "harness install plugin "+ctx.Id)
+		}
 		return fmt.Errorf("%s %q not found", kind, ctx.Id)
 	}
 
@@ -298,7 +301,9 @@ func ListPluginsFetchFn(ctx *cmdctx.Ctx, _ *spec.EndpointSpec, _, _ int, _ any) 
 func ListModulesFetchFn(ctx *cmdctx.Ctx, _ *spec.EndpointSpec, _, _ int, _ any) (*cmdctx.PageResult, error) {
 	typeFilter := cmdctx.GetString(ctx.FlagValues, "module-type")
 	var items []any
+	seen := map[string]bool{}
 	for _, m := range ctx.Resolver.GetModuleMetas() {
+		seen[m.Name] = true
 		if typeFilter != "" && !strings.EqualFold(m.Type, typeFilter) {
 			continue
 		}
@@ -323,6 +328,17 @@ func ListModulesFetchFn(ctx *cmdctx.Ctx, _ *spec.EndpointSpec, _, _ int, _ any) 
 			"version":   version,
 			"desc":      m.Desc,
 		})
+	}
+	if typeFilter == "" || strings.EqualFold(typeFilter, "plugin") {
+		for _, m := range UninstalledRegistryPlugins(seen) {
+			items = append(items, map[string]any{
+				"module":    m.Name,
+				"type":      m.Type,
+				"installed": "no",
+				"version":   "-",
+				"desc":      m.Desc,
+			})
+		}
 	}
 	return &cmdctx.PageResult{
 		Items:       items,

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -13,6 +13,14 @@ help_text: |
   repository. A pull request targets a repository branch and has an activity timeline
   (comments, reviews, state changes) and threaded comments associated with it.
 
+  ### Migrating from another SCM
+
+  To bring existing repositories, pull requests, and pipelines into Harness Code
+  from GitHub, GitLab, Bitbucket, or Bitbucket Server, use the `migrate` plugin
+  module rather than the commands below:
+
+      harness get module migrate
+
   ### Nouns
 
   {{nouns}}


### PR DESCRIPTION
populate uninstalled module descriptions in the main `harness` cmd and in `list modules`. also give install hint in `get module` when not installed