### PR TITLE
feat: Rework `get pr` output into a readable PR summary view

### DIFF
--- a/modules/code/activity.go
+++ b/modules/code/activity.go
@@ -73,7 +73,7 @@ func asInt64(v any) int64 {
 // isComment reports whether the activity is part of the comment/reply thread,
 // as opposed to a system/review timeline event.
 func isComment(kind string) bool {
-	return kind == "comment" || kind == "change-comment"
+	return kind == "comment"
 }
 
 // renderCommentsSummary prints a gh-pr-view-style collapsed comments section:
@@ -102,12 +102,16 @@ func renderCommentsSummary(w io.Writer, activities []any, now time.Time, hintCmd
 	newest := comments[len(comments)-1]
 
 	plu := "s"
-	if len(comments) == 1 {
+	if len(comments)-1 == 1 {
 		plu = ""
 	}
-	divider := fmt.Sprintf(" Not showing %d comment%s ", len(comments), plu)
+	divider := fmt.Sprintf(" Not showing %d comment%s ", len(comments)-1, plu)
 	pad := strings.Repeat("─", 8)
-	fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+divider+pad))
+	if len(comments) == 1 {
+		fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+" Comment "+pad))
+	} else {
+		fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+divider+pad))
+	}
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%s • %s • %s\n\n", console.WithBold(newest.AuthorName), relativeTimeSince(time.UnixMilli(newest.Created), now), console.WithColor(console.ColorBrightBlue, "Newest comment"))

--- a/modules/code/activity.go
+++ b/modules/code/activity.go
@@ -101,17 +101,8 @@ func renderCommentsSummary(w io.Writer, activities []any, now time.Time, hintCmd
 	})
 	newest := comments[len(comments)-1]
 
-	plu := "s"
-	if len(comments)-1 == 1 {
-		plu = ""
-	}
-	divider := fmt.Sprintf(" Not showing %d comment%s ", len(comments)-1, plu)
 	pad := strings.Repeat("─", 8)
-	if len(comments) == 1 {
-		fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+" Comment "+pad))
-	} else {
-		fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+divider+pad))
-	}
+	fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+" Comments "+pad))
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%s • %s • %s\n\n", console.WithBold(newest.AuthorName), relativeTimeSince(time.UnixMilli(newest.Created), now), console.WithColor(console.ColorBrightBlue, "Newest comment"))

--- a/modules/code/activity.go
+++ b/modules/code/activity.go
@@ -1,0 +1,145 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package code
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/harness/cli/pkg/console"
+)
+
+// activityItem is a normalized view of one raw activity map, as returned by
+// /code/api/v1/repos/{repo}/pullreq/{pr}/activities.
+type activityItem struct {
+	Kind       string
+	Type       string
+	AuthorName string
+	Text       string
+	Decision   string
+	Order      int64
+	SubOrder   int64
+	ParentID   int64
+	Created    int64
+}
+
+func toActivityItem(raw any) (activityItem, bool) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return activityItem{}, false
+	}
+	item := activityItem{
+		Kind:     asString(m["kind"]),
+		Type:     asString(m["type"]),
+		Text:     strings.TrimSpace(asString(m["text"])),
+		Order:    asInt64(m["order"]),
+		SubOrder: asInt64(m["sub_order"]),
+		ParentID: asInt64(m["parent_id"]),
+		Created:  asInt64(m["created"]),
+	}
+	if author, ok := m["author"].(map[string]any); ok {
+		item.AuthorName = asString(author["display_name"])
+	}
+	if payload, ok := m["payload"].(map[string]any); ok {
+		item.Decision = asString(payload["decision"])
+	}
+	if item.Decision == "" {
+		item.Decision = asString(m["decision"])
+	}
+	return item, true
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func asInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	}
+	return 0
+}
+
+// isComment reports whether the activity is part of the comment/reply thread,
+// as opposed to a system/review timeline event.
+func isComment(kind string) bool {
+	return kind == "comment" || kind == "change-comment"
+}
+
+// renderCommentsSummary prints a gh-pr-view-style collapsed comments section:
+// a "Not showing N comments" divider, the newest comment's author/time/text, and
+// a hint pointing at hintCmd to see the full conversation. Prints nothing when
+// activities contains no comments.
+func renderCommentsSummary(w io.Writer, activities []any, now time.Time, hintCmd string) {
+	var comments []activityItem
+	for _, raw := range activities {
+		item, ok := toActivityItem(raw)
+		if !ok || !isComment(item.Kind) {
+			continue
+		}
+		comments = append(comments, item)
+	}
+	if len(comments) == 0 {
+		return
+	}
+
+	sort.SliceStable(comments, func(i, j int) bool {
+		if comments[i].Order != comments[j].Order {
+			return comments[i].Order < comments[j].Order
+		}
+		return comments[i].SubOrder < comments[j].SubOrder
+	})
+	newest := comments[len(comments)-1]
+
+	plu := "s"
+	if len(comments) == 1 {
+		plu = ""
+	}
+	divider := fmt.Sprintf(" Not showing %d comment%s ", len(comments), plu)
+	pad := strings.Repeat("─", 8)
+	fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+divider+pad))
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "%s • %s • %s\n\n", console.WithBold(newest.AuthorName), relativeTimeSince(time.UnixMilli(newest.Created), now), console.WithColor(console.ColorBrightBlue, "Newest comment"))
+	text := newest.Text
+	if text == "" {
+		text = "(no comment text)"
+	}
+	for _, line := range strings.Split(text, "\n") {
+		fmt.Fprintf(w, "  %s\n", line)
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "Use `%s` to view the full conversation\n", hintCmd)
+}
+
+// relativeTimeSince formats then relative to now, e.g. "3h ago". Timestamps
+// older than a week fall back to an absolute date.
+func relativeTimeSince(then, now time.Time) string {
+	if then.UnixMilli() == 0 {
+		return ""
+	}
+	d := now.Sub(then)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	default:
+		return then.Format("Jan 2, 2006")
+	}
+}

