### PR TITLE
Add HARNESS_CLI_COLUMNS env var for per-noun default --columns overrides

### DIFF
--- a/pkg/format/columns.go
+++ b/pkg/format/columns.go
@@ -6,11 +6,45 @@ package format
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"unicode"
 
+	"github.com/harness/cli/pkg/hbase"
 	"github.com/harness/cli/pkg/spec"
 )
+
+// EnvColumnsFor returns the --columns override configured via hbase.EnvColumns for the
+// given noun, or "" if the env var is unset or has no entry for that noun. Callers should
+// only consult this when --columns wasn't passed explicitly, since the flag always wins.
+//
+// Format: semicolon-separated "noun=columns" entries, e.g.
+//
+//	HARNESS_CLI_COLUMNS="pipeline=id,name,status;execution=id,status,started"
+//
+// The "columns" half uses the exact same syntax as --columns (including +/- modify mode)
+// and is split from the noun on the first "=" only, so a column expression containing "="
+// (e.g. "status:it.status == 'success'") is preserved intact.
+func EnvColumnsFor(noun string) string {
+	raw := os.Getenv(hbase.EnvColumns)
+	if raw == "" {
+		return ""
+	}
+	for _, entry := range strings.Split(raw, ";") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		idx := strings.Index(entry, "=")
+		if idx < 0 {
+			continue
+		}
+		if key := strings.TrimSpace(entry[:idx]); key == noun {
+			return strings.TrimSpace(entry[idx+1:])
+		}
+	}
+	return ""
+}
 
 // ApplyColumns resolves a --columns string against a set of known FieldDefs into []TableColumn.
 //

--- a/pkg/hbase/hbase.go
+++ b/pkg/hbase/hbase.go
@@ -62,6 +62,12 @@ const (
 	// EnvLogFile redirects all log output to the specified file path.
 	EnvLogFile = "HARNESS_CLI_LOGFILE"
 
+	// EnvColumns sets default --columns overrides per noun for list commands, so users
+	// don't have to pass --columns on every invocation (e.g. to keep demo terminals from
+	// wrapping columns). Format: semicolon-separated "noun=columns" entries, e.g.
+	// "pipeline=id,name,status;execution=id,status,started". See [format.EnvColumnsFor].
+	EnvColumns = "HARNESS_CLI_COLUMNS"
+
 	// EnvCLIHome overrides the harness home directory (default ~/.harness).
 	EnvCLIHome = "HARNESS_CLI_HOME"
 

--- a/pkg/registry/endpoint.go
+++ b/pkg/registry/endpoint.go
@@ -509,7 +509,11 @@ func renderListWithFields(ctx *cmdctx.Ctx, ep *spec.EndpointSpec, items []any, f
 		}
 		listResult = unwrapped
 	}
-	return format.FormatArrayOutput(ctx.FormatFlags, ctx.IsPty, listResult, listItemsExpr, tspec, fields, exprEnv, meta)
+	flags := ctx.FormatFlags
+	if flags.Columns == "" {
+		flags.Columns = format.EnvColumnsFor(ctx.Noun)
+	}
+	return format.FormatArrayOutput(flags, ctx.IsPty, listResult, listItemsExpr, tspec, fields, exprEnv, meta)
 }
 
 // runEndpointValidators runs all validators_endpoint declared on ep, in order.

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -896,7 +896,11 @@ func (r *Registry) RunUIHandler(ctx *cmdctx.Ctx, fnID string) error {
 func (r *Registry) FormatList(ctx *cmdctx.Ctx, rows []any, fields []spec.FieldDef, columnIDs []string) error {
 	tspec := buildTspec(columnIDs, fields)
 	exprEnv := exprenv.Make(ctx)
-	return format.FormatArrayOutput(ctx.FormatFlags, ctx.IsPty, rows, "it", tspec, fields, exprEnv, nil)
+	flags := ctx.FormatFlags
+	if flags.Columns == "" {
+		flags.Columns = format.EnvColumnsFor(ctx.Noun)
+	}
+	return format.FormatArrayOutput(flags, ctx.IsPty, rows, "it", tspec, fields, exprEnv, nil)
 }
 
 // FetchItems implements cmdctx.Resolver.


### PR DESCRIPTION
Typing --columns on every invocation to keep demo terminals from wrapping is tedious, and a config-file setting would be too easy to forget about. An env var set once per session covers both: it defaults columns for list commands per noun (semicolon-separated "noun=columns" pairs, same syntax as --columns) while still letting an explicit --columns win.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

AI-Session-Id: 2f5b7306-cfe4-40a6-9fb9-11c6c133b8c3
AI-Tool: claude-code
AI-Model: unknown