### PR TITLE
 fix(registry): stop dropping the first native arg on NoId commands, and disambiguate optional-id vs. passthrough args after "--" (#159)

### DIFF
--- a/pkg/registry/buildctx.go
+++ b/pkg/registry/buildctx.go
@@ -168,6 +168,10 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 		return nil, fmt.Errorf("unexpected argument %q%s", args[1], cs.UsageLine())
 	}
 	nd := r.GetNoun(cs.Noun)
+	// consumedIdArg tracks whether args[0] was actually assigned to ctx.Id
+	// below, so the HasArgs/Set stripping logic further down only strips it
+	// when it's truly a leftover id, not a native/passthrough arg.
+	consumedIdArg := false
 	if vspec.NounPair {
 		if len(args) > 0 {
 			return nil, fmt.Errorf("%s %s does not take a positional argument; use --from/--to%s", cs.Verb, cs.FullNoun(), cs.UsageLine())
@@ -186,13 +190,21 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 		}
 		if len(args) > 0 {
 			ctx.Id = args[0]
+			consumedIdArg = true
 		}
 	} else if vspec.AllowsId || cs.AllowsId {
-		if cs.RequiresId && len(args) == 0 && !skipIdCheck {
+		// The id is optional here, so args[0] is only really the id if it
+		// precedes a "--" (or there's no "--" at all) — cs.HasArgs commands
+		// pass native/passthrough tokens after "--", which can look like a
+		// flag (e.g. "-r") without being one. ArgsLenAtDash is 0 when "--" is
+		// the very first token (no id given) and -1 when there's no "--".
+		idGiven := len(args) > 0 && cmd.Flags().ArgsLenAtDash() != 0
+		if cs.RequiresId && !idGiven && !skipIdCheck {
 			return nil, fmt.Errorf("%s %s requires a positional %s argument%s", cs.Verb, cs.Noun, idLabel, cs.UsageLine())
 		}
-		if len(args) > 0 {
+		if idGiven {
 			ctx.Id = args[0]
+			consumedIdArg = true
 		}
 	} else if vspec.AllowsParentId {
 		if len(args) > 0 {
@@ -245,12 +257,8 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 	}
 	if cs.HasArgs {
 		extra := args
-		if vspec.RequiresId || vspec.AllowsId {
-			if len(args) > 0 {
-				extra = args[1:]
-			} else {
-				extra = nil
-			}
+		if consumedIdArg {
+			extra = args[1:]
 		}
 		ctx.Args = extra
 	}
@@ -258,12 +266,8 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 		setVals, _ := cmd.Flags().GetStringArray("set")
 		// positional args after the id are also treated as key=value pairs
 		positional := args
-		if vspec.RequiresId || vspec.AllowsId {
-			if len(args) > 0 {
-				positional = args[1:]
-			} else {
-				positional = nil
-			}
+		if consumedIdArg {
+			positional = args[1:]
 		}
 		all := append(setVals, positional...)
 		if len(all) > 0 {


### PR DESCRIPTION
### Description:
buildCtx's HasArgs/BuiltinFlags.Set logic decided whether to strip args[0] (assuming it was a leftover <id>) by re-checking vspec.RequiresId || vspec.AllowsId, instead of tracking whether an id was actually assigned. This caused two bugs:

1. NoId commands lost their first arg. For RequiresId verbs with no_id: true and no allows_id (e.g. execute artifact:pip_install), the id-assignment branch correctly skips consuming args[0] — but the stripping logic still assumed it had, silently dropping the first native arg. harness execute artifact:pip_install -- -r requirements.txt invoked pip with just requirements.txt, not -r requirements.txt.
2. Optional-id + native-args ambiguity. For a verb where the id is optional (AllowsId) alongside has_args: true, args[0] could be a passthrough token from after -- (e.g. -r) that only looks like a flag, indistinguishable by position alone from a real id.

**Fix:** introduce consumedIdArg, set to true only at the exact point ctx.Id is actually assigned from args[0], and use it (instead of re-deriving the condition) for the downstream stripping logic. For the optional-id branch, resolve the ambiguity with cmd.Flags().ArgsLenAtDash() — the id is only real if it precedes a literal -- (or there's no -- at all); if -- is the very first token, nothing was given as an id, regardless of how many flags preceded it.

Fixes #159