### PR TITLE
Add get pr_check:log to resolve a PR check straight to its pipeline stage logs

### DIFF
--- a/modules/code/code.go
+++ b/modules/code/code.go
@@ -25,6 +25,7 @@ func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterWorkflow(getPRWorkflowID, GetPRWorkflow)
 	reg.RegisterWorkflow(pullRepositoryWorkflowID, pullRepositoryWorkflow)
 	reg.RegisterWorkflow(pullPRWorkflowID, pullPRWorkflow)
+	reg.RegisterWorkflow(getPRCheckLogWorkflowID, getPRCheckLogHandler)
 	reg.RegisterTextFormatter(reviewGroupTextFormatterID, reviewGroupTextFormatter)
 	reg.RegisterTextFormatter(insightTextFormatterID, insightTextFormatter)
 }

--- a/modules/code/pr_check_log.go
+++ b/modules/code/pr_check_log.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package code
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/endpoint"
+	"github.com/harness/cli/pkg/exprenv"
+	"github.com/harness/cli/pkg/extractutil"
+	"github.com/harness/cli/pkg/logstream"
+)
+
+const getPRCheckLogWorkflowID = "get_pr_check_log"
+
+// getPRCheckLogHandler implements "get pr_check:log". It resolves a PR status check
+// to its backing pipeline execution and fetches that execution's stage logs, scoped
+// to the pipeline's own org/project (which may differ from the ambient auth scope).
+func getPRCheckLogHandler(ctx *cmdctx.Ctx) error {
+	if len(ctx.IdParts) != 3 || ctx.IdParts[0] == "" || ctx.IdParts[1] == "" || ctx.IdParts[2] == "" {
+		return fmt.Errorf("expected <repo_id>/<pr_number>/<check_identifier>")
+	}
+	repoID, prNumber, checkIdentifier := ctx.IdParts[0], ctx.IdParts[1], ctx.IdParts[2]
+
+	listSpec := ctx.Resolver.GetSpec("list", "pr_check")
+	if listSpec == nil || listSpec.Endpoint == nil {
+		return fmt.Errorf("list pr_check command spec not found")
+	}
+
+	listCtx := *ctx
+	listCtx.ParentId = repoID + "/" + prNumber
+	items, _, err := endpoint.FetchItems(&listCtx, listSpec.Endpoint, cmdctx.PagingFlags{All: true})
+	if err != nil {
+		return fmt.Errorf("fetching checks for %s/%s: %w", repoID, prNumber, err)
+	}
+
+	exprEnv := exprenv.Make(ctx)
+	var match any
+	var available []string
+	for _, item := range items {
+		data := extractutil.MakeDataAccessor(exprEnv, item)
+		identifier := data.GetString("it.check.identifier")
+		available = append(available, identifier)
+		if strings.EqualFold(identifier, checkIdentifier) {
+			match = item
+			break
+		}
+	}
+	if match == nil {
+		return fmt.Errorf("no check %q found on %s/%s (available: %s)", checkIdentifier, repoID, prNumber, strings.Join(available, ", "))
+	}
+
+	data := extractutil.MakeDataAccessor(exprEnv, match)
+	pipelineOrg := data.GetString("it.check.payload.data.org_identifier")
+	pipelineProject := data.GetString("it.check.payload.data.project_identifier")
+	pipelineID := data.GetString("it.check.payload.data.pipeline_identifier")
+	executionID := data.GetString("it.check.payload.data.execution_id")
+	stageID := data.GetString("it.check.payload.data.stage_identifier")
+
+	if pipelineID == "" || executionID == "" {
+		return fmt.Errorf("check %q has no associated pipeline execution (not a Harness pipeline check)", checkIdentifier)
+	}
+
+	fmt.Fprintf(os.Stderr, "check:      %s\n", checkIdentifier)
+	fmt.Fprintf(os.Stderr, "pipeline:   %s  (org: %s, project: %s)\n", pipelineID, pipelineOrg, pipelineProject)
+	fmt.Fprintf(os.Stderr, "execution:  %s\n", executionID)
+	fmt.Fprintf(os.Stderr, "stage:      %s\n", stageID)
+
+	scopedAuth := *ctx.Auth
+	scopedAuth.OrgID = pipelineOrg
+	scopedAuth.ProjectID = pipelineProject
+	scopedCtx := *ctx
+	scopedCtx.Auth = &scopedAuth
+
+	if err := logstream.FollowMulti(&scopedCtx, executionID, stageID, "", logstream.MultiStyleMarkers, nil); err != nil {
+		return fmt.Errorf("fetching logs from %s/%s: %w (you may not have access to this org/project)", pipelineOrg, pipelineProject, err)
+	}
+	return nil
+}

