### PR TITLE
Distinguish cursor and checked colors in column picker

### DIFF
--- a/pkg/registry/uitableview.go
+++ b/pkg/registry/uitableview.go
@@ -626,7 +626,7 @@ func (m uiTableModel) colPickView() string {
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(tui.CLIAccent))
 	subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(tui.CLITextMuted))
 	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(tui.CLIAccent)).Bold(true)
-	checkedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(tui.CLIAccent)).Bold(true)
+	checkedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(tui.CLIBrightWhite)).Bold(true)
 
 	b.WriteString(titleStyle.Render("  columns") + "\n\n")
 

--- a/pkg/tui/palette.go
+++ b/pkg/tui/palette.go
@@ -5,13 +5,14 @@ package tui
 
 // Harness CLI terminal palette — fixed dark theme (docs/design-system.md).
 const (
-	CLIAccent     = "#5EB8FF"
-	CLIText       = "#CED1D7"
-	CLITextMuted  = "#989EA8"
-	CLITextSubtle = "#848892"
-	CLIBorder     = "#343A47"
-	CLIBgElevated = "#1A1B1E"
-	CLIError      = "#FF7870"
-	CLISuccess    = "#5DE28D"
-	CLIWarning    = "#FFC833"
+	CLIAccent      = "#5EB8FF"
+	CLIBrightWhite = "#FFFFFF"
+	CLIText        = "#CED1D7"
+	CLITextMuted   = "#989EA8"
+	CLITextSubtle  = "#848892"
+	CLIBorder      = "#343A47"
+	CLIBgElevated  = "#1A1B1E"
+	CLIError       = "#FF7870"
+	CLISuccess     = "#5DE28D"
+	CLIWarning     = "#FFC833"
 )


### PR DESCRIPTION
Cursor and checked-column highlighting used the same accent blue, making it hard to tell where the cursor is when the first few columns are selected. Cursor stays blue; checked columns now use bright white.

AI-Session-Id: 5cbc5a0d-6ad2-4a2d-9c3a-085606e56121
AI-Tool: claude-code
AI-Model: unknown