### PR TITLE
 feat: Wire up end-to-end --ui click-through for PR review (repo → PR → checks → logs)

### DIFF
--- a/modules/code/code.go
+++ b/modules/code/code.go
@@ -26,6 +26,7 @@ func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterWorkflow(pullRepositoryWorkflowID, pullRepositoryWorkflow)
 	reg.RegisterWorkflow(pullPRWorkflowID, pullPRWorkflow)
 	reg.RegisterWorkflow(getPRCheckLogWorkflowID, getPRCheckLogHandler)
+	reg.RegisterWorkflow(getPRCheckWorkflowID, getPRCheckHandler)
 	reg.RegisterTextFormatter(reviewGroupTextFormatterID, reviewGroupTextFormatter)
 	reg.RegisterTextFormatter(insightTextFormatterID, insightTextFormatter)
 }

--- a/modules/code/code.go
+++ b/modules/code/code.go
@@ -27,6 +27,7 @@ func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterWorkflow(pullPRWorkflowID, pullPRWorkflow)
 	reg.RegisterWorkflow(getPRCheckLogWorkflowID, getPRCheckLogHandler)
 	reg.RegisterWorkflow(getPRCheckWorkflowID, getPRCheckHandler)
+	reg.RegisterItemFn(getPRCheckItemFnID, getPRCheckItemFn)
 	reg.RegisterTextFormatter(reviewGroupTextFormatterID, reviewGroupTextFormatter)
 	reg.RegisterTextFormatter(insightTextFormatterID, insightTextFormatter)
 }

--- a/modules/code/code.go
+++ b/modules/code/code.go
@@ -28,6 +28,7 @@ func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterWorkflow(getPRCheckLogWorkflowID, getPRCheckLogHandler)
 	reg.RegisterWorkflow(getPRCheckWorkflowID, getPRCheckHandler)
 	reg.RegisterItemFn(getPRCheckItemFnID, getPRCheckItemFn)
+	reg.RegisterItemFn(getPRCheckLogItemFnID, getPRCheckLogItemFn)
 	reg.RegisterTextFormatter(reviewGroupTextFormatterID, reviewGroupTextFormatter)
 	reg.RegisterTextFormatter(insightTextFormatterID, insightTextFormatter)
 }

--- a/modules/code/code.go
+++ b/modules/code/code.go
@@ -31,4 +31,5 @@ func ModuleInit(reg registry.ModuleRegistrar) {
 	reg.RegisterItemFn(getPRCheckLogItemFnID, getPRCheckLogItemFn)
 	reg.RegisterTextFormatter(reviewGroupTextFormatterID, reviewGroupTextFormatter)
 	reg.RegisterTextFormatter(insightTextFormatterID, insightTextFormatter)
+	reg.RegisterTextFormatter(prTextFormatterID, prTextFormatter)
 }

--- a/modules/code/insight_test.go
+++ b/modules/code/insight_test.go
@@ -33,6 +33,7 @@ func (noopResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn        
 func (noopResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn             { return nil }
 func (noopResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)                { return nil, nil }
 func (noopResolver) ResolveListTransformFn(id string) cmdctx.ListTransformFn         { return nil }
+func (noopResolver) ResolveItemFn(id string) cmdctx.ItemFn                           { return nil }
 func (noopResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn   { return nil }
 func (noopResolver) GetSpec(verb, noun string) *spec.CommandSpec                     { return nil }
 func (noopResolver) GetNoun(noun string) *spec.NounDef                               { return nil }
@@ -591,6 +592,7 @@ func (s *moduleInitSpy) RegisterQueryParamsFn(string, cmdctx.QueryParamsFn)     
 func (s *moduleInitSpy) RegisterFollowFn(string, cmdctx.FollowFn)                       {}
 func (s *moduleInitSpy) RegisterFetchFn(string, cmdctx.FetchFn)                         {}
 func (s *moduleInitSpy) RegisterListTransformFn(string, cmdctx.ListTransformFn)         {}
+func (s *moduleInitSpy) RegisterItemFn(string, cmdctx.ItemFn)                           {}
 func (s *moduleInitSpy) RegisterFlagCompletionFn(string, registry.FlagCompletionFn)     {}
 func (s *moduleInitSpy) RegisterFlagResolveFn(string, cmdctx.FlagResolveFn)             {}
 func (s *moduleInitSpy) RegisterEndpointValidatorFn(string, cmdctx.EndpointValidatorFn) {}

--- a/modules/code/pr.go
+++ b/modules/code/pr.go
@@ -20,6 +20,7 @@ import (
 )
 
 const getPRWorkflowID = "get_pr"
+const prTextFormatterID = "pr_text"
 
 // isMachineFormat mirrors exprenv.isMachineFormat (unexported): these formats are
 // meant for structured consumption, so the insight section (extra, ad hoc text) is skipped.
@@ -102,11 +103,7 @@ func renderPR(ctx *cmdctx.Ctx, baseSpec *spec.CommandSpec, pr any, insightSpec *
 		}
 	}
 
-	pad := strings.Repeat("─", 25)
-	fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+" Description "+pad))
-	if desc := strings.TrimSpace(data.GetString("it.description")); desc != "" {
-		fmt.Fprintf(w, "\n%s\n", console.RenderMarkdown(desc))
-	}
+	renderPRDescription(w, data)
 
 	if activities, ok := activityData.([]any); ok {
 		fmt.Fprintln(w)
@@ -169,6 +166,26 @@ func renderPRHeader(w io.Writer, d cmdctx.DataAccessor) {
 	}
 
 	fmt.Fprintln(w)
+}
+
+// renderPRDescription prints the PR's description as a heading-delimited markdown block.
+func renderPRDescription(w io.Writer, d cmdctx.DataAccessor) {
+	pad := strings.Repeat("─", 25)
+	fmt.Fprintln(w, console.WithColor(console.ColorBrightBlack, pad+" Description "+pad))
+	if desc := strings.TrimSpace(d.GetString("it.description")); desc != "" {
+		fmt.Fprintf(w, "\n%s\n", console.RenderMarkdown(desc))
+	}
+}
+
+// prTextFormatter renders the header and description shared by "get pr"'s full CLI
+// output and the --ui detail pane. It's registered as the "pr" endpoint's
+// text_formatter so both paths render consistently — the --ui pane only ever fetches
+// the base pr payload (a TextFormatterFn has no access to ctx.Resolver to also pull
+// in the insight/activity sections GetPRWorkflow composes separately).
+func prTextFormatter(w io.Writer, d cmdctx.DataAccessor) error {
+	renderPRHeader(w, d)
+	renderPRDescription(w, d)
+	return nil
 }
 
 // relativeTime renders an epoch-ms timestamp as a coarse "N units ago" string,

