### PR TITLE
Add pr detail ui_commands and reserve scroll keys from ui_commands checks

### DIFF
--- a/pkg/registry/checks.go
+++ b/pkg/registry/checks.go
@@ -29,6 +29,14 @@ func (r *Registry) CheckFunctions() error {
 	return nil
 }
 
+// reservedUIKeys are hardcoded to scroll/quit/print handling in the detail
+// overlay's key switch (see uitableview.go) and never reach ui_commands
+// dispatch, so a spec binding one of them would silently never fire.
+var reservedUIKeys = map[string]bool{
+	"p": true, "q": true, "ctrl+c": true, "esc": true, "backspace": true,
+	"up": true, "down": true, "k": true, "j": true, "pgup": true, "pgdown": true,
+}
+
 // checkUICommands validates a noun's ui_commands list: unique non-reserved keys,
 // exactly one default text entry, and that every text/link/view target resolves.
 func (r *Registry) checkUICommands(noun string, nd spec.NounDef) []string {
@@ -41,7 +49,7 @@ func (r *Registry) checkUICommands(noun string, nd spec.NounDef) []string {
 	for _, uc := range nd.UICommands {
 		if uc.Key == "" {
 			errs = append(errs, fmt.Sprintf("noun %q: ui_commands entry missing key", noun))
-		} else if uc.Key == "p" || uc.Key == "q" {
+		} else if reservedUIKeys[uc.Key] {
 			errs = append(errs, fmt.Sprintf("noun %q: ui_commands key %q is reserved", noun, uc.Key))
 		} else if seenKeys[uc.Key] {
 			errs = append(errs, fmt.Sprintf("noun %q: ui_commands key %q is duplicated", noun, uc.Key))

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -174,6 +174,22 @@ nouns:
         expr: epochMs(it.updated)
       - id: merged
         expr: epochMs(it.merged)
+    ui_commands:
+      - ui_command_type: text
+        key: d
+        label: details
+        noun: pr
+        default: true
+      - ui_command_type: link
+        key: c
+        label: list commits
+        verb: list
+        noun: pr_commit
+      - ui_command_type: link
+        key: s
+        label: list checks
+        verb: list
+        noun: pr_check
 
   - noun: branch
     short_desc: A git branch in a Harness Code repository.


### PR DESCRIPTION
Wires the --ui detail overlay for pr to link into list pr_commit/pr_check, since get pr's id already matches their <repo_id>/<pr_number> parentid shape. Also extends checkUICommands' reserved-key set beyond p/q to cover all keys hardcoded to scroll/quit handling, so a spec binding one of them fails validation instead of silently never firing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

AI-Session-Id: f41cfe8c-4e4b-44c7-b71d-379f732b29fe
AI-Tool: claude-code
AI-Model: unknown