### PR TITLE
fix [#156]: honor HTTP(S)_PROXY in HAR migrate registry adapters

### DIFF
--- a/modules/har/pkg/har/migrate/adapter/harbor/client.go
+++ b/modules/har/pkg/har/migrate/adapter/harbor/client.go
@@ -58,7 +58,7 @@ func newClient(reg *types.RegistryConfig) *client {
 	return &client{
 		http: &http.Client{
 			Transport: &basicTransport{
-				base:     &http.Transport{TLSClientConfig: tlsCfg},
+				base:     &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: tlsCfg},
 				username: reg.Credentials.Username,
 				password: reg.Credentials.Password,
 			},

--- a/modules/har/pkg/har/migrate/adapter/jfrog/client.go
+++ b/modules/har/pkg/har/migrate/adapter/jfrog/client.go
@@ -59,7 +59,7 @@ func newClient(reg *types.RegistryConfig) *client {
 	return &client{
 		client: &http.Client{
 			Transport: &bearerTransport{
-				base:  &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+				base:  &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 				token: reg.Credentials.Password,
 			},
 		},

--- a/modules/har/pkg/har/migrate/adapter/nexus/client.go
+++ b/modules/har/pkg/har/migrate/adapter/nexus/client.go
@@ -37,7 +37,7 @@ func newClient(reg *types.RegistryConfig) *client {
 	return &client{
 		client: &http.Client{
 			Transport: &basicTransport{
-				base:     &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+				base:     &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 				username: username,
 				password: password,
 			},


### PR DESCRIPTION

  ## Summary
  Harbor, JFrog, and Nexus adapters built explicit http.Transport{}
  literals without setting Proxy, so unlike the zero-value http.Client
  (which falls back to http.DefaultTransport's ProxyFromEnvironment),
  these silently ignored HTTPS_PROXY/HTTP_PROXY/NO_PROXY.

  Fixes #156