--- a/modules/code/pr_check_detail.go
+++ b/modules/code/pr_check_detail.go
@@ -10,12 +10,22 @@ import (
 )
 
 const getPRCheckWorkflowID = "get_pr_check"
+const getPRCheckItemFnID = "get_pr_check_item"
+
+// getPRCheckItemFn resolves "get pr_check"'s target item without rendering it. Registered
+// as the spec's item_fn so the TUI's list pr_check -> get pr_check detail-pane drilldown
+// (pkg/registry/uitableview.go's fetchDetail) can fetch the same item a plain CLI invocation
+// of getPRCheckHandler renders, since there is no HTTP endpoint to CallEndpoint against.
+func getPRCheckItemFn(ctx *cmdctx.Ctx) (any, error) {
+	_, _, _, match, err := resolvePRCheck(ctx)
+	return match, err
+}
 
 // getPRCheckHandler implements "get pr_check". There is no direct single-check detail
 // endpoint, so it resolves the check the same way "get pr_check:log" does — via list
 // pr_check plus an identifier match — and renders the matched item as a "get" result.
 func getPRCheckHandler(ctx *cmdctx.Ctx) error {
-	_, _, _, match, err := resolvePRCheck(ctx)
+	match, err := getPRCheckItemFn(ctx)
 	if err != nil {
 		return err
 	}

--- a/modules/code/pr_check_detail.go
+++ b/modules/code/pr_check_detail.go
@@ -1,0 +1,29 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package code
+
+import (
+	"github.com/harness/cli/pkg/cmdctx"
+	"github.com/harness/cli/pkg/registry"
+	"github.com/harness/cli/pkg/spec"
+)
+
+const getPRCheckWorkflowID = "get_pr_check"
+
+// getPRCheckHandler implements "get pr_check". There is no direct single-check detail
+// endpoint, so it resolves the check the same way "get pr_check:log" does — via list
+// pr_check plus an identifier match — and renders the matched item as a "get" result.
+func getPRCheckHandler(ctx *cmdctx.Ctx) error {
+	_, _, _, match, err := resolvePRCheck(ctx)
+	if err != nil {
+		return err
+	}
+
+	// get pr_check has handler_type: workflow with no endpoint: block in the spec (there's
+	// nothing for CallEndpoint to hit), so this EndpointSpec is hand-built purely to drive
+	// rendering via RenderSingleItem — it mirrors what an endpoint block's item_expr would be,
+	// but isn't spec-derived and won't pick up any columns/text_formatter added to the YAML.
+	ep := &spec.EndpointSpec{ItemExpr: "it"}
+	return registry.RenderSingleItem(ctx, ep, match)
+}

--- a/modules/code/pr_check_log.go
+++ b/modules/code/pr_check_log.go
@@ -17,29 +17,27 @@ import (
 
 const getPRCheckLogWorkflowID = "get_pr_check_log"
 
-// getPRCheckLogHandler implements "get pr_check:log". It resolves a PR status check
-// to its backing pipeline execution and fetches that execution's stage logs, scoped
-// to the pipeline's own org/project (which may differ from the ambient auth scope).
-func getPRCheckLogHandler(ctx *cmdctx.Ctx) error {
+// resolvePRCheck resolves <repo_id>/<pr_number>/<check_identifier> to the matching item
+// from "list pr_check", by fetching the full list and matching identifier case-insensitively.
+func resolvePRCheck(ctx *cmdctx.Ctx) (repoID, prNumber, checkIdentifier string, match any, err error) {
 	if len(ctx.IdParts) != 3 || ctx.IdParts[0] == "" || ctx.IdParts[1] == "" || ctx.IdParts[2] == "" {
-		return fmt.Errorf("expected <repo_id>/<pr_number>/<check_identifier>")
+		return "", "", "", nil, fmt.Errorf("expected <repo_id>/<pr_number>/<check_identifier>")
 	}
-	repoID, prNumber, checkIdentifier := ctx.IdParts[0], ctx.IdParts[1], ctx.IdParts[2]
+	repoID, prNumber, checkIdentifier = ctx.IdParts[0], ctx.IdParts[1], ctx.IdParts[2]
 
 	listSpec := ctx.Resolver.GetSpec("list", "pr_check")
 	if listSpec == nil || listSpec.Endpoint == nil {
-		return fmt.Errorf("list pr_check command spec not found")
+		return "", "", "", nil, fmt.Errorf("list pr_check command spec not found")
 	}
 
 	listCtx := *ctx
 	listCtx.ParentId = repoID + "/" + prNumber
 	items, _, err := endpoint.FetchItems(&listCtx, listSpec.Endpoint, cmdctx.PagingFlags{All: true})
 	if err != nil {
-		return fmt.Errorf("fetching checks for %s/%s: %w", repoID, prNumber, err)
+		return "", "", "", nil, fmt.Errorf("fetching checks for %s/%s: %w", repoID, prNumber, err)
 	}
 
 	exprEnv := exprenv.Make(ctx)
-	var match any
 	var available []string
 	for _, item := range items {
 		data := extractutil.MakeDataAccessor(exprEnv, item)
@@ -51,9 +49,21 @@ func getPRCheckLogHandler(ctx *cmdctx.Ctx) error {
 		}
 	}
 	if match == nil {
-		return fmt.Errorf("no check %q found on %s/%s (available: %s)", checkIdentifier, repoID, prNumber, strings.Join(available, ", "))
+		return "", "", "", nil, fmt.Errorf("no check %q found on %s/%s (available: %s)", checkIdentifier, repoID, prNumber, strings.Join(available, ", "))
+	}
+	return repoID, prNumber, checkIdentifier, match, nil
+}
+
+// getPRCheckLogHandler implements "get pr_check:log". It resolves a PR status check
+// to its backing pipeline execution and fetches that execution's stage logs, scoped
+// to the pipeline's own org/project (which may differ from the ambient auth scope).
+func getPRCheckLogHandler(ctx *cmdctx.Ctx) error {
+	_, _, checkIdentifier, match, err := resolvePRCheck(ctx)
+	if err != nil {
+		return err
 	}
 
+	exprEnv := exprenv.Make(ctx)
 	data := extractutil.MakeDataAccessor(exprEnv, match)
 	pipelineOrg := data.GetString("it.check.payload.data.org_identifier")
 	pipelineProject := data.GetString("it.check.payload.data.project_identifier")

--- a/modules/code/pr_check_log.go
+++ b/modules/code/pr_check_log.go
@@ -5,8 +5,10 @@ package code
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/harness/cli/pkg/cmdctx"
 	"github.com/harness/cli/pkg/endpoint"
@@ -16,6 +18,7 @@ import (
 )
 
 const getPRCheckLogWorkflowID = "get_pr_check_log"
+const getPRCheckLogItemFnID = "get_pr_check_log_item"
 
 // resolvePRCheck resolves <repo_id>/<pr_number>/<check_identifier> to the matching item
 // from "list pr_check", by fetching the full list and matching identifier case-insensitively.
@@ -54,6 +57,37 @@ func resolvePRCheck(ctx *cmdctx.Ctx) (repoID, prNumber, checkIdentifier string, 
 	return repoID, prNumber, checkIdentifier, match, nil
 }
 
+// pipelineCoords is the pipeline execution location backing a PR check, extracted from its
+// check payload. Shared by getPRCheckLogHandler (live tail) and getPRCheckLogItemFn (snapshot).
+type pipelineCoords struct {
+	org, project, pipelineID, executionID, stageID string
+}
+
+func pipelineCoordsFromCheck(ctx *cmdctx.Ctx, match any, checkIdentifier string) (pipelineCoords, error) {
+	exprEnv := exprenv.Make(ctx)
+	data := extractutil.MakeDataAccessor(exprEnv, match)
+	pc := pipelineCoords{
+		org:         data.GetString("it.check.payload.data.org_identifier"),
+		project:     data.GetString("it.check.payload.data.project_identifier"),
+		pipelineID:  data.GetString("it.check.payload.data.pipeline_identifier"),
+		executionID: data.GetString("it.check.payload.data.execution_id"),
+		stageID:     data.GetString("it.check.payload.data.stage_identifier"),
+	}
+	if pc.pipelineID == "" || pc.executionID == "" {
+		return pc, fmt.Errorf("check %q has no associated pipeline execution (not a Harness pipeline check)", checkIdentifier)
+	}
+	return pc, nil
+}
+
+func scopedCtxForPipeline(ctx *cmdctx.Ctx, pc pipelineCoords) *cmdctx.Ctx {
+	scopedAuth := *ctx.Auth
+	scopedAuth.OrgID = pc.org
+	scopedAuth.ProjectID = pc.project
+	scopedCtx := *ctx
+	scopedCtx.Auth = &scopedAuth
+	return &scopedCtx
+}
+
 // getPRCheckLogHandler implements "get pr_check:log". It resolves a PR status check
 // to its backing pipeline execution and fetches that execution's stage logs, scoped
 // to the pipeline's own org/project (which may differ from the ambient auth scope).
@@ -63,31 +97,73 @@ func getPRCheckLogHandler(ctx *cmdctx.Ctx) error {
 		return err
 	}
 
-	exprEnv := exprenv.Make(ctx)
-	data := extractutil.MakeDataAccessor(exprEnv, match)
-	pipelineOrg := data.GetString("it.check.payload.data.org_identifier")
-	pipelineProject := data.GetString("it.check.payload.data.project_identifier")
-	pipelineID := data.GetString("it.check.payload.data.pipeline_identifier")
-	executionID := data.GetString("it.check.payload.data.execution_id")
-	stageID := data.GetString("it.check.payload.data.stage_identifier")
-
-	if pipelineID == "" || executionID == "" {
-		return fmt.Errorf("check %q has no associated pipeline execution (not a Harness pipeline check)", checkIdentifier)
+	pc, err := pipelineCoordsFromCheck(ctx, match, checkIdentifier)
+	if err != nil {
+		return err
 	}
 
 	fmt.Fprintf(os.Stderr, "check:      %s\n", checkIdentifier)
-	fmt.Fprintf(os.Stderr, "pipeline:   %s  (org: %s, project: %s)\n", pipelineID, pipelineOrg, pipelineProject)
-	fmt.Fprintf(os.Stderr, "execution:  %s\n", executionID)
-	fmt.Fprintf(os.Stderr, "stage:      %s\n", stageID)
+	fmt.Fprintf(os.Stderr, "pipeline:   %s  (org: %s, project: %s)\n", pc.pipelineID, pc.org, pc.project)
+	fmt.Fprintf(os.Stderr, "execution:  %s\n", pc.executionID)
+	fmt.Fprintf(os.Stderr, "stage:      %s\n", pc.stageID)
 
-	scopedAuth := *ctx.Auth
-	scopedAuth.OrgID = pipelineOrg
-	scopedAuth.ProjectID = pipelineProject
-	scopedCtx := *ctx
-	scopedCtx.Auth = &scopedAuth
-
-	if err := logstream.FollowMulti(&scopedCtx, executionID, stageID, "", logstream.MultiStyleMarkers, nil); err != nil {
-		return fmt.Errorf("fetching logs from %s/%s: %w (you may not have access to this org/project)", pipelineOrg, pipelineProject, err)
+	scopedCtx := scopedCtxForPipeline(ctx, pc)
+	if err := logstream.FollowMulti(scopedCtx, pc.executionID, pc.stageID, "", logstream.MultiStyleMarkers, nil); err != nil {
+		return fmt.Errorf("fetching logs from %s/%s: %w (you may not have access to this org/project)", pc.org, pc.project, err)
 	}
 	return nil
+}
+
+// getPRCheckLogItemFn resolves "get pr_check:log"'s target check to a one-shot snapshot of
+// its pipeline stage's logs. Registered as the spec's item_fn so the TUI's detail-pane
+// drilldown (pkg/registry/uitableview.go's fetchDetail) can render something for the "get
+// check logs" pane inline; unlike getPRCheckLogHandler it fetches once rather than following,
+// since a still-open text pane has no mechanism to tail forever.
+func getPRCheckLogItemFn(ctx *cmdctx.Ctx) (any, error) {
+	_, _, checkIdentifier, match, err := resolvePRCheck(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pc, err := pipelineCoordsFromCheck(ctx, match, checkIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	scopedCtx := scopedCtxForPipeline(ctx, pc)
+	entries, _, err := logstream.FetchLogKeys(scopedCtx, pc.executionID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching logs from %s/%s: %w (you may not have access to this org/project)", pc.org, pc.project, err)
+	}
+	entries = logstream.StageSubtreeEntries(entries, pc.stageID)
+
+	hc := &http.Client{Timeout: 30 * time.Second}
+	fmtFlag := ctx.FormatFlags.Format
+	multiLog := len(entries) > 1
+	var out strings.Builder
+	for _, e := range entries {
+		label := e.FQN
+		if label == "" {
+			label = e.LogKey
+		}
+		var buf strings.Builder
+		hasContent, fetchErr := logstream.FetchAndPrintLog(hc, scopedCtx.Auth, e.LogKey, fmtFlag, ctx.IsPty, &buf)
+		if fetchErr != nil {
+			fmt.Fprintf(&out, "== %s ==\n(error: %v)\n", label, fetchErr)
+			continue
+		}
+		if !hasContent {
+			continue
+		}
+		if multiLog {
+			fmt.Fprintf(&out, "== %s ==\n", label)
+		}
+		out.WriteString(buf.String())
+	}
+
+	logs := out.String()
+	if logs == "" {
+		logs = "(no log content yet)"
+	}
+	return map[string]any{"logs": logs}, nil
 }

--- a/modules/gitops/gitops_test.go
+++ b/modules/gitops/gitops_test.go
@@ -31,6 +31,7 @@ func (noopResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn        
 func (noopResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn             { return nil }
 func (noopResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)                { return nil, nil }
 func (noopResolver) ResolveListTransformFn(id string) cmdctx.ListTransformFn         { return nil }
+func (noopResolver) ResolveItemFn(id string) cmdctx.ItemFn                           { return nil }
 func (noopResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn   { return nil }
 func (noopResolver) GetSpec(verb, noun string) *spec.CommandSpec                     { return nil }
 func (noopResolver) GetNoun(noun string) *spec.NounDef                               { return nil }
@@ -380,6 +381,7 @@ func (s *moduleInitSpy) RegisterQueryParamsFn(string, cmdctx.QueryParamsFn)     
 func (s *moduleInitSpy) RegisterFollowFn(string, cmdctx.FollowFn)                       {}
 func (s *moduleInitSpy) RegisterFetchFn(string, cmdctx.FetchFn)                         {}
 func (s *moduleInitSpy) RegisterListTransformFn(string, cmdctx.ListTransformFn)         {}
+func (s *moduleInitSpy) RegisterItemFn(string, cmdctx.ItemFn)                           {}
 func (s *moduleInitSpy) RegisterFlagCompletionFn(string, registry.FlagCompletionFn)     {}
 func (s *moduleInitSpy) RegisterFlagResolveFn(string, cmdctx.FlagResolveFn)             {}
 func (s *moduleInitSpy) RegisterEndpointValidatorFn(string, cmdctx.EndpointValidatorFn) {}

--- a/pkg/cmdctx/cmdctx.go
+++ b/pkg/cmdctx/cmdctx.go
@@ -93,6 +93,10 @@ type FetchFn func(ctx *Ctx, ep *spec.EndpointSpec, wantStart, wantCount int, cur
 // the row slice, the columns available on those rows, and optional paging summary info.
 type ListTransformFn func(ctx *Ctx, data any) (items []any, fields []spec.FieldDef, meta PageMeta, err error)
 
+// ItemFn resolves a workflow-backed "get" command's target item without rendering it —
+// used by the TUI detail-pane drilldown, which needs a value to render, not written text.
+type ItemFn func(ctx *Ctx) (any, error)
+
 // RawBody signals that the body should be sent as-is with the given ContentType,
 // bypassing JSON encoding. Return this from a CreateBodyFn when the API expects
 // a raw non-JSON body (e.g. application/yaml).
@@ -123,6 +127,7 @@ type Resolver interface {
 	ResolveFlagResolveFn(id string) FlagResolveFn
 	ResolveFetchFn(id string) (FetchFn, error)
 	ResolveListTransformFn(id string) ListTransformFn
+	ResolveItemFn(id string) ItemFn
 	ResolveEndpointValidator(id string) EndpointValidatorFn
 	GetSpec(verb, noun string) *spec.CommandSpec
 	GetNoun(noun string) *spec.NounDef

--- a/pkg/registry/buildctx.go
+++ b/pkg/registry/buildctx.go
@@ -308,7 +308,7 @@ func buildCtx(cmd *cobra.Command, cs *spec.CommandSpec, args []string, r *Regist
 // to "get", and injects the resolved id.
 func buildDetailCtx(parent *cmdctx.Ctx, cs *spec.CommandSpec, id string) *cmdctx.Ctx {
 	goCtx, cancel := context.WithCancelCause(parent.Context)
-	return &cmdctx.Ctx{
+	ctx := &cmdctx.Ctx{
 		Context:     goCtx,
 		CancelFn:    cancel,
 		Auth:        parent.Auth,
@@ -323,6 +323,13 @@ func buildDetailCtx(parent *cmdctx.Ctx, cs *spec.CommandSpec, id string) *cmdctx
 		FormatFlags: cmdctx.FormatFlags{Format: "text"},
 		FlagValues:  map[string]any{},
 	}
+	// Endpoint path templates split ctx.Id into idParts on the fly (see exprenv.Make), but
+	// workflow handlers that read the ctx.IdParts struct field directly (e.g. a multi-part
+	// id_parts target resolved via item_fn) need it populated here too.
+	if cs.IdParts > 1 {
+		ctx.IdParts = strings.SplitN(id, "/", cs.IdParts)
+	}
+	return ctx
 }
 
 // resolveFlagValues runs any flag_resolve_fn declared on spec flags, overwriting

--- a/pkg/registry/checks.go
+++ b/pkg/registry/checks.go
@@ -129,6 +129,11 @@ func (r *Registry) checkFunctionsSpec(cs *spec.CommandSpec) []string {
 			errs = append(errs, fmt.Sprintf("command %q: workflow_id %q not registered", cs.Command, cs.WorkflowID))
 		}
 	}
+	if cs.ItemFn != "" {
+		if _, ok := r.itemFns[cs.ItemFn]; !ok {
+			errs = append(errs, fmt.Sprintf("command %q: item_fn %q not registered", cs.Command, cs.ItemFn))
+		}
+	}
 	if cs.Endpoint != nil {
 		if cs.Endpoint.TextFormatter != "" {
 			if _, ok := r.textFormatters[cs.Endpoint.TextFormatter]; !ok {

--- a/pkg/registry/endpoint.go
+++ b/pkg/registry/endpoint.go
@@ -382,10 +382,22 @@ func RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error) {
 		return nil, nil
 	}
 
+	return result, RenderSingleItem(ctx, ep, result)
+}
+
+// RenderSingleItem renders a single "get"-shaped result according to ep's field/text-formatter
+// configuration. It is the tail end of RunEndpoint's rendering logic, factored out so handlers
+// that resolve an item via custom logic (rather than a direct CallEndpoint) can render it the
+// same way a plain endpoint-backed "get" command would. Unlike RunEndpoint, it does not handle
+// --list-fields — that branch runs before CallEndpoint and only applies to endpoint-backed
+// commands, so callers driving a workflow handler don't get --list-fields support for free.
+func RenderSingleItem(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, result any) error {
+	exprEnv := exprenv.Make(ctx)
+
 	if ctx.VerbHandler == VerbGet && ctx.FormatFlags.Fields != "" {
 		fieldIDs := splitFieldIDs(ctx.FormatFlags.Fields)
 		fields := resolveFieldsForCommand(ctx, ep)
-		return result, format.FormatFieldsOutput(ctx.FormatFlags, result, ep.ItemExpr, fields, fieldIDs, exprEnv)
+		return format.FormatFieldsOutput(ctx.FormatFlags, result, ep.ItemExpr, fields, fieldIDs, exprEnv)
 	}
 
 	var textFmt cmdctx.TextFormatterFn
@@ -398,7 +410,7 @@ func RunEndpoint(ctx *cmdctx.Ctx, ep *spec.EndpointSpec) (any, error) {
 			textFmt = buildDeclTextFmt(fields, ep, exprEnv)
 		}
 	}
-	return result, format.FormatSingleOutput(ctx.FormatFlags, ctx.IsPty, result, ep.ItemExpr, ep.YamlPickExpr, ep.YamlExclude, textFmt, exprEnv)
+	return format.FormatSingleOutput(ctx.FormatFlags, ctx.IsPty, result, ep.ItemExpr, ep.YamlPickExpr, ep.YamlExclude, textFmt, exprEnv)
 }
 
 // RunListEndpoint calls CallEndpoint then renders the result as a list.

--- a/pkg/registry/fields_test.go
+++ b/pkg/registry/fields_test.go
@@ -99,6 +99,7 @@ func (tr *testResolver) ResolveBodyFn(id string) cmdctx.CreateBodyFn            
 func (tr *testResolver) ResolveQueryParamsFn(id string) cmdctx.QueryParamsFn     { return nil }
 func (tr *testResolver) ResolveFetchFn(id string) (cmdctx.FetchFn, error)        { return nil, nil }
 func (tr *testResolver) ResolveListTransformFn(id string) cmdctx.ListTransformFn { return nil }
+func (tr *testResolver) ResolveItemFn(id string) cmdctx.ItemFn                   { return nil }
 func (tr *testResolver) ResolveFlagResolveFn(id string) cmdctx.FlagResolveFn     { return nil }
 func (tr *testResolver) ResolveEndpointValidator(id string) cmdctx.EndpointValidatorFn {
 	return nil

--- a/pkg/registry/moduleregistrar.go
+++ b/pkg/registry/moduleregistrar.go
@@ -32,6 +32,7 @@ type ModuleRegistrar interface {
 	RegisterFollowFn(shortID string, fn cmdctx.FollowFn)
 	RegisterFetchFn(shortID string, fn cmdctx.FetchFn)
 	RegisterListTransformFn(shortID string, fn cmdctx.ListTransformFn)
+	RegisterItemFn(shortID string, fn cmdctx.ItemFn)
 	RegisterFlagCompletionFn(shortID string, fn FlagCompletionFn)
 	RegisterFlagResolveFn(shortID string, fn cmdctx.FlagResolveFn)
 	RegisterEndpointValidatorFn(shortID string, fn cmdctx.EndpointValidatorFn)
@@ -76,6 +77,9 @@ func (m *moduleRegistrar) Register(cs *spec.CommandSpec) error {
 	cmd := fmt.Sprintf("command %q", cs.Command)
 	if cs.WorkflowID != "" {
 		cs.WorkflowID = m.qualify(cs.WorkflowID, cmd+" workflow_id", true)
+	}
+	if cs.ItemFn != "" {
+		cs.ItemFn = m.qualify(cs.ItemFn, cmd+" item_fn", true)
 	}
 	if cs.Endpoint != nil && cs.Endpoint.TextFormatter != "" {
 		cs.Endpoint.TextFormatter = m.qualify(cs.Endpoint.TextFormatter, cmd+" text_formatter", true)
@@ -159,6 +163,12 @@ func (m *moduleRegistrar) RegisterFetchFn(shortID string, fn cmdctx.FetchFn) {
 func (m *moduleRegistrar) RegisterListTransformFn(shortID string, fn cmdctx.ListTransformFn) {
 	if q := m.qualify(shortID, fmt.Sprintf("list_transform_fn %q", shortID), false); q != "" {
 		m.reg.RegisterListTransformFn(q, fn)
+	}
+}
+
+func (m *moduleRegistrar) RegisterItemFn(shortID string, fn cmdctx.ItemFn) {
+	if q := m.qualify(shortID, fmt.Sprintf("item_fn %q", shortID), false); q != "" {
+		m.reg.RegisterItemFn(q, fn)
 	}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -62,6 +62,7 @@ type Registry struct {
 	followFns            map[string]cmdctx.FollowFn
 	fetchFns             map[string]cmdctx.FetchFn
 	listTransformFns     map[string]cmdctx.ListTransformFn
+	itemFns              map[string]cmdctx.ItemFn
 	flagCompletionFns    map[string]FlagCompletionFn
 	flagResolveFns       map[string]cmdctx.FlagResolveFn
 	endpointValidatorFns map[string]cmdctx.EndpointValidatorFn
@@ -82,6 +83,7 @@ func New() *Registry {
 		followFns:            map[string]cmdctx.FollowFn{},
 		fetchFns:             map[string]cmdctx.FetchFn{},
 		listTransformFns:     map[string]cmdctx.ListTransformFn{},
+		itemFns:              map[string]cmdctx.ItemFn{},
 		flagCompletionFns:    map[string]FlagCompletionFn{},
 		flagResolveFns:       map[string]cmdctx.FlagResolveFn{},
 		endpointValidatorFns: map[string]cmdctx.EndpointValidatorFn{},
@@ -375,6 +377,19 @@ func (r *Registry) RegisterListTransformFn(id string, fn cmdctx.ListTransformFn)
 		panic(fmt.Sprintf("registry: duplicate list transform fn %q", id))
 	}
 	r.listTransformFns[id] = fn
+}
+
+// ResolveItemFn implements cmdctx.Resolver.
+func (r *Registry) ResolveItemFn(id string) cmdctx.ItemFn {
+	return r.itemFns[id]
+}
+
+// RegisterItemFn registers a fully-qualified item resolver function ID.
+func (r *Registry) RegisterItemFn(id string, fn cmdctx.ItemFn) {
+	if _, ok := r.itemFns[id]; ok {
+		panic(fmt.Sprintf("registry: duplicate item fn %q", id))
+	}
+	r.itemFns[id] = fn
 }
 
 // RegisterFlagCompletionFn registers a fully-qualified flag completion function.

--- a/pkg/registry/uitableview.go
+++ b/pkg/registry/uitableview.go
@@ -537,7 +537,8 @@ func (m uiTableModel) dispatchUICommandKey(key string) (uiTableModel, tea.Cmd, b
 	return m, nil, false
 }
 
-// fetchDetail fetches the get endpoint for id and renders it to a string.
+// fetchDetail fetches the get endpoint (or, for a workflow-backed get, its registered
+// item_fn) for id and renders it to a string.
 func (m uiTableModel) fetchDetail(id string) tea.Cmd {
 	ctx := m.ctx
 	cs := m.activeDetailCs()
@@ -546,9 +547,27 @@ func (m uiTableModel) fetchDetail(id string) tea.Cmd {
 		detailCtx := buildDetailCtx(ctx, cs, id)
 		var buf strings.Builder
 		detailCtx.FormatFlags = cmdctx.FormatFlags{Format: "text"}
-		result, err := CallEndpoint(detailCtx, ep)
-		if err != nil {
-			return uiDetailMsg{err: err}
+
+		var result any
+		if ep != nil {
+			var err error
+			result, err = CallEndpoint(detailCtx, ep)
+			if err != nil {
+				return uiDetailMsg{err: err}
+			}
+		} else if cs.ItemFn != "" && ctx.Resolver != nil {
+			fn := ctx.Resolver.ResolveItemFn(cs.ItemFn)
+			if fn == nil {
+				return uiDetailMsg{err: fmt.Errorf("item_fn %q not registered", cs.ItemFn)}
+			}
+			item, err := fn(detailCtx)
+			if err != nil {
+				return uiDetailMsg{err: err}
+			}
+			result = item
+			ep = &spec.EndpointSpec{ItemExpr: "it"}
+		} else {
+			return uiDetailMsg{err: fmt.Errorf("get %s has no endpoint or item_fn; cannot render detail", cs.Noun)}
 		}
 		exprEnv := exprenv.Make(detailCtx)
 		fields := resolveFieldsForCommand(detailCtx, ep)

--- a/pkg/registry/uitableview.go
+++ b/pkg/registry/uitableview.go
@@ -731,7 +731,12 @@ func (m uiTableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.detail.err = msg.err.Error()
 		} else {
-			m.detail.lines = strings.Split(strings.TrimRight(msg.content, "\n"), "\n")
+			wrapWidth := m.width - 1
+			if wrapWidth < 20 {
+				wrapWidth = 20
+			}
+			wrapped := lipgloss.Wrap(strings.TrimRight(msg.content, "\n"), wrapWidth, "")
+			m.detail.lines = strings.Split(wrapped, "\n")
 			m.detail.scroll = 0
 			m.detail.upIds = msg.upIds
 		}

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -378,12 +378,13 @@ nouns:
       - id: stage_id
         label: Stage ID
         expr: it.check.payload.data.stage_identifier
-    ui_commands:
-      - ui_command_type: text
-        key: g
-        label: get check logs
-        verb: get
-        noun: pr_check_log
+
+  - noun: pr_check_log
+    short_desc: A snapshot of a PR check's backing pipeline stage logs.
+    fields:
+      - id: logs
+        expr: it.logs
+        field_type: multiline_text
 
   - noun: pr_insight
     short_desc: Risk summary for a pull request (Harness Code review insights).
@@ -1776,6 +1777,8 @@ commands:
       pipeline execution (external check, webhook-reported status, etc).
     handler_type: workflow
     workflow_id: get_pr_check_log
+    item_fn: get_pr_check_log_item
+    fields_noun: pr_check_log
     id_parts: 3
     id_label: "<repo_id>/<pr_number>/<check_identifier>"
     completion_seq:

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -1665,6 +1665,21 @@ commands:
         page_base: 1
       columns: [sha, title, author, authored]
 
+  - command: get pr_commit
+    verb: get
+    noun: pr_commit
+    fields_noun: commit
+    short: "Get a commit in a pull request: harness get pr_commit <repo_id>/<sha>"
+    handler_type: endpoint
+    id_parts: 2
+    completion_seq:
+      - completion_noun: repository
+      - completion_noun: commit
+        keep_order: true
+    endpoint:
+      path: /code/api/v1/repos/{{ctx.idParts[0]}}/commits/{{ctx.idParts[1]}}
+      item_expr: it
+
   # ── commit_check ─────────────────────────────────────────────────────────────
 
   - command: list commit_check

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -1740,6 +1740,20 @@ commands:
         name_expr: it.check.status
       columns: [identifier, status, required, summary, reported_by, duration]
 
+  - command: get pr_check
+    verb: get
+    noun: pr_check
+    short: "Get a status check on a pull request: harness get pr_check <repo_id>/<pr_number>/<check_identifier>"
+    handler_type: workflow
+    workflow_id: get_pr_check
+    id_parts: 3
+    id_label: "<repo_id>/<pr_number>/<check_identifier>"
+    completion_seq:
+      - completion_noun: repository
+      - completion_noun: pr
+        keep_order: true
+      - completion_noun: pr_check
+
   - command: get pr_check:log
     verb: get
     noun: pr_check

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -429,6 +429,11 @@ nouns:
         label: up to PR
         noun: pr
         up_id_expr: ctx.idParts[0] + "/" + ctx.idParts[1]
+      - ui_command_type: up
+        key: "e"
+        label: view execution
+        noun: execution
+        up_id_expr: it.check.payload.data.pipeline_identifier + "/" + it.check.payload.data.execution_id
 
   - noun: pr_check_log
     short_desc: A snapshot of a PR check's backing pipeline stage logs.

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -378,6 +378,12 @@ nouns:
       - id: stage_id
         label: Stage ID
         expr: it.check.payload.data.stage_identifier
+    ui_commands:
+      - ui_command_type: text
+        key: g
+        label: get check logs
+        verb: get
+        noun: pr_check_log
 
   - noun: pr_insight
     short_desc: Risk summary for a pull request (Harness Code review insights).
@@ -1732,7 +1738,7 @@ commands:
     endpoint:
       path: /code/api/v1/repos/{{ctx.parentIdParts[0]}}/pullreq/{{ctx.parentIdParts[1]}}/checks
       items_expr: it.checks
-      get_id_expr: it.check.identifier
+      get_id_expr: ctx.parentId + "/" + it.check.identifier
       paging:
         paging_strategy: flat_list
       completion:
@@ -1746,6 +1752,7 @@ commands:
     short: "Get a status check on a pull request: harness get pr_check <repo_id>/<pr_number>/<check_identifier>"
     handler_type: workflow
     workflow_id: get_pr_check
+    item_fn: get_pr_check_item
     id_parts: 3
     id_label: "<repo_id>/<pr_number>/<check_identifier>"
     completion_seq:

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -76,6 +76,17 @@ nouns:
         expr: epochMs(it.updated)
       - id: created
         expr: epochMs(it.created)
+    ui_commands:
+      - ui_command_type: text
+        key: d
+        label: details
+        noun: repository
+        default: true
+      - ui_command_type: link
+        key: l
+        label: list pull requests
+        verb: list
+        noun: pr
 
   - noun: pr
     short_desc: A Harness Code pull request.
@@ -180,11 +191,20 @@ nouns:
         label: details
         noun: pr
         default: true
+      - ui_command_type: text
+        key: i
+        label: AI review
+        noun: pr:insight
       - ui_command_type: link
         key: c
         label: list commits
         verb: list
         noun: pr_commit
+      - ui_command_type: link
+        key: a
+        label: list activity
+        verb: list
+        noun: pr_activity
       - ui_command_type: link
         key: s
         label: list checks
@@ -378,6 +398,16 @@ nouns:
       - id: stage_id
         label: Stage ID
         expr: it.check.payload.data.stage_identifier
+    ui_commands:
+      - ui_command_type: text
+        key: d
+        label: details
+        noun: pr_check
+        default: true
+      - ui_command_type: text
+        key: g
+        label: get check logs
+        noun: pr_check:log
 
   - noun: pr_check_log
     short_desc: A snapshot of a PR check's backing pipeline stage logs.
@@ -1658,7 +1688,7 @@ commands:
     endpoint:
       path: /code/api/v1/repos/{{ctx.parentIdParts[0]}}/pullreq/{{ctx.parentIdParts[1]}}/commits
       items_expr: it
-      get_id_expr: it.sha
+      get_id_expr: ctx.parentIdParts[0] + "/" + it.sha
       query_params:
         page: flags.page
         limit: flags.limit

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -880,6 +880,7 @@ commands:
       item_expr: it
       yaml_pick_expr: it
       text_footer: "\n{{url(it)}}\n"
+      text_formatter: pr_text
 
   - command: create pr
     verb: create

--- a/pkg/spec/code.spec.yaml
+++ b/pkg/spec/code.spec.yaml
@@ -87,6 +87,11 @@ nouns:
         label: list pull requests
         verb: list
         noun: pr
+      - ui_command_type: up
+        key: "<"
+        label: up to repo list
+        verb: list
+        noun: repository
 
   - noun: pr
     short_desc: A Harness Code pull request.
@@ -210,6 +215,17 @@ nouns:
         label: list checks
         verb: list
         noun: pr_check
+      - ui_command_type: up
+        key: "^"
+        label: up to repo
+        noun: repository
+        up_id_expr: ctx.idParts[0]
+      - ui_command_type: up
+        key: "<"
+        label: up to PR list
+        verb: list
+        noun: pr
+        up_id_expr: ctx.idParts[0]
 
   - noun: branch
     short_desc: A git branch in a Harness Code repository.
@@ -408,6 +424,11 @@ nouns:
         key: g
         label: get check logs
         noun: pr_check:log
+      - ui_command_type: up
+        key: "^"
+        label: up to PR
+        noun: pr
+        up_id_expr: ctx.idParts[0] + "/" + ctx.idParts[1]
 
   - noun: pr_check_log
     short_desc: A snapshot of a PR check's backing pipeline stage logs.

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -581,6 +581,7 @@ type CommandSpec struct {
 	VerbHandler      string              `yaml:"verb_handler,omitempty"`    // overrides verb for behavioral dispatch (flag binding, ctx.Verb); leave unset to use verb
 	ConfirmMode      string              `yaml:"confirm_mode,omitempty"`    // not allowed on list or get; see ConfirmNone/ConfirmPrompt/ConfirmID
 	WorkflowID       string              `yaml:"workflow_id,omitempty"`     // set when HandlerType == HandlerWorkflow
+	ItemFn           string              `yaml:"item_fn,omitempty"`         // optional: workflow-backed get's item resolver, used for TUI drilldown rendering
 	FollowFn         string              `yaml:"follow_fn,omitempty"`       // optional: called after a successful endpoint command when --follow is set
 	Flags            []Flag              `yaml:"flags,omitempty"`           // custom flags for workflow commands
 	Endpoint         *EndpointSpec       `yaml:"endpoint,omitempty"`        // set when HandlerType == HandlerEndpoint


### PR DESCRIPTION


### Summary

- Wires ui_commands across repository, pr, and pr_check nouns so --ui supports one continuous session: repo list → PR list → PR details/AI review/commits/activity/checks → a check → its pipeline execution log.
- Adds item_fn-backed detail rendering for pr_check and pr_check:log (no HTTP endpoint backs these, so the TUI detail pane renders via registered Go functions instead).
- Adds backward up navigation (^ jumps to the parent's detail, < jumps to the parent's list) from pr → repository and from pr_check → pr.
- Registers a shared pr_text formatter so the --ui detail pane for a PR renders the same header + description as the plain get pr CLI output.
- Fixes list pr_commit's get_id_expr to produce the correct <repo_id>/<sha> shape for drilldown.