--- a/modules/code/activity_test.go
+++ b/modules/code/activity_test.go
@@ -11,180 +11,6 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// activityTextFormatter / renderActivityTimeline
-// ---------------------------------------------------------------------------
-
-func TestActivityTextFormatter_EmptyList(t *testing.T) {
-	out := captureStdout(t, func() {
-		if err := activityTextFormatter(os.Stdout, nil); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	if !strings.Contains(out, "No activity.") {
-		t.Fatalf("expected empty-state message, got:\n%s", out)
-	}
-}
-
-func TestRenderActivityTimeline_CommentOnly(t *testing.T) {
-	now := time.UnixMilli(1_700_000_000_000)
-	activities := []any{
-		map[string]any{
-			"kind":    "comment",
-			"author":  map[string]any{"display_name": "Alice"},
-			"text":    "Looks good overall.",
-			"order":   float64(1),
-			"created": float64(now.Add(-2 * time.Hour).UnixMilli()),
-		},
-	}
-	out := captureStdout(t, func() {
-		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	if !strings.Contains(out, "Alice") {
-		t.Fatalf("expected author name in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "2h ago") {
-		t.Fatalf("expected relative timestamp \"2h ago\", got:\n%s", out)
-	}
-	if !strings.Contains(out, "Looks good overall.") {
-		t.Fatalf("expected comment text, got:\n%s", out)
-	}
-}
-
-func TestRenderActivityTimeline_MixedCommentAndSystem(t *testing.T) {
-	now := time.UnixMilli(1_700_000_000_000)
-	activities := []any{
-		map[string]any{
-			"kind":    "system",
-			"type":    "merge",
-			"author":  map[string]any{"display_name": "Bob"},
-			"order":   float64(2),
-			"created": float64(now.UnixMilli()),
-		},
-		map[string]any{
-			"kind":    "comment",
-			"author":  map[string]any{"display_name": "Alice"},
-			"text":    "Can you tweak this?",
-			"order":   float64(1),
-			"created": float64(now.UnixMilli()),
-		},
-	}
-	out := captureStdout(t, func() {
-		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	commentIdx := strings.Index(out, "Can you tweak this?")
-	mergeIdx := strings.Index(out, "merged this pull request")
-	if commentIdx == -1 || mergeIdx == -1 {
-		t.Fatalf("expected both comment and system event in output, got:\n%s", out)
-	}
-	if commentIdx > mergeIdx {
-		t.Fatalf("expected comment (order=1) before system event (order=2), got:\n%s", out)
-	}
-	if !strings.Contains(out, "●") {
-		t.Fatalf("expected bullet marker on system event line, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Bob merged this pull request") {
-		t.Fatalf("expected hand-rolled verb for merge type, got:\n%s", out)
-	}
-}
-
-func TestRenderActivityTimeline_SystemEventUsesTextWhenPresent(t *testing.T) {
-	now := time.UnixMilli(1_700_000_000_000)
-	activities := []any{
-		map[string]any{
-			"kind":    "system",
-			"type":    "title-change",
-			"author":  map[string]any{"display_name": "Carol"},
-			"text":    "Carol changed the title from \"foo\" to \"bar\"",
-			"order":   float64(1),
-			"created": float64(now.UnixMilli()),
-		},
-	}
-	out := captureStdout(t, func() {
-		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	if !strings.Contains(out, `Carol changed the title from "foo" to "bar"`) {
-		t.Fatalf("expected raw text to be used verbatim, got:\n%s", out)
-	}
-	if strings.Contains(out, "changed the title") == false {
-		t.Fatalf("sanity: expected substring not found, got:\n%s", out)
-	}
-}
-
-func TestRenderActivityTimeline_ThreadedRepliesIndented(t *testing.T) {
-	now := time.UnixMilli(1_700_000_000_000)
-	activities := []any{
-		map[string]any{
-			"kind":      "comment",
-			"author":    map[string]any{"display_name": "Alice"},
-			"text":      "Top-level comment",
-			"order":     float64(1),
-			"parent_id": float64(0),
-			"created":   float64(now.UnixMilli()),
-		},
-		map[string]any{
-			"kind":      "comment",
-			"author":    map[string]any{"display_name": "Bob"},
-			"text":      "A reply",
-			"order":     float64(1),
-			"sub_order": float64(1),
-			"parent_id": float64(1),
-			"created":   float64(now.UnixMilli()),
-		},
-	}
-	out := captureStdout(t, func() {
-		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	lines := strings.Split(out, "\n")
-	var replyLine string
-	for _, l := range lines {
-		if strings.Contains(l, "A reply") {
-			replyLine = l
-			break
-		}
-	}
-	if replyLine == "" {
-		t.Fatalf("expected reply text in output, got:\n%s", out)
-	}
-	if !strings.HasPrefix(replyLine, "    ") {
-		t.Fatalf("expected reply to be indented under its parent, got line: %q", replyLine)
-	}
-}
-
-func TestRenderActivityTimeline_SortsByOrderThenSubOrder(t *testing.T) {
-	now := time.UnixMilli(1_700_000_000_000)
-	activities := []any{
-		map[string]any{
-			"kind": "comment", "author": map[string]any{"display_name": "X"},
-			"text": "second", "order": float64(1), "sub_order": float64(2),
-			"created": float64(now.UnixMilli()),
-		},
-		map[string]any{
-			"kind": "comment", "author": map[string]any{"display_name": "X"},
-			"text": "first", "order": float64(1), "sub_order": float64(1),
-			"created": float64(now.UnixMilli()),
-		},
-	}
-	out := captureStdout(t, func() {
-		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	firstIdx := strings.Index(out, "first")
-	secondIdx := strings.Index(out, "second")
-	if firstIdx == -1 || secondIdx == -1 || firstIdx > secondIdx {
-		t.Fatalf("expected \"first\" (sub_order=1) before \"second\" (sub_order=2), got:\n%s", out)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // relativeTimeSince
 // ---------------------------------------------------------------------------
 
@@ -213,28 +39,49 @@ func TestRelativeTimeSince(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// systemEventColor
+// renderCommentsSummary
 // ---------------------------------------------------------------------------
 
-func TestSystemEventColor(t *testing.T) {
-	cases := []struct {
-		name         string
-		activityType string
-		decision     string
-		wantColor    bool
-	}{
-		{"approved decision", "review-submit", "approved", true},
-		{"changereq decision", "review-submit", "changereq", true},
-		{"merge type", "merge", "", true},
-		{"branch-delete type", "branch-delete", "", true},
-		{"unknown type no decision", "reviewer-add", "", false},
+func TestRenderCommentsSummary_NoComments(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{"kind": "system", "type": "merge", "order": float64(1)},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := systemEventColor(tc.activityType, tc.decision)
-			if (got != 0) != tc.wantColor {
-				t.Fatalf("systemEventColor(%q, %q) = %v, want color set: %v", tc.activityType, tc.decision, got, tc.wantColor)
-			}
-		})
+	out := captureStdout(t, func() {
+		renderCommentsSummary(os.Stdout, activities, now, "harness list pr_comment repo1/42")
+	})
+	if out != "" {
+		t.Fatalf("expected no output when there are no comments, got:\n%s", out)
+	}
+}
+
+func TestRenderCommentsSummary_ShowsNewestCommentOnly(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{
+			"kind": "comment", "author": map[string]any{"display_name": "Alice"},
+			"text": "first comment", "order": float64(1),
+			"created": float64(now.Add(-2 * time.Hour).UnixMilli()),
+		},
+		map[string]any{
+			"kind": "comment", "author": map[string]any{"display_name": "Bob"},
+			"text": "newest comment", "order": float64(2),
+			"created": float64(now.UnixMilli()),
+		},
+	}
+	out := captureStdout(t, func() {
+		renderCommentsSummary(os.Stdout, activities, now, "harness list pr_comment repo1/42")
+	})
+	if !strings.Contains(out, "Not showing 2 comments") {
+		t.Fatalf("expected collapsed comments summary with count 2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Bob") || !strings.Contains(out, "newest comment") {
+		t.Fatalf("expected the newest comment (Bob's) to be shown, got:\n%s", out)
+	}
+	if strings.Contains(out, "first comment") {
+		t.Fatalf("expected only the newest comment to render, not the older one, got:\n%s", out)
+	}
+	if !strings.Contains(out, "harness list pr_comment repo1/42") {
+		t.Fatalf("expected hint pointing at \"list pr_comment\" with the PR id, got:\n%s", out)
 	}
 }

--- a/modules/code/activity_test.go
+++ b/modules/code/activity_test.go
@@ -68,12 +68,17 @@ func TestRenderCommentsSummary_ShowsNewestCommentOnly(t *testing.T) {
 			"text": "newest comment", "order": float64(2),
 			"created": float64(now.UnixMilli()),
 		},
+		map[string]any{
+			"kind": "change-comment", "author": map[string]any{"display_name": "Charlie"},
+			"text": "change comment", "order": float64(3),
+			"created": float64(now.Add(-3 * time.Hour).UnixMilli()),
+		},
 	}
 	out := captureStdout(t, func() {
 		renderCommentsSummary(os.Stdout, activities, now, "harness list pr_comment repo1/42")
 	})
-	if !strings.Contains(out, "Not showing 2 comments") {
-		t.Fatalf("expected collapsed comments summary with count 2, got:\n%s", out)
+	if !strings.Contains(out, "Not showing 1 comment") {
+		t.Fatalf("expected collapsed comments summary with count 1 comment, got:\n%s", out)
 	}
 	if !strings.Contains(out, "Bob") || !strings.Contains(out, "newest comment") {
 		t.Fatalf("expected the newest comment (Bob's) to be shown, got:\n%s", out)

--- a/modules/code/activity_test.go
+++ b/modules/code/activity_test.go
@@ -1,0 +1,240 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package code
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// activityTextFormatter / renderActivityTimeline
+// ---------------------------------------------------------------------------
+
+func TestActivityTextFormatter_EmptyList(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := activityTextFormatter(os.Stdout, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No activity.") {
+		t.Fatalf("expected empty-state message, got:\n%s", out)
+	}
+}
+
+func TestRenderActivityTimeline_CommentOnly(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{
+			"kind":    "comment",
+			"author":  map[string]any{"display_name": "Alice"},
+			"text":    "Looks good overall.",
+			"order":   float64(1),
+			"created": float64(now.Add(-2 * time.Hour).UnixMilli()),
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Alice") {
+		t.Fatalf("expected author name in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2h ago") {
+		t.Fatalf("expected relative timestamp \"2h ago\", got:\n%s", out)
+	}
+	if !strings.Contains(out, "Looks good overall.") {
+		t.Fatalf("expected comment text, got:\n%s", out)
+	}
+}
+
+func TestRenderActivityTimeline_MixedCommentAndSystem(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{
+			"kind":    "system",
+			"type":    "merge",
+			"author":  map[string]any{"display_name": "Bob"},
+			"order":   float64(2),
+			"created": float64(now.UnixMilli()),
+		},
+		map[string]any{
+			"kind":    "comment",
+			"author":  map[string]any{"display_name": "Alice"},
+			"text":    "Can you tweak this?",
+			"order":   float64(1),
+			"created": float64(now.UnixMilli()),
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	commentIdx := strings.Index(out, "Can you tweak this?")
+	mergeIdx := strings.Index(out, "merged this pull request")
+	if commentIdx == -1 || mergeIdx == -1 {
+		t.Fatalf("expected both comment and system event in output, got:\n%s", out)
+	}
+	if commentIdx > mergeIdx {
+		t.Fatalf("expected comment (order=1) before system event (order=2), got:\n%s", out)
+	}
+	if !strings.Contains(out, "●") {
+		t.Fatalf("expected bullet marker on system event line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Bob merged this pull request") {
+		t.Fatalf("expected hand-rolled verb for merge type, got:\n%s", out)
+	}
+}
+
+func TestRenderActivityTimeline_SystemEventUsesTextWhenPresent(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{
+			"kind":    "system",
+			"type":    "title-change",
+			"author":  map[string]any{"display_name": "Carol"},
+			"text":    "Carol changed the title from \"foo\" to \"bar\"",
+			"order":   float64(1),
+			"created": float64(now.UnixMilli()),
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, `Carol changed the title from "foo" to "bar"`) {
+		t.Fatalf("expected raw text to be used verbatim, got:\n%s", out)
+	}
+	if strings.Contains(out, "changed the title") == false {
+		t.Fatalf("sanity: expected substring not found, got:\n%s", out)
+	}
+}
+
+func TestRenderActivityTimeline_ThreadedRepliesIndented(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{
+			"kind":      "comment",
+			"author":    map[string]any{"display_name": "Alice"},
+			"text":      "Top-level comment",
+			"order":     float64(1),
+			"parent_id": float64(0),
+			"created":   float64(now.UnixMilli()),
+		},
+		map[string]any{
+			"kind":      "comment",
+			"author":    map[string]any{"display_name": "Bob"},
+			"text":      "A reply",
+			"order":     float64(1),
+			"sub_order": float64(1),
+			"parent_id": float64(1),
+			"created":   float64(now.UnixMilli()),
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := strings.Split(out, "\n")
+	var replyLine string
+	for _, l := range lines {
+		if strings.Contains(l, "A reply") {
+			replyLine = l
+			break
+		}
+	}
+	if replyLine == "" {
+		t.Fatalf("expected reply text in output, got:\n%s", out)
+	}
+	if !strings.HasPrefix(replyLine, "    ") {
+		t.Fatalf("expected reply to be indented under its parent, got line: %q", replyLine)
+	}
+}
+
+func TestRenderActivityTimeline_SortsByOrderThenSubOrder(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	activities := []any{
+		map[string]any{
+			"kind": "comment", "author": map[string]any{"display_name": "X"},
+			"text": "second", "order": float64(1), "sub_order": float64(2),
+			"created": float64(now.UnixMilli()),
+		},
+		map[string]any{
+			"kind": "comment", "author": map[string]any{"display_name": "X"},
+			"text": "first", "order": float64(1), "sub_order": float64(1),
+			"created": float64(now.UnixMilli()),
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := renderActivityTimeline(os.Stdout, activities, now); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	firstIdx := strings.Index(out, "first")
+	secondIdx := strings.Index(out, "second")
+	if firstIdx == -1 || secondIdx == -1 || firstIdx > secondIdx {
+		t.Fatalf("expected \"first\" (sub_order=1) before \"second\" (sub_order=2), got:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// relativeTimeSince
+// ---------------------------------------------------------------------------
+
+func TestRelativeTimeSince(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	cases := []struct {
+		name string
+		then time.Time
+		want string
+	}{
+		{"zero timestamp", time.UnixMilli(0), ""},
+		{"just now", now.Add(-10 * time.Second), "just now"},
+		{"minutes ago", now.Add(-5 * time.Minute), "5m ago"},
+		{"hours ago", now.Add(-3 * time.Hour), "3h ago"},
+		{"days ago", now.Add(-2 * 24 * time.Hour), "2d ago"},
+		{"weeks ago falls back to date", now.Add(-14 * 24 * time.Hour), now.Add(-14 * 24 * time.Hour).Format("Jan 2, 2006")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := relativeTimeSince(tc.then, now)
+			if got != tc.want {
+				t.Fatalf("relativeTimeSince(%v, %v) = %q, want %q", tc.then, now, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// systemEventColor
+// ---------------------------------------------------------------------------
+
+func TestSystemEventColor(t *testing.T) {
+	cases := []struct {
+		name         string
+		activityType string
+		decision     string
+		wantColor    bool
+	}{
+		{"approved decision", "review-submit", "approved", true},
+		{"changereq decision", "review-submit", "changereq", true},
+		{"merge type", "merge", "", true},
+		{"branch-delete type", "branch-delete", "", true},
+		{"unknown type no decision", "reviewer-add", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := systemEventColor(tc.activityType, tc.decision)
+			if (got != 0) != tc.wantColor {
+				t.Fatalf("systemEventColor(%q, %q) = %v, want color set: %v", tc.activityType, tc.decision, got, tc.wantColor)
+			}
+		})
+	}
+}

--- a/modules/code/activity_test.go
+++ b/modules/code/activity_test.go
@@ -77,9 +77,6 @@ func TestRenderCommentsSummary_ShowsNewestCommentOnly(t *testing.T) {
 	out := captureStdout(t, func() {
 		renderCommentsSummary(os.Stdout, activities, now, "harness list pr_comment repo1/42")
 	})
-	if !strings.Contains(out, "Not showing 1 comment") {
-		t.Fatalf("expected collapsed comments summary with count 1 comment, got:\n%s", out)
-	}
 	if !strings.Contains(out, "Bob") || !strings.Contains(out, "newest comment") {
 		t.Fatalf("expected the newest comment (Bob's) to be shown, got:\n%s", out)
 	}

--- a/modules/code/insight_test.go
+++ b/modules/code/insight_test.go
@@ -269,6 +269,95 @@ func TestGetPRWorkflow_InsightSuccessRendersSection(t *testing.T) {
 	}
 }
 
+func TestGetPRWorkflow_ActivityFailureOmitsSectionButSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/activities") {
+			w.WriteHeader(500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"number":1}`))
+	}))
+	defer srv.Close()
+
+	var err error
+	out := captureStdout(t, func() {
+		err = GetPRWorkflow(insightTestCtx(srv.URL, ""))
+	})
+	if err != nil {
+		t.Fatalf("get pr must succeed even when the activity endpoint fails, got: %v", err)
+	}
+	if strings.Contains(out, "Not showing") {
+		t.Fatalf("output must omit the comments summary when the activity fetch fails, got:\n%s", out)
+	}
+}
+
+func TestGetPRWorkflow_ActivityWithNoCommentsOmitsSection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/activities"):
+			w.Write([]byte(`[]`))
+		default:
+			w.Write([]byte(`{"number":1}`))
+		}
+	}))
+	defer srv.Close()
+
+	var err error
+	out := captureStdout(t, func() {
+		err = GetPRWorkflow(insightTestCtx(srv.URL, ""))
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "Not showing") {
+		t.Fatalf("output must omit the comments summary when there are no comments, got:\n%s", out)
+	}
+}
+
+func TestGetPRWorkflow_ActivitySuccessRendersCommentsSummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/activities"):
+			w.Write([]byte(`[
+				{"kind":"comment","type":"comment","author":{"display_name":"Alice"},"text":"first comment","order":1,"created":1000},
+				{"kind":"comment","type":"comment","author":{"display_name":"Bob"},"text":"newest comment","order":2,"created":2000}
+			]`))
+		default:
+			w.Write([]byte(`{"number":1}`))
+		}
+	}))
+	defer srv.Close()
+
+	var err error
+	out := captureStdout(t, func() {
+		err = GetPRWorkflow(insightTestCtx(srv.URL, ""))
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Not showing 2 comments") {
+		t.Fatalf("expected collapsed comments summary with count 2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Bob") || !strings.Contains(out, "newest comment") {
+		t.Fatalf("expected the newest comment (Bob's) to be shown, got:\n%s", out)
+	}
+	if strings.Contains(out, "first comment") {
+		t.Fatalf("expected only the newest comment to render, not the older one, got:\n%s", out)
+	}
+	if !strings.Contains(out, "harness list pr_comment repo1/42") {
+		t.Fatalf("expected hint pointing at \"list pr_comment\" with the PR id, got:\n%s", out)
+	}
+	// The comments summary must render after the description and before the footer link.
+	summaryIdx := strings.Index(out, "Not showing")
+	lastLinkIdx := strings.LastIndex(out, "/pulls/42")
+	if summaryIdx == -1 || lastLinkIdx == -1 || lastLinkIdx < summaryIdx {
+		t.Fatalf("expected the PR link to appear after the comments summary, got:\n%s", out)
+	}
+}
+
 // TestReviewGroupCommand_StandaloneRendersLink verifies "get pr:review_group" run on
 // its own (it's no longer embedded in GetPRWorkflow) still prints its own trailing
 // PR link.

--- a/modules/code/insight_test.go
+++ b/modules/code/insight_test.go
@@ -338,8 +338,8 @@ func TestGetPRWorkflow_ActivitySuccessRendersCommentsSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Not showing 2 comments") {
-		t.Fatalf("expected collapsed comments summary with count 2, got:\n%s", out)
+	if !strings.Contains(out, "Not showing 1 comment") {
+		t.Fatalf("expected collapsed comments summary with count 1, got:\n%s", out)
 	}
 	if !strings.Contains(out, "Bob") || !strings.Contains(out, "newest comment") {
 		t.Fatalf("expected the newest comment (Bob's) to be shown, got:\n%s", out)

--- a/modules/code/insight_test.go
+++ b/modules/code/insight_test.go
@@ -246,16 +246,16 @@ func TestGetPRWorkflow_InsightSuccessRendersSection(t *testing.T) {
 	if !strings.Contains(out, "AI Code Review") {
 		t.Fatalf("output must contain the AI Code Review heading, got:\n%s", out)
 	}
-	if !strings.Contains(out, "Number:") {
-		t.Fatalf("output must contain the PR's labeled fields, got:\n%s", out)
+	if !strings.Contains(out, "#1") {
+		t.Fatalf("output must contain the PR header, got:\n%s", out)
 	}
 
-	// Labeled fields must render first, Insight last (right before the link), and the
+	// The header must render first, Insight last (right before the link), and the
 	// PR link must print exactly once, at the very end.
-	numberIdx := strings.Index(out, "Number:")
+	numberIdx := strings.Index(out, "#1")
 	insightIdx := strings.Index(out, "AI Code Review")
 	if insightIdx == -1 || numberIdx == -1 || insightIdx < numberIdx {
-		t.Fatalf("expected labeled fields to render before Insight, got:\n%s", out)
+		t.Fatalf("expected the header to render before Insight, got:\n%s", out)
 	}
 	lastLinkIdx := strings.LastIndex(out, "/pulls/42")
 	if lastLinkIdx == -1 || lastLinkIdx < insightIdx {

--- a/modules/code/insight_test.go
+++ b/modules/code/insight_test.go
@@ -338,9 +338,6 @@ func TestGetPRWorkflow_ActivitySuccessRendersCommentsSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Not showing 1 comment") {
-		t.Fatalf("expected collapsed comments summary with count 1, got:\n%s", out)
-	}
 	if !strings.Contains(out, "Bob") || !strings.Contains(out, "newest comment") {
 		t.Fatalf("expected the newest comment (Bob's) to be shown, got:\n%s", out)
 	}
@@ -351,7 +348,7 @@ func TestGetPRWorkflow_ActivitySuccessRendersCommentsSummary(t *testing.T) {
 		t.Fatalf("expected hint pointing at \"list pr_comment\" with the PR id, got:\n%s", out)
 	}
 	// The comments summary must render after the description and before the footer link.
-	summaryIdx := strings.Index(out, "Not showing")
+	summaryIdx := strings.Index(out, "Comments")
 	lastLinkIdx := strings.LastIndex(out, "/pulls/42")
 	if summaryIdx == -1 || lastLinkIdx == -1 || lastLinkIdx < summaryIdx {
 		t.Fatalf("expected the PR link to appear after the comments summary, got:\n%s", out)

--- a/modules/code/insight_test.go
+++ b/modules/code/insight_test.go
@@ -4,6 +4,7 @@
 package code
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -11,9 +12,11 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/harness/cli/pkg/auth"
 	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/extractutil"
 	"github.com/harness/cli/pkg/registry"
 	"github.com/harness/cli/pkg/spec"
 )
@@ -342,6 +345,135 @@ func TestReviewGroupTextFormatter_ColorizesBulletAndRiskTag(t *testing.T) {
 	}
 	if !strings.Contains(out, "auth/middleware.go") {
 		t.Fatalf("output must still list the file path, got:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderPRHeader / relativeTime / checkStatusText / plural / prStateColor
+// ---------------------------------------------------------------------------
+
+func TestRelativeTime(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		epochMs int64
+		want    string
+	}{
+		{"zero timestamp", 0, ""},
+		{"negative timestamp", -5, ""},
+		{"just now", now.Add(-10 * time.Second).UnixMilli(), "just now"},
+		{"minutes ago", now.Add(-5 * time.Minute).UnixMilli(), "• 5 mins ago"},
+		{"one minute ago (singular)", now.Add(-1 * time.Minute).UnixMilli(), "• 1 min ago"},
+		{"hours ago", now.Add(-3 * time.Hour).UnixMilli(), "• 3 hrs ago"},
+		{"days ago", now.Add(-13 * 24 * time.Hour).UnixMilli(), "• 13 days ago"},
+		{"one day ago (singular)", now.Add(-1 * 24 * time.Hour).UnixMilli(), "• 1 day ago"},
+		{"months ago", now.Add(-60 * 24 * time.Hour).UnixMilli(), "• 2 mons ago"},
+		{"years ago", now.Add(-400 * 24 * time.Hour).UnixMilli(), "• 1 yr ago"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := relativeTime(tt.epochMs); got != tt.want {
+				t.Fatalf("relativeTime(%d) = %q, want %q", tt.epochMs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckStatusText(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"mergeable", "✓ Checks passing"},
+		{"Mergeable", "✓ Checks passing"},
+		{"unchecked", "… Checks running"},
+		{"checking", "… Checks running"},
+		{"blocked", "✗ Checks failing (blocked)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := checkStatusText(tt.status)
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("checkStatusText(%q) = %q, want to contain %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlural(t *testing.T) {
+	if got := plural(1); got != "" {
+		t.Fatalf("plural(1) = %q, want empty", got)
+	}
+	for _, n := range []int64{0, 2, -1} {
+		if got := plural(n); got != "s" {
+			t.Fatalf("plural(%d) = %q, want %q", n, got, "s")
+		}
+	}
+}
+
+func TestPRStateColor(t *testing.T) {
+	tests := map[string]bool{"open": true, "draft": true, "merged": true, "closed": true, "unknown": false}
+	for state, wantColor := range tests {
+		got := prStateColor(state) != 0
+		if got != wantColor {
+			t.Fatalf("prStateColor(%q) colored = %v, want %v", state, got, wantColor)
+		}
+	}
+}
+
+func TestRenderPRHeader_OmitsEmptyChecksAndReviews(t *testing.T) {
+	pr := map[string]any{
+		"number": 1, "title": "Add feature", "state": "open", "is_draft": false,
+		"source_branch": "feature", "target_branch": "main",
+		"author": map[string]any{"display_name": "Jane Doe"},
+		"stats":  map[string]any{"files_changed": 2, "commits": 1, "additions": 10, "deletions": 3},
+	}
+	d := extractutil.MakeDataAccessor(map[string]any{}, pr)
+	var buf bytes.Buffer
+	renderPRHeader(&buf, d)
+	out := buf.String()
+
+	if strings.Contains(out, "Checks") {
+		t.Fatalf("expected no checks line when merge_check_status is empty, got:\n%s", out)
+	}
+	if strings.Contains(out, "Reviews:") {
+		t.Fatalf("expected no reviews line when required_count is 0, got:\n%s", out)
+	}
+	if !strings.Contains(out, "#1") || !strings.Contains(out, "Add feature") {
+		t.Fatalf("expected header with number and title, got:\n%s", out)
+	}
+	if !strings.Contains(out, "OPEN") {
+		t.Fatalf("expected OPEN badge, got:\n%s", out)
+	}
+}
+
+func TestRenderPRHeader_IncludesChecksAndReviewsWhenPresent(t *testing.T) {
+	pr := map[string]any{
+		"number": 111, "title": "Point spec at v4 endpoints", "state": "open", "is_draft": true,
+		"source_branch": "worktree-fme-spec-fix", "target_branch": "main",
+		"author": map[string]any{"display_name": "Deepak Puthraya"},
+		"stats": map[string]any{
+			"files_changed": 12, "commits": 8, "additions": 938, "deletions": 58,
+			"reviews": map[string]any{"required_count": 1, "latest_approvals": 0},
+		},
+		"merge_check_status": "mergeable",
+	}
+	d := extractutil.MakeDataAccessor(map[string]any{}, pr)
+	var buf bytes.Buffer
+	renderPRHeader(&buf, d)
+	out := buf.String()
+
+	if !strings.Contains(out, "DRAFT") {
+		t.Fatalf("expected DRAFT badge for is_draft PR in open state, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Checks passing") {
+		t.Fatalf("expected checks line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Reviews: 0/1 approved") {
+		t.Fatalf("expected reviews line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "938") || !strings.Contains(out, "58") {
+		t.Fatalf("expected additions/deletions stats, got:\n%s", out)
 	}
 }
 

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -93,7 +93,7 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 	}
 
 	if desc := strings.TrimSpace(data.GetString("it.description")); desc != "" {
-		fmt.Fprintf(w, "\n%s\n", desc)
+		fmt.Fprintf(w, "\n%s\n", console.RenderMarkdown(desc))
 	}
 	_, err = fmt.Fprint(w, interpolate(baseSpec.Endpoint.TextFooter, pr))
 	return err

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -63,13 +63,23 @@ func GetPRWorkflow(ctx *cmdctx.Ctx) error {
 		}
 	}
 
-	return renderPR(ctx, baseSpec, pr, insightSpec, insightData)
+	activityEndpoint := &spec.EndpointSpec{
+		Path: "/code/api/v1/repos/{{ctx.idParts[0]}}/pullreq/{{ctx.idParts[1]}}/activities",
+	}
+	activityData, err := registry.CallEndpoint(ctx, activityEndpoint)
+	if err != nil {
+		hlog.Warn("activity fetch failed, omitting comments summary from get pr", "err", err)
+		activityData = nil
+	}
+
+	return renderPR(ctx, baseSpec, pr, insightSpec, insightData, activityData)
 }
 
-// renderPR prints "get pr" output in three parts so the AI Code Review (Insight)
-// section can sit between them: labeled fields, then the insight section (best-effort
-// — a failure here still only omits it), then the description text block and footer.
-func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *spec.CommandSpec, insightData any) error {
+// renderPR prints "get pr" output in parts so the AI Code Review (Insight) and
+// comments sections can sit where they belong: labeled fields, then the insight
+// section (best-effort — a failure here still only omits it), then the description
+// text block, then a collapsed comments summary (best-effort), then the footer.
+func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *spec.CommandSpec, insightData any, activityData any) error {
 	w, closeW, err := format.OpenWriter(ctx.FormatFlags.OutFile)
 	if err != nil {
 		return err
@@ -95,6 +105,12 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 	if desc := strings.TrimSpace(data.GetString("it.description")); desc != "" {
 		fmt.Fprintf(w, "\n%s\n", console.RenderMarkdown(desc))
 	}
+
+	if activities, ok := activityData.([]any); ok {
+		fmt.Fprintln(w)
+		renderCommentsSummary(w, activities, time.Now(), "harness list pr_comment "+ctx.Id)
+	}
+
 	_, err = fmt.Fprint(w, interpolate(baseSpec.Endpoint.TextFooter, pr))
 	return err
 }

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -141,8 +141,8 @@ func renderPRHeader(w io.Writer, d cmdctx.DataAccessor) {
 	author := d.GetString("it.author.display_name")
 	source := d.GetString("it.source_branch")
 	target := d.GetString("it.target_branch")
-	fmt.Fprintf(w, "%s • %s wants to merge %s into %s\n", 
-	console.WithColor(prStateColor(badge), strings.ToUpper(badge)),author, source, target)
+	fmt.Fprintf(w, "%s • %s wants to merge %s into %s\n",
+		console.WithColor(prStateColor(badge), strings.ToUpper(badge)), author, source, target)
 
 	files := d.GetInt64("it.stats.files_changed")
 	commits := d.GetInt64("it.stats.commits")

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -102,6 +102,8 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 		}
 	}
 
+	pad := strings.Repeat("─", 25)
+	fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+" Description "+pad))
 	if desc := strings.TrimSpace(data.GetString("it.description")); desc != "" {
 		fmt.Fprintf(w, "\n%s\n", console.RenderMarkdown(desc))
 	}
@@ -132,7 +134,7 @@ func renderPRHeader(w io.Writer, d cmdctx.DataAccessor) {
 		when = merged
 	}
 
-	fmt.Fprintf(w, "%s %s  %s\n",
+	fmt.Fprintf(w, "\n%s %s  %s\n\n",
 		console.WithBold(title),
 		fmt.Sprintf("#%d", number),
 		relativeTime(when),
@@ -141,7 +143,7 @@ func renderPRHeader(w io.Writer, d cmdctx.DataAccessor) {
 	author := d.GetString("it.author.display_name")
 	source := d.GetString("it.source_branch")
 	target := d.GetString("it.target_branch")
-	fmt.Fprintf(w, "%s • %s wants to merge %s into %s\n",
+	fmt.Fprintf(w, "%s • %s wants to merge %s into %s\n\n",
 		console.WithColor(prStateColor(badge), strings.ToUpper(badge)), author, source, target)
 
 	files := d.GetInt64("it.stats.files_changed")

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -5,9 +5,11 @@ package code
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/console"
 	"github.com/harness/cli/pkg/exprenv"
 	"github.com/harness/cli/pkg/extractutil"
 	"github.com/harness/cli/pkg/format"
@@ -15,6 +17,14 @@ import (
 	"github.com/harness/cli/pkg/registry"
 	"github.com/harness/cli/pkg/spec"
 )
+
+// prHeaderFieldIDs are the noun fields folded into renderPRHeader's title/badge,
+// branch, and stats lines, so they aren't repeated in the labeled-field dump below.
+var prHeaderFieldIDs = map[string]bool{
+	"number": true, "title": true, "state": true, "is_draft": true,
+	"source_branch": true, "target_branch": true, "author": true,
+	"commits": true, "files_changed": true, "additions": true, "deletions": true,
+}
 
 const getPRWorkflowID = "get_pr"
 
@@ -73,6 +83,15 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 	}
 	defer closeW()
 
+	exprEnv := exprenv.Make(ctx)
+	interpolate := func(tmpl string, item any) string {
+		s, _ := exprenv.ResolvePath(exprenv.WithIt(exprEnv, item), tmpl)
+		return s
+	}
+	data := extractutil.MakeDataAccessor(exprEnv, pr)
+
+	renderPRHeader(w, data)
+
 	nounForFields := ctx.Noun
 	if ctx.FieldsNoun != "" {
 		nounForFields = ctx.FieldsNoun
@@ -80,19 +99,12 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 	var labeledFields []spec.FieldDef
 	if nd := ctx.Resolver.GetNoun(nounForFields); nd != nil {
 		for _, f := range nd.Fields {
-			if f.FieldType == "multiline_text" || f.FieldType == "yaml" {
+			if f.FieldType == "multiline_text" || f.FieldType == "yaml" || prHeaderFieldIDs[f.ID] {
 				continue
 			}
 			labeledFields = append(labeledFields, f)
 		}
 	}
-
-	exprEnv := exprenv.Make(ctx)
-	interpolate := func(tmpl string, item any) string {
-		s, _ := exprenv.ResolvePath(exprenv.WithIt(exprEnv, item), tmpl)
-		return s
-	}
-	data := extractutil.MakeDataAccessor(exprEnv, pr)
 
 	if err := format.BuildTextFieldFormatter(labeledFields, "", "", interpolate)(w, data); err != nil {
 		return err
@@ -110,6 +122,65 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 	}
 	_, err = fmt.Fprint(w, interpolate(baseSpec.Endpoint.TextFooter, pr))
 	return err
+}
+
+// renderPRHeader prints a gh-pr-view-style header: "#<number> <title>" with a
+// colorized state/draft badge, then compact author/branch and stat summary lines.
+func renderPRHeader(w io.Writer, d cmdctx.DataAccessor) {
+	number := d.GetInt64("it.number")
+	title := d.GetString("it.title")
+	state := strings.ToLower(d.GetString("it.state"))
+
+	badge := state
+	if d.GetBool("it.is_draft") && state == "open" {
+		badge = "draft"
+	}
+	fmt.Fprintf(w, "%s %s  %s\n",
+	title,
+	console.WithBold(fmt.Sprintf("#%d", number)),
+	console.WithBoldColor(prStateColor(badge), strings.ToUpper(badge)),
+	)
+
+	author := d.GetString("it.author.display_name")
+	source := d.GetString("it.source_branch")
+	target := d.GetString("it.target_branch")
+	fmt.Fprintf(w, "%s wants to merge %s into %s\n", author, source, target)
+
+	files := d.GetInt64("it.stats.files_changed")
+	commits := d.GetInt64("it.stats.commits")
+	additions := d.GetInt64("it.stats.additions")
+	deletions := d.GetInt64("it.stats.deletions")
+	fmt.Fprintf(w, "%d file%s changed · %d commit%s · %s %s\n\n",
+		files, plural(files), commits, plural(commits),
+		console.WithColor(console.ColorGreen, fmt.Sprintf("+%d", additions)),
+		console.WithColor(console.ColorRed, fmt.Sprintf("-%d", deletions)),
+	)
+}
+
+// plural returns "s" unless n is exactly 1.
+func plural(n int64) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// prStateColor maps a PR state/badge ("open"/"draft"/"merged"/"closed",
+// case-insensitive) to the color it's displayed in, following riskColor's
+// green/yellow/red conventions. Returns 0 (no color) for any other value.
+func prStateColor(state string) console.Color {
+	switch strings.ToLower(state) {
+	case "open":
+		return console.ColorGreen
+	case "draft":
+		return console.ColorYellow
+	case "merged":
+		return console.ColorMagenta
+	case "closed":
+		return console.ColorRed
+	default:
+		return 0
+	}
 }
 
 // createPRBodyFn builds the pull request create body.

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/harness/cli/pkg/cmdctx"
 	"github.com/harness/cli/pkg/console"
@@ -17,14 +18,6 @@ import (
 	"github.com/harness/cli/pkg/registry"
 	"github.com/harness/cli/pkg/spec"
 )
-
-// prHeaderFieldIDs are the noun fields folded into renderPRHeader's title/badge,
-// branch, and stats lines, so they aren't repeated in the labeled-field dump below.
-var prHeaderFieldIDs = map[string]bool{
-	"number": true, "title": true, "state": true, "is_draft": true,
-	"source_branch": true, "target_branch": true, "author": true,
-	"commits": true, "files_changed": true, "additions": true, "deletions": true,
-}
 
 const getPRWorkflowID = "get_pr"
 
@@ -92,24 +85,6 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 
 	renderPRHeader(w, data)
 
-	nounForFields := ctx.Noun
-	if ctx.FieldsNoun != "" {
-		nounForFields = ctx.FieldsNoun
-	}
-	var labeledFields []spec.FieldDef
-	if nd := ctx.Resolver.GetNoun(nounForFields); nd != nil {
-		for _, f := range nd.Fields {
-			if f.FieldType == "multiline_text" || f.FieldType == "yaml" || prHeaderFieldIDs[f.ID] {
-				continue
-			}
-			labeledFields = append(labeledFields, f)
-		}
-	}
-
-	if err := format.BuildTextFieldFormatter(labeledFields, "", "", interpolate)(w, data); err != nil {
-		return err
-	}
-
 	if insightSpec != nil {
 		sectionData := extractutil.MakeDataAccessor(exprEnv, insightData)
 		if err := insightTextFormatter(w, sectionData); err != nil {
@@ -135,26 +110,88 @@ func renderPRHeader(w io.Writer, d cmdctx.DataAccessor) {
 	if d.GetBool("it.is_draft") && state == "open" {
 		badge = "draft"
 	}
+
+	when := d.GetInt64("it.created")
+	if merged := d.GetInt64("it.merged"); merged > 0 {
+		when = merged
+	}
+
 	fmt.Fprintf(w, "%s %s  %s\n",
-	title,
-	console.WithBold(fmt.Sprintf("#%d", number)),
-	console.WithBoldColor(prStateColor(badge), strings.ToUpper(badge)),
+		console.WithBold(title),
+		fmt.Sprintf("#%d", number),
+		relativeTime(when),
 	)
 
 	author := d.GetString("it.author.display_name")
 	source := d.GetString("it.source_branch")
 	target := d.GetString("it.target_branch")
-	fmt.Fprintf(w, "%s wants to merge %s into %s\n", author, source, target)
+	fmt.Fprintf(w, "%s • %s wants to merge %s into %s\n", 
+	console.WithColor(prStateColor(badge), strings.ToUpper(badge)),author, source, target)
 
 	files := d.GetInt64("it.stats.files_changed")
 	commits := d.GetInt64("it.stats.commits")
 	additions := d.GetInt64("it.stats.additions")
 	deletions := d.GetInt64("it.stats.deletions")
-	fmt.Fprintf(w, "%d file%s changed · %d commit%s · %s %s\n\n",
+	fmt.Fprintf(w, "%d file%s changed · %d commit%s · %s %s ",
 		files, plural(files), commits, plural(commits),
 		console.WithColor(console.ColorGreen, fmt.Sprintf("+%d", additions)),
 		console.WithColor(console.ColorRed, fmt.Sprintf("-%d", deletions)),
 	)
+
+	var extras []string
+	if check := d.GetString("it.merge_check_status"); check != "" {
+		extras = append(extras, checkStatusText(check))
+	}
+	if required := d.GetInt64("it.stats.reviews.required_count"); required > 0 {
+		approved := d.GetInt64("it.stats.reviews.latest_approvals")
+		extras = append(extras, fmt.Sprintf("Reviews: %d/%d approved", approved, required))
+	}
+	if len(extras) > 0 {
+		fmt.Fprintln(w, strings.Join(extras, " · "))
+	}
+
+	fmt.Fprintln(w)
+}
+
+// relativeTime renders an epoch-ms timestamp as a coarse "N units ago" string,
+// gh pr view style. Returns "" for a zero/missing timestamp.
+func relativeTime(epochMs int64) string {
+	if epochMs <= 0 {
+		return ""
+	}
+	d := time.Since(time.UnixMilli(epochMs))
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		n := int64(d.Minutes())
+		return fmt.Sprintf("• %d min%s ago", n, plural(n))
+	case d < 24*time.Hour:
+		n := int64(d.Hours())
+		return fmt.Sprintf("• %d hr%s ago", n, plural(n))
+	case d < 30*24*time.Hour:
+		n := int64(d.Hours() / 24)
+		return fmt.Sprintf("• %d day%s ago", n, plural(n))
+	case d < 365*24*time.Hour:
+		n := int64(d.Hours() / 24 / 30)
+		return fmt.Sprintf("• %d mon%s ago", n, plural(n))
+	default:
+		n := int64(d.Hours() / 24 / 365)
+		return fmt.Sprintf("• %d yr%s ago", n, plural(n))
+	}
+}
+
+// checkStatusText renders a merge_check_status value as a colorized one-liner,
+// following gh pr view's "✓ Checks passing" style.
+func checkStatusText(status string) string {
+	switch strings.ToLower(status) {
+	case "mergeable":
+		return console.WithColor(console.ColorGreen, "• ✓ Checks passing")
+	case "unchecked", "checking":
+		return console.WithColor(console.ColorYellow, "• … Checks running")
+	default:
+		return console.WithColor(console.ColorRed, "• ✗ Checks failing ("+status+")")
+	}
 }
 
 // plural returns "s" unless n is exactly 1.

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -113,6 +113,23 @@ func WithBold(text string) string {
 	return fmt.Sprintf("\x1b[1m%s\x1b[0m", text)
 }
 
+// WithItalic wraps text in an italic ANSI code (no color) when stdout is a TTY.
+func WithItalic(text string) string {
+	if !ensureStdoutTTY() {
+		return text
+	}
+	return fmt.Sprintf("\x1b[3m%s\x1b[0m", text)
+}
+
+// WithHighlight renders text in red on a dark grey background when stdout is
+// a TTY, used for inline code spans.
+func WithHighlight(text string) string {
+	if !ensureStdoutTTY() {
+		return text
+	}
+	return fmt.Sprintf("\x1b[91;48;5;236m%s\x1b[0m", text)
+}
+
 // ReadSecret prints prompt to stderr and reads a masked line from the terminal.
 func ReadSecret(prompt string) (string, error) {
 	if !ensureTTY() {

--- a/pkg/console/markdown.go
+++ b/pkg/console/markdown.go
@@ -1,0 +1,95 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package console
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	mdFence      = regexp.MustCompile("^```")
+	mdHeader     = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
+	mdBlockquote = regexp.MustCompile(`^>\s?(.*)$`)
+	mdBullet     = regexp.MustCompile(`^(\s*)[-*+]\s+(.*)$`)
+	mdNumbered   = regexp.MustCompile(`^(\s*)(\d+)([.)])\s+(.*)$`)
+
+	mdInlineCode = regexp.MustCompile("`([^`]+)`")
+	mdLink       = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	mdBold       = regexp.MustCompile(`\*\*([^*]+)\*\*|__([^_]+)__`)
+	mdItalic     = regexp.MustCompile(`\*([^*]+)\*`)
+)
+
+// RenderMarkdown renders a lightweight subset of Markdown (bold, italic, inline
+// code, fenced code blocks, headers, lists, blockquotes, links) as ANSI-styled
+// plain text for terminal display. It is a line-oriented best-effort renderer,
+// not a full CommonMark implementation: nested/overlapping emphasis, tables,
+// raw HTML, footnotes/reference-style links, checkbox lists, and cross-line
+// paragraph rewrapping are not specially handled and degrade to plain text.
+// Styling delegates to the With* helpers in this package, which already no-op
+// to plain text when stdout isn't a TTY.
+func RenderMarkdown(text string) string {
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	inFence := false
+
+	for _, line := range lines {
+		switch {
+		case mdFence.MatchString(strings.TrimSpace(line)):
+			inFence = !inFence
+		case inFence:
+			out = append(out, WithColor(ColorBrightBlack, "  "+line))
+		case mdHeader.MatchString(line):
+			m := mdHeader.FindStringSubmatch(line)
+			hashes := m[1]
+			if len(hashes) <= 2 {
+				out = append(out, hashes+" "+WithBoldColor(ColorCyan, renderInline(m[2])))
+			} else {
+				out = append(out, hashes+" "+WithColor(ColorCyan, renderInline(m[2])))
+			}
+		case mdBlockquote.MatchString(line):
+			m := mdBlockquote.FindStringSubmatch(line)
+			out = append(out, WithColor(ColorBrightBlack, "│ "+renderInline(m[1])))
+		case mdBullet.MatchString(line):
+			m := mdBullet.FindStringSubmatch(line)
+			out = append(out, m[1]+"• "+renderInline(m[2]))
+		case mdNumbered.MatchString(line):
+			m := mdNumbered.FindStringSubmatch(line)
+			out = append(out, m[1]+m[2]+m[3]+" "+renderInline(m[4]))
+		default:
+			out = append(out, renderInline(line))
+		}
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// renderInline applies inline styling (code spans, links, bold, italic) to a
+// single line of non-code, non-heading text. Order matters: code spans are
+// protected first so markers inside them are never treated as emphasis, then
+// links, then bold before italic (so "**x**" isn't partially matched by the
+// italic regex).
+func renderInline(line string) string {
+	line = mdLink.ReplaceAllStringFunc(line, func(m string) string {
+		sub := mdLink.FindStringSubmatch(m)
+		text, url := sub[1], sub[2]
+		return WithColor(ColorBrightBlue, text) + " (" + WithColor(ColorBrightBlack, url) + ")"
+	})
+	line = mdInlineCode.ReplaceAllStringFunc(line, func(m string) string {
+		inner := mdInlineCode.FindStringSubmatch(m)[1]
+		return WithHighlight(inner)
+	})
+	line = mdBold.ReplaceAllStringFunc(line, func(m string) string {
+		sub := mdBold.FindStringSubmatch(m)
+		if sub[1] != "" {
+			return WithBold(sub[1])
+		}
+		return WithBold(sub[2])
+	})
+	line = mdItalic.ReplaceAllStringFunc(line, func(m string) string {
+		sub := mdItalic.FindStringSubmatch(m)
+		return WithItalic(sub[1])
+	})
+	return line
+}


### PR DESCRIPTION
## Summary

  Reworks `harness get pr` rendering into a readable summary view, instead of the previous plain labeled-fields dump.

  - **Header**: `#<number> <title>` with a colorized state/draft badge, author/branch summary, file/commit/diff stats, and check status.
  - **Description**: rendered through a lightweight markdown formatter (`pkg/console/markdown.go`).
  - **Comments summary**: a collapsed "Not showing N comments" section at the end showing the newest comment (author, relative time, text), with a hint pointing at `harness list pr_comment <id>` to view the full conversation. Best-effort
  — fetched via the PR's activities endpoint; a failure or empty comment list simply omits the section without failing the command.

  ## Details
  
  - `modules/code/pr.go`: new `renderPRHeader`, description block, and comments-summary wiring in `GetPRWorkflow`/`renderPR`.
  - `modules/code/activity.go` (new): normalizes raw PR activity items and renders the collapsed comments summary (`renderCommentsSummary`) plus relative-time formatting.
  - `pkg/console/markdown.go` (new): minimal markdown-to-terminal renderer for the PR description.
  - `pkg/console/console.go`: small additions supporting the new rendering (colors/helpers).
  
  Comments are fetched inline via the existing PR activities endpoint (no new registered command) — kept intentionally minimal for now.