### PR TITLE
Enrich trigger get/list output and fix --ui detail pane pipeline mismatch.

### DIFF
--- a/pkg/spec/pipeline.spec.yaml
+++ b/pkg/spec/pipeline.spec.yaml
@@ -139,6 +139,24 @@ nouns:
         expr: it.type
       - id: enabled
         expr: it.enabled
+      - id: description
+        expr: it.description
+      - id: pipeline
+        expr: coalesce(it.targetIdentifier, ctx.idParts[0])
+      - id: tags
+        expr: formatTagDisplay(it.tags)
+      - id: webhook_url
+        expr: it.webhookUrl
+      - id: last_execution_status
+        expr: it.lastTriggerExecutionDetails.lastExecutionStatus
+      - id: last_execution_time
+        expr: epochMs(it.lastTriggerExecutionDetails.lastExecutionTime)
+      - id: last_execution_message
+        expr: it.lastTriggerExecutionDetails.message
+        width_max: 60
+      - id: yaml
+        expr: it.yaml
+        field_type: yaml
 
   - noun: input_set
     short_desc: A reusable set of runtime inputs that can be applied when running a pipeline.
@@ -911,8 +929,8 @@ commands:
         keep_order: true
     handler_type: endpoint
     endpoint:
-      path: /pipeline/api/triggers/{{lastPart(ctx.id)}}
-      item_expr: it.data
+      path: /pipeline/api/triggers
+      item_expr: find(it.data.content, .identifier == lastPart(ctx.id))
       query_params:
         targetIdentifier: ctx.idParts[0]
 

--- a/pkg/spec/pipeline.spec.yaml
+++ b/pkg/spec/pipeline.spec.yaml
@@ -902,7 +902,7 @@ commands:
     endpoint:
       path: /pipeline/api/triggers
       items_expr: it.data.content
-      get_id_expr: it.identifier
+      get_id_expr: ctx.parentId + "/" + it.identifier
       completion:
         id_expr: it.identifier
         name_expr: it.name

--- a/pkg/spec/pipeline.spec.yaml
+++ b/pkg/spec/pipeline.spec.yaml
@@ -148,9 +148,11 @@ nouns:
       - id: webhook_url
         expr: it.webhookUrl
       - id: last_execution_status
-        expr: it.lastTriggerExecutionDetails.lastExecutionStatus
+        expr: '(it.lastTriggerExecutionDetails != nil && it.lastTriggerExecutionDetails.lastExecutionSuccessful == true) ? "Passed" : "Failed"'
       - id: last_execution_time
         expr: epochMs(it.lastTriggerExecutionDetails.lastExecutionTime)
+      - id: last_execution_id
+        expr: it.lastTriggerExecutionDetails.planExecutionId
       - id: last_execution_message
         expr: it.lastTriggerExecutionDetails.message
         width_max: 60
@@ -915,7 +917,7 @@ commands:
         page_size_default: 25
         page_size_max: 100
         total_expr: it.data.totalItems
-      columns: [identifier, name, type, enabled]
+      columns: [identifier, name, type, enabled, last_execution_status, tags]
 
   - command: get trigger
     verb: get


### PR DESCRIPTION
Description:
Closes #197.
Enriches get/list trigger with description, tags, webhook URL, and last-activation status/time/id/message (via the list endpoint + find(), no extra API call), and fixes a --ui bug where drilling into a trigger showed a blank detail pane because get_id_expr dropped the pipeline prefix, causing the detail fetch to query the wrong pipeline.