### PR TITLE
Feat: Add up ui_command_type for parent navigation via a custom id expression

### DIFF
--- a/pkg/registry/checks.go
+++ b/pkg/registry/checks.go
@@ -80,6 +80,21 @@ func (r *Registry) checkUICommands(noun string, nd spec.NounDef) []string {
 			if _, ok := r.workflows[uc.UIHandlerFn]; !ok {
 				errs = append(errs, fmt.Sprintf("noun %q: ui_commands view entry %q: ui_handler_fn %q not registered", noun, uc.Key, uc.UIHandlerFn))
 			}
+		case spec.UICommandUp:
+			if uc.Default {
+				errs = append(errs, fmt.Sprintf("noun %q: ui_commands up entry %q: default is only allowed on text entries", noun, uc.Key))
+			}
+			verb := uc.Verb
+			if verb == "" {
+				verb = VerbGet
+			}
+			if verb != VerbList && verb != VerbGet {
+				errs = append(errs, fmt.Sprintf("noun %q: ui_commands up entry %q: verb must be %q or %q", noun, uc.Key, VerbList, VerbGet))
+			} else if targetCs := r.GetSpec(verb, uc.Noun); targetCs == nil {
+				errs = append(errs, fmt.Sprintf("noun %q: ui_commands up entry %q: %s %q does not resolve", noun, uc.Key, verb, uc.Noun))
+			} else if uc.UpIdExpr == "" && upTargetRequiresId(verb, targetCs) {
+				errs = append(errs, fmt.Sprintf("noun %q: ui_commands up entry %q: up_id_expr is required (%s %q requires an id)", noun, uc.Key, verb, uc.Noun))
+			}
 		default:
 			errs = append(errs, fmt.Sprintf("noun %q: ui_commands entry %q: invalid ui_command_type %q", noun, uc.Key, uc.UICommandType))
 		}
@@ -88,6 +103,20 @@ func (r *Registry) checkUICommands(noun string, nd spec.NounDef) []string {
 		errs = append(errs, fmt.Sprintf("noun %q: ui_commands requires exactly one default text entry, found %d", noun, defaultCount))
 	}
 	return errs
+}
+
+// upTargetRequiresId reports whether an up entry's resolved target command
+// actually needs an id to run: get commands need ctx.Id unless opted out via
+// NoId, list commands only need ctx.ParentId when requires_parentid is set.
+func upTargetRequiresId(verb string, cs *spec.CommandSpec) bool {
+	switch verb {
+	case VerbGet:
+		return verbRegistry[VerbGet].RequiresId && !cs.NoId
+	case VerbList:
+		return cs.RequiresParentId
+	default:
+		return false
+	}
 }
 
 func (r *Registry) checkFunctionsSpec(cs *spec.CommandSpec) []string {

--- a/pkg/registry/uitableview.go
+++ b/pkg/registry/uitableview.go
@@ -32,6 +32,10 @@ type uiDetailModel struct {
 	err     string
 	lines   []string
 	scroll  int
+	// upIds maps an "up" ui_commands entry's key to its up_id_expr result,
+	// evaluated against this detail's item once when it's fetched (see
+	// fetchDetail) since that's the only place the raw item data is available.
+	upIds map[string]string
 }
 
 // uiLinkTarget carries a resolved link-type ui_commands entry to follow once
@@ -45,6 +49,7 @@ type uiLinkTarget struct {
 // uiDetailMsg is sent when a background detail fetch completes.
 type uiDetailMsg struct {
 	content string
+	upIds   map[string]string
 	err     error
 }
 
@@ -513,6 +518,20 @@ func (m uiTableModel) dispatchUICommandKey(key string) (uiTableModel, tea.Cmd, b
 		case spec.UICommandLink:
 			m.linkTarget = &uiLinkTarget{verb: uc.Verb, noun: uc.Noun, id: m.detail.id}
 			return m, tea.Quit, true
+		case spec.UICommandUp:
+			id := m.detail.upIds[uc.Key]
+			if id == "" && uc.UpIdExpr != "" {
+				// up_id_expr was declared but the current item had nothing at
+				// that path (e.g. an externally-reported check) — nothing to
+				// jump to.
+				return m, nil, true
+			}
+			verb := uc.Verb
+			if verb == "" {
+				verb = VerbGet
+			}
+			m.linkTarget = &uiLinkTarget{verb: verb, noun: uc.Noun, id: id}
+			return m, tea.Quit, true
 		}
 	}
 	return m, nil, false
@@ -552,7 +571,17 @@ func (m uiTableModel) fetchDetail(id string) tea.Cmd {
 		if err := textFmt(&buf, extractutil.MakeDataAccessor(exprEnv, payload)); err != nil {
 			return uiDetailMsg{err: err}
 		}
-		return uiDetailMsg{content: buf.String()}
+		var upIds map[string]string
+		itEnv := exprenv.WithIt(exprEnv, payload)
+		for _, uc := range m.uiCommands {
+			if uc.UICommandType == spec.UICommandUp {
+				if upIds == nil {
+					upIds = make(map[string]string)
+				}
+				upIds[uc.Key] = exprenv.EvalExpr(itEnv, uc.UpIdExpr)
+			}
+		}
+		return uiDetailMsg{content: buf.String(), upIds: upIds}
 	}
 }
 
