### PR TITLE
Add testexpr command for testing expr-lang expressions in isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,14 @@ Available variables: `ctx.id`, `ctx.idParts[N]`, `ctx.parentId`, `auth.account`,
 - Array concat: `concat(it.entity_types ?? [], it.event_types ?? [])`.
 - Epoch formatting: `epochMs(it.created)` → human-readable timestamp.
 
+### Testing expr-lang expressions in isolation
+
+```sh
+task testexpr -- '<expression>' '<envJSON>'   # or @file.json, or - for stdin
+```
+
+Evaluates against the same helper functions (`truncate`, `coalesce`, `epochMs`, ...) as real spec expressions, via `exprenv.BaseFuncs`. Useful for checking a `columns:`/`body_params:` expression before wiring it into a spec.
+
 ### Body params (dotted paths)
 
 ```yaml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -117,6 +117,11 @@ tasks:
     cmds:
       - go run {{.MAIN}} {{.CLI_ARGS}}
 
+  testexpr:
+    desc: 'Evaluate an expr-lang expression against a JSON env: task testexpr -- ''<expr>'' [envJSON|@file|-]'
+    cmds:
+      - go run ./cmd/testexpr/main-testexpr.go {{.CLI_ARGS}}
+
   check:specs:
     desc: Validate all *.spec.yaml files
     deps: [build:main, build:har]

--- a/cmd/testexpr/main-testexpr.go
+++ b/cmd/testexpr/main-testexpr.go
@@ -1,0 +1,99 @@
+// Copyright © 2026 Harness Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Command testexpr evaluates an expr-lang expression against a JSON environment
+// and prints the result. Meant for local iteration on spec expressions, not for
+// end users.
+//
+// Usage:
+//
+//	go run ./cmd/testexpr <expression> [envJSON|@file|-]
+//
+// The env arg defaults to "{}" when omitted. "-" reads JSON from stdin;
+// "@file" reads it from a file; anything else is parsed as a literal JSON
+// string. The expression is evaluated with the same helper functions
+// (truncate, coalesce, epochMs, ...) available to spec expressions, injected
+// via exprenv.BaseFuncs.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"strings"
+
+	"github.com/expr-lang/expr"
+
+	"github.com/harness/cli/pkg/exprenv"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: testexpr <expression> [envJSON|@file|-]")
+		os.Exit(1)
+	}
+	exprStr := os.Args[1]
+
+	envArg := "{}"
+	if len(os.Args) > 2 {
+		envArg = os.Args[2]
+	}
+
+	envJSON, err := readEnvArg(envArg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(envJSON), &env); err != nil {
+		fmt.Fprintf(os.Stderr, "error: invalid env JSON: %v\n", err)
+		os.Exit(1)
+	}
+	if env == nil {
+		env = map[string]any{}
+	}
+	maps.Copy(env, exprenv.BaseFuncs(false))
+
+	program, err := expr.Compile(exprStr, expr.Env(env), expr.AsAny())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "compile error: %v\n", err)
+		os.Exit(1)
+	}
+
+	out, err := expr.Run(program, env)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval error: %v\n", err)
+		os.Exit(1)
+	}
+
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		fmt.Printf("%v\n", out)
+		return
+	}
+	fmt.Println(string(b))
+}
+
+// readEnvArg resolves the env argument into raw JSON text: "-" reads stdin,
+// "@file" reads the named file, anything else is returned as-is.
+func readEnvArg(arg string) (string, error) {
+	switch {
+	case arg == "-":
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("reading stdin: %w", err)
+		}
+		return string(b), nil
+	case strings.HasPrefix(arg, "@"):
+		b, err := os.ReadFile(arg[1:])
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", arg[1:], err)
+		}
+		return string(b), nil
+	default:
+		return arg, nil
+	}
+}

--- a/pkg/exprenv/exprenv.go
+++ b/pkg/exprenv/exprenv.go
@@ -34,6 +34,35 @@ func WithIt(env map[string]any, val any) map[string]any {
 	return out
 }
 
+// BaseFuncs returns the ctx-independent functions injected into every expr-lang
+// environment. ptyEnabled gates the PTY-sensitive rendering functions
+// (pipelineSparkline, statusIcon, prLabelColor).
+func BaseFuncs(ptyEnabled bool) map[string]any {
+	return map[string]any{
+		"lastPart":              exprfuncs.LastPart,
+		"coalesce":              exprfuncs.Coalesce,
+		"isBlank":               exprfuncs.IsBlank,
+		"formatTags":            exprfuncs.FormatTags,
+		"formatTagDisplay":      exprfuncs.FormatTagDisplay,
+		"formatMetadata":        exprfuncs.FormatMetadata,
+		"pipelineSparkline":     exprfuncs.NewPipelineSparkline(ptyEnabled),
+		"statusIcon":            exprfuncs.NewStatusIcon(ptyEnabled),
+		"prLabelColor":          exprfuncs.NewPrLabelColor(ptyEnabled),
+		"spaceAfter":            exprfuncs.SpaceAfter,
+		"duration":              exprfuncs.Duration,
+		"harScopeUrl":           exprfuncs.HarScopeUrl,
+		"scopePath":             exprfuncs.HarScopeUrl,
+		"epochMs":               exprfuncs.EpochMs,
+		"parseDateMs":           exprfuncs.ParseDateMs,
+		"jsonArray":             exprfuncs.JsonArray,
+		"formatRoleAssignments": exprfuncs.FormatRoleAssignments,
+		"formatRoleIds":         exprfuncs.FormatRoleIds,
+		"truncate":              exprfuncs.Truncate,
+		"substr":                exprfuncs.Substr,
+		"formatOrder":           exprfuncs.FormatOrder,
+	}
+}
+
 // Make builds the expr-lang environment from ctx.
 // Flags are exposed as a flat map under "flags".
 func Make(ctx *cmdctx.Ctx) map[string]any {
@@ -83,29 +112,9 @@ func Make(ctx *cmdctx.Ctx) map[string]any {
 				"ui_url":  uiURL,
 			}
 		}(),
-		"flags":                 flags,
-		"lastPart":              exprfuncs.LastPart,
-		"coalesce":              exprfuncs.Coalesce,
-		"isBlank":               exprfuncs.IsBlank,
-		"formatTags":            exprfuncs.FormatTags,
-		"formatTagDisplay":      exprfuncs.FormatTagDisplay,
-		"formatMetadata":        exprfuncs.FormatMetadata,
-		"pipelineSparkline":     exprfuncs.NewPipelineSparkline(ctx.IsPty && !isMachineFormat(flags)),
-		"statusIcon":            exprfuncs.NewStatusIcon(ctx.IsPty && !isMachineFormat(flags)),
-		"prLabelColor":          exprfuncs.NewPrLabelColor(ctx.IsPty && !isMachineFormat(flags)),
-		"spaceAfter":            exprfuncs.SpaceAfter,
-		"duration":              exprfuncs.Duration,
-		"harScopeUrl":           exprfuncs.HarScopeUrl,
-		"scopePath":             exprfuncs.HarScopeUrl,
-		"epochMs":               exprfuncs.EpochMs,
-		"parseDateMs":           exprfuncs.ParseDateMs,
-		"jsonArray":             exprfuncs.JsonArray,
-		"formatRoleAssignments": exprfuncs.FormatRoleAssignments,
-		"formatRoleIds":         exprfuncs.FormatRoleIds,
-		"truncate":              exprfuncs.Truncate,
-		"substr":                exprfuncs.Substr,
-		"formatOrder":           exprfuncs.FormatOrder,
+		"flags": flags,
 	}
+	maps.Copy(env, BaseFuncs(ctx.IsPty && !isMachineFormat(flags)))
 	if ctx.Resolver != nil {
 		noun := ctx.Noun
 		if ctx.FieldsNoun != "" {


### PR DESCRIPTION
Lets us iterate on spec expressions (columns, body_params, path templates) without wiring them into a spec first. Extracts the ctx-independent helper functions from exprenv.Make into exprenv.BaseFuncs so both the real CLI and testexpr share the same function set.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>