--- a/modules/pipeline/execution_log.go
+++ b/modules/pipeline/execution_log.go
@@ -84,6 +84,7 @@ func getPipelineLogHandler(ctx *cmdctx.Ctx) error {
 	if err != nil {
 		return err
 	}
+	entries = logstream.StageSubtreeEntries(entries, stageFlag)
 
 	type result struct {
 		name string
@@ -93,9 +94,6 @@ func getPipelineLogHandler(ctx *cmdctx.Ctx) error {
 	var results []result
 	for _, e := range entries {
 		if prefixFlag != "" && !strings.HasPrefix(e.LogKey, prefixFlag) {
-			continue
-		}
-		if stageFlag != "" && !strings.EqualFold(e.ParentName, stageFlag) && !strings.EqualFold(e.Name, stageFlag) {
 			continue
 		}
 		if stepFlag != "" && !strings.EqualFold(e.Name, stepFlag) {

--- a/pkg/logstream/logstream.go
+++ b/pkg/logstream/logstream.go
@@ -81,31 +81,38 @@ func RenderLogLinesToWriter(text, fmtFlag string, isPty bool, w io.Writer) error
 		Time  string `json:"time"`
 	}
 
-	sc := bufio.NewScanner(strings.NewReader(text))
-	for sc.Scan() {
-		line := sc.Text()
-		if line == "" {
-			continue
+	// bufio.Reader.ReadString grows its buffer as needed instead of erroring on
+	// lines longer than a fixed token size, unlike bufio.Scanner.
+	r := bufio.NewReader(strings.NewReader(text))
+	for {
+		raw, rerr := r.ReadString('\n')
+		line := strings.TrimRight(raw, "\r\n")
+		if line != "" {
+			var ll logLine
+			if err := json.Unmarshal([]byte(line), &ll); err != nil {
+				fmt.Fprintln(w, line)
+			} else {
+				ts := ll.Time
+				if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+					ts = t.UTC().Format("2006-01-02 15:04:05")
+				}
+				out := strings.TrimRight(ll.Out, "\n")
+				out = strings.ReplaceAll(out, "\r", "")
+				if !isPty {
+					out = console.StripANSI(out)
+					fmt.Fprintf(w, "%s [%s] %s\n", ts, ll.Level, out)
+				} else {
+					fmt.Fprintf(w, "%s [%s] %s\033[0m\n", ts, ll.Level, out)
+				}
+			}
 		}
-		var ll logLine
-		if err := json.Unmarshal([]byte(line), &ll); err != nil {
-			fmt.Fprintln(w, line)
-			continue
-		}
-		ts := ll.Time
-		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
-			ts = t.UTC().Format("2006-01-02 15:04:05")
-		}
-		out := strings.TrimRight(ll.Out, "\n")
-		out = strings.ReplaceAll(out, "\r", "")
-		if !isPty {
-			out = console.StripANSI(out)
-			fmt.Fprintf(w, "%s [%s] %s\n", ts, ll.Level, out)
-		} else {
-			fmt.Fprintf(w, "%s [%s] %s\033[0m\n", ts, ll.Level, out)
+		if rerr != nil {
+			if rerr == io.EOF {
+				return nil
+			}
+			return rerr
 		}
 	}
-	return sc.Err()
 }
 
 // FetchAndPrintLog fetches a log blob and writes it to out.
@@ -342,14 +349,17 @@ func StreamSSEToChannel(ctx context.Context, hc *http.Client, a *auth.ResolvedAu
 	}
 
 	var hadContent bool
-	sc := bufio.NewScanner(resp.Body)
+	// bufio.Reader.ReadString grows its buffer as needed instead of erroring on
+	// lines longer than a fixed token size, unlike bufio.Scanner.
+	r := bufio.NewReader(resp.Body)
 	var eventType, dataLine string
-	for sc.Scan() {
-		line := sc.Text()
-		if strings.HasPrefix(line, ":") {
-			continue
-		}
-		if line == "" {
+	for {
+		raw, rerr := r.ReadString('\n')
+		line := strings.TrimRight(raw, "\r\n")
+		switch {
+		case strings.HasPrefix(line, ":"):
+			// comment line, ignore
+		case line == "":
 			if eventType == "error" && dataLine == "eof" {
 				return hadContent, nil
 			}
@@ -363,15 +373,18 @@ func StreamSSEToChannel(ctx context.Context, hc *http.Client, a *auth.ResolvedAu
 			}
 			eventType = ""
 			dataLine = ""
-			continue
-		}
-		if strings.HasPrefix(line, "event:") {
+		case strings.HasPrefix(line, "event:"):
 			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-		} else if strings.HasPrefix(line, "data:") {
+		case strings.HasPrefix(line, "data:"):
 			dataLine = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				return hadContent, nil
+			}
+			return hadContent, rerr
+		}
 	}
-	return hadContent, sc.Err()
 }
 
 // FetchBlobToChannel fetches a completed log blob and sends it as a single EvBlob event.
@@ -464,6 +477,38 @@ func FetchLogKeys(ctx *cmdctx.Ctx, execId string) ([]LogKeyEntry, string, error)
 	return entries, exec.PipelineStatus, nil
 }
 
+// StageSubtreeEntries filters entries down to the full subtree of steps nested under the
+// stage named stageFilter, excluding the stage's own top-level entry. Subtree membership is
+// determined via BaseFQN (a dot-delimited ancestry path), not immediate-parent name, so
+// steps nested behind containers like spec.execution or a parallel step-group are included.
+// Returns nil if no entry's name matches stageFilter. stageFilter == "" returns entries
+// unchanged.
+func StageSubtreeEntries(entries []LogKeyEntry, stageFilter string) []LogKeyEntry {
+	if stageFilter == "" {
+		return entries
+	}
+	var stageFQN string
+	found := false
+	for _, e := range entries {
+		if strings.EqualFold(e.Name, stageFilter) {
+			stageFQN = e.FQN
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	prefix := stageFQN + "."
+	var out []LogKeyEntry
+	for _, e := range entries {
+		if strings.HasPrefix(e.FQN, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // FollowMulti follows all log keys for an execution (or a stage/step filtered subset).
 // extraSkipTypes supplements BaseSkipStepTypes — pass nil to use the base set only.
 func FollowMulti(ctx *cmdctx.Ctx, execId, stageFilter, stepFilter string, style MultiStyle, extraSkipTypes map[string]bool) error {
@@ -499,9 +544,11 @@ func FollowMulti(ctx *cmdctx.Ctx, execId, stageFilter, stepFilter string, style 
 	var finalStatus string
 	var hasSSE bool
 
-	nodeMatchesFilter := func(node execgraph.GraphNode, parentName string) bool {
-		name := execgraph.NodeName(node)
-		if stageFilter != "" && !strings.EqualFold(name, stageFilter) && !strings.EqualFold(parentName, stageFilter) {
+	// nodeMatchesFilter is evaluated during the graph walk below, which tracks insideStage:
+	// true once we've descended into the matched stage's subtree via any edge. The stage's
+	// own top-level node is walked with insideStage still false, so it's excluded.
+	nodeMatchesFilter := func(name string, insideStage bool) bool {
+		if stageFilter != "" && !insideStage {
 			return false
 		}
 		if stepFilter != "" && !strings.EqualFold(name, stepFilter) {
@@ -526,16 +573,21 @@ func FollowMulti(ctx *cmdctx.Ctx, execId, stageFilter, stepFilter string, style 
 
 		seenNode := make(map[string]bool)
 		var newNodes []nodeEntry
-		var walk func(id string, parentName string)
-		walk = func(id string, parentName string) {
+		var walk func(id string, insideStage bool)
+		walk = func(id string, insideStage bool) {
 			if seenNode[id] {
 				return
 			}
 			seenNode[id] = true
 			node := exec.Graph.NodeMap[id]
 			name := execgraph.NodeName(node)
+			// Only detect stage entry from OUTSIDE the stage — once already inside, a
+			// deeper node coincidentally sharing the stage's display name (e.g. stage
+			// "MessageCheck" containing a step also named "messagecheck") must not be
+			// mistaken for a fresh entry into the stage.
+			childInsideStage := insideStage || (stageFilter != "" && strings.EqualFold(name, stageFilter))
 			if execgraph.HasLogs(node) && !skipTypes[node.StepType] {
-				if !nodeStarted[node.UUID] && nodeMatchesFilter(node, parentName) {
+				if !nodeStarted[node.UUID] && nodeMatchesFilter(name, insideStage) {
 					bucket := format.ClassifyExecutionStatus(node.Status)
 					if bucket == format.StatusRunning || bucket == format.StatusSuccess || bucket == format.StatusSkipped || bucket == format.StatusFailed {
 						newNodes = append(newNodes, nodeEntry{logUnits: execgraph.GetLogUnits(node), node: node, rank: node.Rank})
@@ -543,14 +595,14 @@ func FollowMulti(ctx *cmdctx.Ctx, execId, stageFilter, stepFilter string, style 
 				}
 			}
 			for _, child := range exec.Graph.NodeAdjacencyListMap[id].Children {
-				walk(child, name)
+				walk(child, childInsideStage)
 			}
 			for _, next := range exec.Graph.NodeAdjacencyListMap[id].NextIDs {
-				walk(next, parentName)
+				walk(next, insideStage)
 			}
 		}
 		if exec.Graph.RootNodeID != "" {
-			walk(exec.Graph.RootNodeID, "")
+			walk(exec.Graph.RootNodeID, false)
 		}
 
 		hlog.Debug("pollOnce", "pipelineStatus", exec.PipelineStatus, "newNodes", len(newNodes))

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -1704,7 +1704,33 @@ commands:
       get_id_expr: it.check.identifier
       paging:
         paging_strategy: flat_list
+      completion:
+        id_expr: it.check.identifier
+        name_expr: it.check.status
       columns: [identifier, status, required, summary, reported_by, duration]
+
+  - command: get pr_check:log
+    verb: get
+    noun: pr_check
+    noun_variant: log
+    short: "Fetch pipeline logs for a PR check: harness get pr_check:log <repo_id>/<pr_number>/<check_identifier>"
+    long: |
+      Resolves a pull request status check to its backing Harness pipeline execution
+      and dumps the logs of every step under that execution's stage, in order
+      (excluding the stage's own top-level log), scoped to the pipeline's own
+      org/project (which may differ from the current --profile/--org/--project).
+      If the stage is still running, streams live and exits when it reaches a
+      terminal state. Fails with a clear error if the check has no associated
+      pipeline execution (external check, webhook-reported status, etc).
+    handler_type: workflow
+    workflow_id: get_pr_check_log
+    id_parts: 3
+    id_label: "<repo_id>/<pr_number>/<check_identifier>"
+    completion_seq:
+      - completion_noun: repository
+      - completion_noun: pr
+        keep_order: true
+      - completion_noun: pr_check
 
   # ── pr_comment ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Resolves a PR status check to its backing pipeline execution and dumps every step log under that execution's stage, in order, scoped to the pipeline's own org/project. Fixes FollowMulti's stage-subtree matching along the way: it previously matched by comparing a node's own or immediate-parent display name against the stage filter, missing steps nested behind containers like spec.execution or a parallel step-group, and misfiring on name collisions between a stage and a step nested inside it. get execution_log --stage shared the same shallow-match bug and is fixed by the same change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

AI-Session-Id: 50d7e53f-08ac-41a0-a3b6-a8ffb19d5323
AI-Tool: claude-code
AI-Model: unknown