@@ -615,6 +644,8 @@ func uiCommandHintLabel(uc spec.UICommand) string {
 		return uc.Verb + " " + strings.ReplaceAll(uc.Noun, "_", " ")
 	case spec.UICommandView:
 		return "view"
+	case spec.UICommandUp:
+		return "up " + strings.ReplaceAll(uc.Noun, "_", " ")
 	default:
 		return ""
 	}
@@ -683,6 +714,7 @@ func (m uiTableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.detail.lines = strings.Split(strings.TrimRight(msg.content, "\n"), "\n")
 			m.detail.scroll = 0
+			m.detail.upIds = msg.upIds
 		}
 		return m, nil
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -238,10 +238,15 @@ const (
 	UICommandText = "text"
 	UICommandLink = "link"
 	UICommandView = "view"
+	// UICommandUp jumps to another noun's get detail using an id derived from
+	// fields on the current item's own data (via UpIdExpr), not the current
+	// item's id or its ParentId. Must be declared explicitly per noun — there
+	// is no implicit "go up" navigation stack.
+	UICommandUp = "up"
 )
 
 // UICommand is a single hotkey offered by a noun's --ui detail overlay. One flat
-// struct for all three ui_command_types, matching how CommandSpec/EndpointSpec
+// struct for all ui_command_types, matching how CommandSpec/EndpointSpec
 // already mix fields that only apply to some verbs/shapes — checks.go enforces
 // which fields are required/forbidden for which type.
 type UICommand struct {
@@ -254,12 +259,17 @@ type UICommand struct {
 	// Only valid on text entries; exactly one text entry per noun must set it.
 	Default bool `yaml:"default,omitempty"`
 	// Noun is a full "noun[:variant]" string resolved via GetSpec(VerbGet, ...)
-	// for text entries, or GetSpec(Verb, ...) for link entries.
+	// for text entries, or GetSpec(Verb, ...) for link/up entries.
 	Noun string `yaml:"noun,omitempty"`
-	// Verb is the link target's verb: "list" or "get". Link only.
+	// Verb is the link target's verb: "list" or "get". Required for link;
+	// for up it's optional and defaults to "get".
 	Verb string `yaml:"verb,omitempty"`
 	// UIHandlerFn is the registered workflow id to hand off to. View only.
 	UIHandlerFn string `yaml:"ui_handler_fn,omitempty"`
+	// UpIdExpr is an expr-lang expression evaluated against the current
+	// item ("it") to derive the target id for an "up" jump, e.g.
+	// "it.check.payload.data.execution_id". Up only, required.
+	UpIdExpr string `yaml:"up_id_expr,omitempty"`
 }
 
 // FieldDef defines a named, reusable field for a noun. Fields declared here can be


### PR DESCRIPTION
### Summary

  - Introduces a new ui_command_type: up for the --ui detail overlay, letting a noun declare an explicit "jump to a related noun" hotkey whose target id is derived from an expression against the
    current item's own data (up_id_expr), rather than reusing the item's id or its ParentId. There is no implicit navigation stack — each noun opts in explicitly, same as link/view.
  - up entries take an optional verb: get|list (defaults to get), so they can target either a get or list command, same as link.
  - up_id_expr is only required when the resolved target command actually needs an id — checked against the verb's RequiresId/NoId/RequiresParentId, not assumed.
  - Dispatch reuses the existing link-navigation machinery (uiLinkTarget / dispatchUILink) once the id is resolved, so no new navigation path was needed.

 ### Changes

  - pkg/spec/spec.go: added UICommandUp constant and UpIdExpr field on UICommand.
  - pkg/registry/checks.go: validates up entries (verb, target resolution, and conditional up_id_expr requirement via new upTargetRequiresId helper).
  - pkg/registry/uitableview.go: fetchDetail evaluates each up entry's up_id_expr against the fetched item and caches results on uiDetailModel.upIds; dispatchUICommandKey resolves the id on
    keypress and hands off to the existing link-quit flow.