### PR TITLE
Colorize status icons for commit_check and pr_check

### DIFF
--- a/pkg/format/formatstatus.go
+++ b/pkg/format/formatstatus.go
@@ -16,20 +16,25 @@ const (
 )
 
 // ClassifyExecutionStatus maps a Harness execution status string (PascalCase or
-// legacy SCREAMING_SNAKE_CASE) to one of the five display buckets.
+// legacy SCREAMING_SNAKE_CASE) to one of the five display buckets. Also accepts
+// the lowercase Harness Code check-status vocabulary (pending, running, success,
+// failure, failure_ignored, error).
 func ClassifyExecutionStatus(status string) ExecutionStatusBucket {
 	switch status {
 	case "Success", "IgnoreFailed",
-		"IGNORE_FAILED":
+		"IGNORE_FAILED",
+		"success", "failure_ignored":
 		return StatusSuccess
 	case "Skipped", "SKIPPED":
 		return StatusSkipped
 	case "Failed", "Errored", "Aborted", "AbortedByFreeze", "Expired",
 		"ApprovalRejected", "RollbackFailed",
-		"APPROVAL_REJECTED", "ROLLBACK_FAILED":
+		"APPROVAL_REJECTED", "ROLLBACK_FAILED",
+		"failure", "error":
 		return StatusFailed
 	case "Running", "Pausing", "Discontinuing",
-		"AsyncWaiting", "TaskWaiting", "TimedWaiting", "WaitStepRunning", "UploadWaiting":
+		"AsyncWaiting", "TaskWaiting", "TimedWaiting", "WaitStepRunning", "UploadWaiting",
+		"running":
 		return StatusRunning
 	case "ResourceWaiting",
 		"InterventionWaiting", "ApprovalWaiting",
@@ -38,7 +43,8 @@ func ClassifyExecutionStatus(status string) ExecutionStatusBucket {
 		"QueuedExecutionConcurrencyReached", "QueuedGlobalInfraCapacityReached",
 		"Suspended", "NotStarted",
 		"ASYNC_WAITING", "TASK_WAITING", "TIMED_WAITING",
-		"INTERVENTION_WAITING", "APPROVAL_WAITING", "NOT_STARTED":
+		"INTERVENTION_WAITING", "APPROVAL_WAITING", "NOT_STARTED",
+		"pending":
 		return StatusWaiting
 	default:
 		return StatusNoData

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -276,7 +276,7 @@ nouns:
       - id: identifier
         expr: it.identifier
       - id: status
-        expr: it.status
+        expr: spaceAfter(statusIcon(it.status)) + it.status
       - id: summary
         expr: it.summary
         width_max: 60
@@ -314,7 +314,7 @@ nouns:
       - id: identifier
         expr: it.check.identifier
       - id: status
-        expr: it.check.status
+        expr: spaceAfter(statusIcon(it.check.status)) + it.check.status
       - id: required
         expr: it.required
       - id: summary


### PR DESCRIPTION
Match the same statusIcon/spaceAfter treatment used for pipeline executions, degrading to plain text on non-TTY or machine formats (csv/tsv/json). Extends ClassifyExecutionStatus to also recognize the lowercase Harness Code check-status vocabulary.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

AI-Session-Id: 2dd9d37b-6aea-4cc2-b4c7-487117ff5817
AI-Tool: claude-code
AI-Model: unknown